### PR TITLE
Release Motion Finder v0.2.0

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,12 +1,13 @@
-# Motion Lexicon Launch Design
+# Motion Lexicon v0.2 Design
 
 ## Product Shape
 
-Motion Lexicon is a static, SEO-friendly motion recipe library. The launch version curates 91 motion terms into 44 canonical units: 31 components, 9 playgrounds, and 4 guides.
+Motion Lexicon is a static, SEO-friendly motion finder and recipe library. The catalog curates 91 motion terms into 44 canonical units: 31 components, 9 playgrounds, and 4 guides. v0.2 adds an explainable decision surface for moving from vague intent to three comparable variants.
 
 The user-facing structure is:
 
 - `/zh/` and `/en/`: landing pages with a curated component-library surface.
+- `/:locale/finder/`: bilingual natural-language recommendation, synchronized Top 3 comparison, variant selection, parameter tuning, and portable output.
 - `/:locale/catalog/`: shareable Components, Playgrounds, and Guides catalog filters.
 - `/:locale/vocabulary/`: the complete 91-term bilingual vocabulary and distinction layer.
 - `/:locale/:categoryId/`: indexable category collections.
@@ -48,6 +49,7 @@ Categories and entries live as frontend data. Each entry contains a project-main
 
 Data ownership stays explicit across these layers:
 
+- Motion Lexicon maintains the bilingual intent phrases, comparison groups, scoring weights, match reasons, distinctions, and variant presets used by the Finder and CLI.
 - Motion Lexicon independently maintains English definitions, Chinese translations, alias-to-workspace mapping, and bilingual distinction copy in `src/data/glossary.ts`.
 - Motion Lexicon maintains the product contracts and review guidance in `src/data/motion-guidance.ts`.
 - Preview behavior and portable output are Motion Lexicon implementation artifacts.
@@ -67,11 +69,19 @@ Query state identifies current entry parameters:
 
 Default parameter values are omitted from the query string. Changed values update the preview, generated HTML/CSS/JavaScript, prompt text, and URL. Alias redirects preserve the focused vocabulary term through `?term=`.
 
+Finder query state preserves a vague request, comparison variants, and the current selection:
+
+```txt
+/:locale/finder/?q=<encoded-intent>&compare=<variant-ids>&selected=<variant-id>
+```
+
+The CLI provides `q` plus the ordered `compare` list. The Finder selects the first variant by default and writes `selected` after a user choice. Any non-default recipe parameters follow in the same query string. The canonical Finder URL remains `/:locale/finder/`. Web and CLI recommendations use the same intent data and ranking implementation.
+
 ## SEO
 
-The build pipeline renders static HTML for 118 localized canonical routes. Each route receives a self canonical, reciprocal hreflang set, Open Graph metadata, and static JSON-LD. The vocabulary routes publish a `DefinedTermSet` containing all 91 terms.
+The build pipeline renders static HTML for 120 localized canonical routes. Each route receives a self canonical, reciprocal hreflang set, Open Graph metadata, and static JSON-LD. The vocabulary routes publish a `DefinedTermSet` containing all 91 terms. Finder query variations canonicalize to their localized Finder route.
 
-Landing, catalog, category, and canonical detail pages are indexable. Alias routes redirect and stay out of the sitemap.
+Landing, Finder, catalog, category, and canonical detail pages are indexable. Alias and Finder query variations stay out of the sitemap.
 
 ## Motion Rules
 
@@ -85,6 +95,7 @@ Each recipe uses one semantic motion specification for its parameter schema, pre
 - Gate hover movement behind fine pointer media queries.
 - Use Pointer Events and velocity-aware settlement for gesture components.
 - Keep keyboard-initiated navigation and repeated parameter editing visually immediate.
+- Replay Finder candidates from one synchronized control and use the same scene dimensions and content for direct comparison.
 
 ## Launch Acceptance
 
@@ -102,4 +113,6 @@ Launch is complete when:
 - `npm run bundle:check` passes.
 - `npm run crawl:dist` passes.
 - `npm run test:visual` passes on desktop and mobile.
+- Web and CLI recommendations agree on ordered variants, reasons, presets, and shareable compare state.
+- Both localized Finder routes are prerendered, canonicalized, crawlable, and free of horizontal overflow.
 - The local dev server runs and the site is available for manual review.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -21,6 +21,7 @@ The product helps a user move from a vague motion idea to a precise recipe they 
 The site is a static, SEO-friendly application with these public surfaces:
 
 - Landing page: introduces the library and highlights representative motion recipes.
+- Motion Finder: turns a vague bilingual description into three ranked variants, explains their differences, compares them in one scene, and continues into tuning and export.
 - Components: 31 copy-ready patterns with real previews, relevant controls, and synchronized exports.
 - Playgrounds: 9 focused labs for timing, easing, spring physics, transforms, scroll, and review principles.
 - Guides: 4 reference hubs for performance, purposeful motion, perceived performance, and reduced motion.
@@ -30,9 +31,19 @@ The site is a static, SEO-friendly application with these public surfaces:
 
 Recipe URLs are canonical content URLs. Query parameters carry only tunable state such as duration, delay, distance, and easing.
 
-## Launch Strategy
+## Version Strategy
 
-The launch version ships 44 canonical units backed by all 91 vocabulary terms. Architecture, routing, SEO, i18n, themes, controls, exports, content, assets, and test gates are part of the production surface.
+The v0.1 launch ships 44 canonical units backed by all 91 vocabulary terms. Architecture, routing, SEO, i18n, themes, controls, exports, content, assets, and test gates are part of the production surface.
+
+The v0.2 release adds Motion Finder as the decision layer above that catalog:
+
+1. Accept a vague feeling, interface goal, or behavior in Chinese or English.
+2. Return up to three ranked variants with a concise reason and close-term distinction.
+3. Replay the candidates in the same scene for direct comparison.
+4. Preserve variants and aliases as meaningful presets while resolving implementation through canonical recipes.
+5. Continue into the existing parameter, Prompt, HTML, CSS, JavaScript, and reduced-motion workflow.
+
+The recommendation engine, web Finder, CLI `recommend` command, and Agent Skill share one versioned intent model. The entire path runs locally in the static frontend or CLI and requires no account or runtime server.
 
 ## Content Principles
 
@@ -56,6 +67,8 @@ The launch version ships 44 canonical units backed by all 91 vocabulary terms. A
 - Controls must update preview, generated CSS, generated HTML, generated prompt, and URL state together.
 - Gesture components must perform the named behavior in the preview and copied output, with pointer capture, multi-touch protection, damping, velocity-aware settlement, cancellation, and keyboard parity where applicable.
 - The current recipe should stay shareable through its URL.
+- Finder URLs should preserve the original query, candidate comparison, selected variant, and non-default parameter values.
+- Finder candidates should replay from one control and use a shared scene so visual differences remain directly comparable.
 - Copy actions need explicit success and failure states.
 - Touch targets should meet 44px on mobile and remain comfortable on desktop.
 - Motion controls should respect `prefers-reduced-motion` while preserving meaning.
@@ -78,6 +91,8 @@ Avoid generic SaaS decoration, oversized marketing card stacks, ornamental gradi
 Before a change is considered done:
 
 - Static pages build with route-level SEO metadata.
+- Finder pages prerender in both locales and publish stable canonical URLs.
+- Web and CLI recommendation tests return the same ordered variants, reasons, presets, and compare state for the same intent.
 - Recipe pages contain a real H1 and stable canonical path.
 - Desktop and mobile have no horizontal overflow.
 - Functional text passes accessible contrast in light and dark themes.

--- a/README.md
+++ b/README.md
@@ -4,15 +4,16 @@
 [![Code license: MIT](https://img.shields.io/badge/code-MIT-black.svg)](./LICENSE)
 [![Content license: CC BY 4.0](https://img.shields.io/badge/content-CC_BY_4.0-2457ff.svg)](./CONTENT-LICENSE)
 
-**[Live website](https://motion-lexicon.pages.dev/)** · **[44-recipe catalog](https://motion-lexicon.pages.dev/en/catalog/)** · **[91-term vocabulary](https://motion-lexicon.pages.dev/en/vocabulary/)** · **[Versioned JSON API](https://motion-lexicon.pages.dev/data/v1/catalog.json)**
+**[Live website](https://motion-lexicon.pages.dev/)** · **[Motion Finder](https://motion-lexicon.pages.dev/en/finder/)** · **[44-recipe catalog](https://motion-lexicon.pages.dev/en/catalog/)** · **[91-term vocabulary](https://motion-lexicon.pages.dev/en/vocabulary/)** · **[Versioned JSON API](https://motion-lexicon.pages.dev/data/v1/catalog.json)**
 
-Motion Lexicon is a visual motion recipe library. It helps users find a production-ready motion pattern, inspect its real behavior, tune relevant parameters, and copy agent-ready prompt text plus portable HTML, CSS, and interaction JavaScript.
+Motion Lexicon is a visual motion finder and recipe library. Describe a vague interface feeling or goal to receive three explainable candidates, compare them in one scene, select and tune a recipe, then copy agent-ready prompt text plus portable HTML, CSS, and interaction JavaScript.
 
 The launch catalog contains 44 canonical units across 12 categories: 31 copy-ready components, 9 focused playgrounds, and 4 guides. A dedicated bilingual vocabulary surface covers all 91 motion terms with original English technical definitions, accurate Chinese translations, and close-term distinctions. The 47 related terms resolve into the curated workspaces without duplicating components.
 
 ## Current Status
 
 - Static React + TypeScript application is implemented.
+- The bilingual Motion Finder turns vague intent into three ranked candidates with reasons, synchronized previews, shareable comparison state, and the existing tune-and-export workflow.
 - 44 canonical catalog units and all 91 source terms are available in Chinese and English.
 - Motion Lexicon independently maintains all 91 English definitions; every term includes a specific Chinese translation and every alias includes a bilingual distinction.
 - Preview, parameters, prompt, HTML, CSS, JavaScript, and reduced-motion output share one semantic motion specification.
@@ -37,10 +38,13 @@ The launch catalog contains 44 canonical units across 12 categories: 31 copy-rea
 Run the versioned CLI directly from GitHub:
 
 ```bash
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 search "shared element" --locale en --format json
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 show slide-in --locale en --format json
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 export slide-in --locale en --format bundle
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 recommend "卡片弹出来要有重量，最后收得住" --locale zh --format json
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 search "shared element" --locale en --format json
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 show spring --locale en --format json
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 export spring --locale en --format bundle
 ```
+
+`recommend` returns up to three ranked variants with match reasons, distinctions, resolved presets, preview URLs, and a shareable Finder comparison URL. `search` remains the exact vocabulary and catalog lookup command. Agent workflows continue from `recommend` or `search` through `show` and `export`.
 
 Install the Agent Skill:
 
@@ -57,6 +61,8 @@ Agent and tool integrations can use [llms.txt](https://motion-lexicon.pages.dev/
 /en/
 /zh/catalog/
 /en/catalog/
+/zh/finder/
+/en/finder/
 /zh/vocabulary/
 /en/vocabulary/
 /zh/:categoryId/
@@ -122,7 +128,15 @@ dist/sitemap.xml
 dist/robots.txt
 ```
 
-The public sitemap contains 118 canonical URLs: localized landing pages, catalogs, vocabulary pages, 12 category pages, and 44 canonical entries. Alias routes stay out of the sitemap.
+The public sitemap contains 120 canonical URLs: localized landing pages, Finders, catalogs, vocabulary pages, 12 category pages, and 44 canonical entries. Alias routes stay out of the sitemap.
+
+Finder input and comparison state live in the query string:
+
+```txt
+?q=card%20should%20land%20with%20weight&compare=spring%2Cpop-in%2Cscale-in&selected=spring
+```
+
+The canonical Finder URL omits query state. The CLI supplies `q` and the ordered `compare` variants; selecting a candidate adds `selected`, followed by any non-default recipe parameters.
 
 The deployed site is static HTML, CSS, and JavaScript. A Node server is not required at runtime. The code uses a React server renderer during the build step only.
 
@@ -196,8 +210,8 @@ npx impeccable --json src
 
 Current expected test surface:
 
-- Unit tests verify motion parameter and export generation.
-- Playwright checks desktop and mobile rendering, URL state updates, copy behavior, and horizontal overflow.
+- Unit tests verify recommendation ranking, web/CLI consistency, motion parameters, and export generation.
+- Playwright checks Finder comparison, desktop and mobile rendering, URL state updates, copy behavior, and horizontal overflow.
 - Static checks verify i18n coverage, SEO route coverage, motion rules, accessibility baseline, bundle budget, and built dist crawl.
 
 ## Content Standards

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,7 +20,8 @@ export default tseslint.config(
     },
     rules: {
       ...reactHooks.configs.recommended.rules,
-      // Hydration intentionally synchronizes persisted browser state after mount.
+      // Hydration intentionally synchronizes persisted browser state after the
+      // server-compatible first render.
       "react-hooks/set-state-in-effect": "off",
       "react-refresh/only-export-components": "off"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "motion-lexicon",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "motion-lexicon",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -15,7 +15,7 @@
         "motion-lexicon": "packages/cli/dist/motion-lexicon.mjs"
       },
       "devDependencies": {
-        "@eslint/js": "^9.17.0",
+        "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.49.1",
         "@radix-ui/react-slider": "^1.4.5",
         "@radix-ui/react-slot": "^1.3.1",
@@ -1017,14 +1017,24 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.4",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -4929,7 +4939,7 @@
     },
     "packages/cli": {
       "name": "@motion-lexicon/cli",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "bin": {
         "motion-lexicon": "dist/motion-lexicon.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "motion-lexicon",
-  "version": "0.1.0",
-  "description": "Open motion recipes for humans and agents, with an offline CLI and Node API.",
+  "version": "0.2.0",
+  "description": "An open motion finder and recipe library for humans and agents, with an offline CLI and Node API.",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -73,7 +73,7 @@
     "test:visual": "playwright test"
   },
   "devDependencies": {
-    "@eslint/js": "^9.17.0",
+    "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.49.1",
     "@radix-ui/react-slider": "^1.4.5",
     "@radix-ui/react-slot": "^1.3.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@motion-lexicon/cli",
-  "version": "0.1.0",
-  "description": "Offline CLI and Node API for Motion Lexicon recipes.",
+  "version": "0.2.0",
+  "description": "Offline recommendation CLI and Node API for Motion Lexicon recipes.",
   "type": "module",
   "bin": {
     "motion-lexicon": "./dist/motion-lexicon.mjs"

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,10 +1,12 @@
 import { resolve } from "node:path";
-import { catalog, exportRecipe, getSchema, search, show } from "./core.js";
+import { catalog, exportRecipe, getSchema, recommend, search, show } from "./core.js";
 import {
   formatCatalogMarkdown,
   formatCatalogText,
   formatRecipeMarkdown,
   formatRecipeText,
+  formatRecommendMarkdown,
+  formatRecommendText,
   formatSearchMarkdown,
   formatSearchText,
   json
@@ -30,9 +32,10 @@ const help = `Motion Lexicon ${version}
 Usage:
   motion-lexicon catalog [options]
   motion-lexicon search <query> [options]
+  motion-lexicon recommend <description> [options]
   motion-lexicon show <id-or-alias> [options]
   motion-lexicon export <id-or-alias> [options]
-  motion-lexicon schema [recipe|catalog|search|export]
+  motion-lexicon schema [recipe|catalog|search|recommend|export]
 
 Common options:
   --locale <zh|en>                Output language (default: en)
@@ -52,6 +55,7 @@ Export formats:
 
 Examples:
   motion-lexicon search "弹簧"
+  motion-lexicon recommend "卡片弹出来要有重量、最后收得住" --locale zh
   motion-lexicon show pop-in --locale zh --format json
   motion-lexicon export slide-in -p duration=260 --format bundle
   motion-lexicon export ripple --format files --out ./ripple-demo
@@ -197,6 +201,32 @@ async function runSearch(parsed: Parsed, io: CliIo) {
   write(io, format === "json" ? json(document) : format === "md" ? formatSearchMarkdown(document) : formatSearchText(document));
 }
 
+async function runRecommend(parsed: Parsed, io: CliIo) {
+  rejectOptions(parsed, ["--locale", "--format", "--limit"]);
+  if (!parsed.positionals.length) {
+    throw new MotionLexiconError("recommend requires a motion description.");
+  }
+  const format = discoveryFormat(parsed);
+  const rawLimit = option(parsed, "--limit");
+  if (rawLimit !== undefined && !/^\d+$/.test(rawLimit)) {
+    throw new MotionLexiconError(
+      "Motion Finder limit must be an integer from 1 to 3."
+    );
+  }
+  const document = recommend(parsed.positionals.join(" "), {
+    locale: locale(parsed),
+    limit: rawLimit === undefined ? undefined : Number(rawLimit)
+  });
+  write(
+    io,
+    format === "json"
+      ? json(document)
+      : format === "md"
+        ? formatRecommendMarkdown(document)
+        : formatRecommendText(document)
+  );
+}
+
 async function runShow(parsed: Parsed, io: CliIo) {
   rejectOptions(parsed, ["--locale", "--format", "--param"]);
   const id = onePositional(parsed, "show");
@@ -228,7 +258,7 @@ async function runSchema(parsed: Parsed, io: CliIo) {
   rejectOptions(parsed, []);
   if (parsed.positionals.length > 1) throw new MotionLexiconError("schema accepts one schema name.");
   const name = (parsed.positionals[0] ?? "recipe") as SchemaName;
-  if (!["recipe", "catalog", "search", "export"].includes(name)) {
+  if (!["recipe", "catalog", "search", "recommend", "export"].includes(name)) {
     throw new MotionLexiconError(`Unknown schema: ${name}.`);
   }
   write(io, json(getSchema(name)));
@@ -252,6 +282,7 @@ export async function runCli(argv: string[], io: CliIo): Promise<number> {
     }
     if (command === "catalog") await runCatalog(parsed, io);
     else if (command === "search") await runSearch(parsed, io);
+    else if (command === "recommend") await runRecommend(parsed, io);
     else if (command === "show") await runShow(parsed, io);
     else if (command === "export") await runExport(parsed, io);
     else if (command === "schema") await runSchema(parsed, io);

--- a/packages/cli/src/core.ts
+++ b/packages/cli/src/core.ts
@@ -27,6 +27,7 @@ import {
   getDefaultParamValues,
   valuesToSearchParams
 } from "../../../src/lib/motion-engine.js";
+import { recommendMotions } from "../../../src/lib/motion-finder.js";
 import {
   MotionLexiconError,
   schemaVersion,
@@ -38,6 +39,8 @@ import {
   type RecipeExportDocument,
   type RecipeOptions,
   type ResolvedRecipe,
+  type RecommendDocument,
+  type RecommendOptions,
   type SchemaName,
   type SearchDocument,
   type SearchOptions
@@ -286,6 +289,55 @@ export function search(query: string, options: SearchOptions = {}): SearchDocume
   return { schemaVersion, query: cleanQuery, locale, count: items.length, items };
 }
 
+export function recommend(
+  query: string,
+  options: RecommendOptions = {}
+): RecommendDocument {
+  const cleanQuery = query.trim();
+  if (!cleanQuery) throw new MotionLexiconError("A motion description is required.");
+  const locale = validateLocale(options.locale);
+  const limit = options.limit ?? 3;
+  if (!Number.isInteger(limit) || limit < 1 || limit > 3) {
+    throw new MotionLexiconError(
+      "Motion Finder limit must be an integer from 1 to 3."
+    );
+  }
+  const result = recommendMotions(cleanQuery, locale, limit);
+  return {
+    schemaVersion,
+    query: result.query,
+    locale,
+    confidence: result.confidence,
+    confidenceScore: result.confidenceScore,
+    matchedTerms: result.matchedTerms,
+    groupId: result.groupId,
+    groupName: result.groupName,
+    reason: result.reason,
+    finderPath: result.finderPath,
+    finderUrl: absolutePreviewUrl(result.finderPath),
+    comparePath: result.comparePath,
+    compareUrl: absolutePreviewUrl(result.comparePath),
+    count: result.candidates.length,
+    items: result.candidates.map((candidate) => ({
+      rank: candidate.rank,
+      variantId: candidate.variantId,
+      canonicalId: candidate.canonicalId,
+      name: candidate.name,
+      description: candidate.description,
+      reason: candidate.reason,
+      ...(candidate.distinction ? { distinction: candidate.distinction } : {}),
+      score: candidate.score,
+      confidence: candidate.confidence,
+      matchedTerms: candidate.matchedTerms,
+      ...(candidate.presetQuery ? { presetQuery: candidate.presetQuery } : {}),
+      presetValues: candidate.presetValues,
+      values: candidate.values,
+      path: candidate.recipePath,
+      previewUrl: absolutePreviewUrl(candidate.recipePath)
+    }))
+  };
+}
+
 export function show(id: string, options: RecipeOptions = {}): RecipeDocument {
   const locale = validateLocale(options.locale);
   const { recipe } = requireRecipe(id);
@@ -425,6 +477,61 @@ const definitions: Record<SchemaName, Record<string, unknown>> = {
             path: { type: "string", pattern: "^/" },
             previewUrl: { type: "string", format: "uri" },
             score: { type: "number", minimum: 0 }
+          }
+        }
+      }
+    }
+  },
+  recommend: {
+    type: "object",
+    required: [
+      "schemaVersion",
+      "query",
+      "locale",
+      "confidence",
+      "confidenceScore",
+      "groupId",
+      "finderUrl",
+      "compareUrl",
+      "count",
+      "items"
+    ],
+    properties: {
+      schemaVersion: { const: schemaVersion },
+      query: { type: "string" },
+      locale: { enum: ["zh", "en"] },
+      confidence: { enum: ["high", "medium", "low"] },
+      confidenceScore: { type: "number", minimum: 0, maximum: 1 },
+      groupId: { type: "string" },
+      finderUrl: { type: "string", format: "uri" },
+      compareUrl: { type: "string", format: "uri" },
+      count: { type: "integer", minimum: 0, maximum: 3 },
+      items: {
+        type: "array",
+        maxItems: 3,
+        items: {
+          type: "object",
+          required: [
+            "rank",
+            "variantId",
+            "canonicalId",
+            "score",
+            "confidence",
+            "presetValues",
+            "values",
+            "path",
+            "previewUrl"
+          ],
+          properties: {
+            rank: { type: "integer", minimum: 1, maximum: 3 },
+            variantId: { type: "string" },
+            canonicalId: { type: "string" },
+            score: { type: "number", minimum: 0, maximum: 100 },
+            confidence: { type: "number", minimum: 0, maximum: 1 },
+            presetValues: { type: "object" },
+            values: { type: "object" },
+            path: { type: "string", pattern: "^/" },
+            previewUrl: { type: "string", format: "uri" }
           }
         }
       }

--- a/packages/cli/src/format.ts
+++ b/packages/cli/src/format.ts
@@ -1,5 +1,6 @@
 import type {
   CatalogDocument,
+  RecommendDocument,
   RecipeDocument,
   SearchDocument
 } from "./types.js";
@@ -46,6 +47,32 @@ export function formatSearchMarkdown(document: SearchDocument) {
   return [
     "| ID | Name | Score | Description |",
     "| --- | --- | ---: | --- |",
+    ...rows
+  ].join("\n");
+}
+
+export function formatRecommendText(document: RecommendDocument) {
+  const heading = `${document.groupName}\t${document.confidence}\t${document.compareUrl}`;
+  const items = document.items.map(
+    (item) => `${item.rank}\t${item.variantId}\t${item.name}\t${item.score}\t${item.confidence}\t${item.reason}`
+  );
+  return [heading, ...items].join("\n");
+}
+
+export function formatRecommendMarkdown(document: RecommendDocument) {
+  const rows = document.items.map(
+    (item) => `| ${item.rank} | ${escapeCell(item.variantId)} | ${escapeCell(item.name)} | ${item.score} | ${item.confidence} | ${escapeCell(item.reason)} |`
+  );
+  return [
+    `# ${escapeCell(document.groupName)}`,
+    "",
+    document.reason,
+    "",
+    `- Confidence: \`${document.confidence}\` (${document.confidenceScore})`,
+    `- Compare: ${document.compareUrl}`,
+    "",
+    "| Rank | Variant | Name | Score | Confidence | Reason |",
+    "| ---: | --- | --- | ---: | ---: | --- |",
     ...rows
   ].join("\n");
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,7 @@ export {
   getSchema,
   listCanonicalIds,
   listCategories,
+  recommend,
   resolveRecipe,
   search,
   show
@@ -24,6 +25,9 @@ export {
   type RecipeExportDocument,
   type RecipeOptions,
   type ResolvedRecipe,
+  type RecommendDocument,
+  type RecommendItem,
+  type RecommendOptions,
   type SchemaName,
   type SearchDocument,
   type SearchItem,

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -9,7 +9,7 @@ import type {
 } from "../../../src/data/types.js";
 
 export const schemaVersion = 1 as const;
-export const version = "0.1.0";
+export const version = "0.2.0";
 
 export type CliLocale = "zh" | "en";
 export type DiscoveryFormat = "text" | "json" | "md";
@@ -29,6 +29,11 @@ export type CatalogOptions = {
 };
 
 export type SearchOptions = CatalogOptions & {
+  limit?: number;
+};
+
+export type RecommendOptions = {
+  locale?: CliLocale;
   limit?: number;
 };
 
@@ -67,6 +72,42 @@ export type SearchDocument = {
   locale: CliLocale;
   count: number;
   items: SearchItem[];
+};
+
+export type RecommendItem = {
+  rank: number;
+  variantId: string;
+  canonicalId: string;
+  name: string;
+  description: string;
+  reason: string;
+  distinction?: string;
+  score: number;
+  confidence: number;
+  matchedTerms: string[];
+  presetQuery?: string;
+  presetValues: ParamValues;
+  values: ParamValues;
+  path: string;
+  previewUrl: string;
+};
+
+export type RecommendDocument = {
+  schemaVersion: typeof schemaVersion;
+  query: string;
+  locale: CliLocale;
+  confidence: "high" | "medium" | "low";
+  confidenceScore: number;
+  matchedTerms: string[];
+  groupId: string;
+  groupName: string;
+  reason: string;
+  finderPath: string;
+  finderUrl: string;
+  comparePath: string;
+  compareUrl: string;
+  count: number;
+  items: RecommendItem[];
 };
 
 export type RecipeParamOption = {
@@ -146,7 +187,7 @@ export type ResolvedRecipe = {
   values: ParamValues;
 };
 
-export type SchemaName = "recipe" | "catalog" | "search" | "export";
+export type SchemaName = "recipe" | "catalog" | "search" | "recommend" | "export";
 
 export class MotionLexiconError extends Error {
   readonly code: string;

--- a/public/data/v1/catalog.json
+++ b/public/data/v1/catalog.json
@@ -5,8 +5,8 @@
   "project": {
     "name": "Motion Lexicon",
     "description": {
-      "zh": "可视、可调、可复制的界面动效词典。",
-      "en": "A visual, tunable, and copy-ready lexicon for interface motion."
+      "zh": "从模糊描述推荐候选，并提供可视、可调、可复制配方的界面动效词典。",
+      "en": "An interface motion finder that turns fuzzy descriptions into comparable, tunable, and copy-ready recipes."
     },
     "siteUrl": "https://motion-lexicon.pages.dev",
     "repositoryUrl": "https://github.com/Ryan-yang125/motion-lexicon",
@@ -14,10 +14,14 @@
       "zh",
       "en"
     ],
-    "cliCommand": "npx github:Ryan-yang125/motion-lexicon",
+    "cliCommand": "npx -y github:Ryan-yang125/motion-lexicon#v0.2.0",
     "skillCommand": "npx skills add Ryan-yang125/motion-lexicon --skill motion-lexicon"
   },
   "endpoints": {
+    "finder": {
+      "zh": "https://motion-lexicon.pages.dev/zh/finder/",
+      "en": "https://motion-lexicon.pages.dev/en/finder/"
+    },
     "catalog": "https://motion-lexicon.pages.dev/data/v1/catalog.json",
     "vocabulary": "https://motion-lexicon.pages.dev/data/v1/vocabulary.json",
     "recipeTemplate": "https://motion-lexicon.pages.dev/data/v1/recipes/{id}.json",

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,9 +1,11 @@
 # Motion Lexicon
 
-> A free, open-source, bilingual reference for choosing, tuning, reviewing, and implementing interface motion.
+> A free, open-source, bilingual motion finder and recipe reference for choosing, comparing, tuning, reviewing, and implementing interface motion.
 
 - Website: https://motion-lexicon.pages.dev/en/
 - Chinese website: https://motion-lexicon.pages.dev/zh/
+- Motion Finder: https://motion-lexicon.pages.dev/en/finder/
+- 中文动效选择器: https://motion-lexicon.pages.dev/zh/finder/
 - Source: https://github.com/Ryan-yang125/motion-lexicon
 - Pricing: https://motion-lexicon.pages.dev/pricing.txt (free; no account required)
 - Catalog JSON: https://motion-lexicon.pages.dev/data/v1/catalog.json
@@ -13,7 +15,8 @@
 
 ## Free tools
 
-- CLI: `npx github:Ryan-yang125/motion-lexicon`
+- CLI: `npx -y github:Ryan-yang125/motion-lexicon#v0.2.0`
+- Fuzzy recommendation: `npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 recommend "describe the motion you want" --locale en --format json`
 - Agent Skill: `npx skills add Ryan-yang125/motion-lexicon --skill motion-lexicon`
 
 ## Canonical recipes

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,9 +1,11 @@
 # Motion Lexicon
 
-> A free, open-source, bilingual reference for choosing, tuning, reviewing, and implementing interface motion.
+> A free, open-source, bilingual motion finder and recipe reference for choosing, comparing, tuning, reviewing, and implementing interface motion.
 
 - Website: https://motion-lexicon.pages.dev/en/
 - Chinese website: https://motion-lexicon.pages.dev/zh/
+- Motion Finder: https://motion-lexicon.pages.dev/en/finder/
+- 中文动效选择器: https://motion-lexicon.pages.dev/zh/finder/
 - Source: https://github.com/Ryan-yang125/motion-lexicon
 - Pricing: https://motion-lexicon.pages.dev/pricing.txt (free; no account required)
 - Catalog JSON: https://motion-lexicon.pages.dev/data/v1/catalog.json
@@ -13,7 +15,8 @@
 
 ## Free tools
 
-- CLI: `npx github:Ryan-yang125/motion-lexicon`
+- CLI: `npx -y github:Ryan-yang125/motion-lexicon#v0.2.0`
+- Fuzzy recommendation: `npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 recommend "describe the motion you want" --locale en --format json`
 - Agent Skill: `npx skills add Ryan-yang125/motion-lexicon --skill motion-lexicon`
 
 ## Canonical recipes

--- a/public/pricing.txt
+++ b/public/pricing.txt
@@ -6,11 +6,11 @@
 - Billing: None
 - Account required: No
 - Website: https://motion-lexicon.pages.dev
-- CLI: npx github:Ryan-yang125/motion-lexicon
+- CLI: npx -y github:Ryan-yang125/motion-lexicon#v0.2.0
 - Agent Skill: npx skills add Ryan-yang125/motion-lexicon --skill motion-lexicon
 - Source: https://github.com/Ryan-yang125/motion-lexicon
 - Code license: MIT
 - Vocabulary and editorial content license: CC BY 4.0
 - Generated code snippets license: 0BSD
 - Usage: The public static website is available without an account. The CLI and Agent Skill run locally.
-- Last updated: 2026-07-23
+- Last updated: 2026-07-30

--- a/scripts/check-bundle.ts
+++ b/scripts/check-bundle.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { gzipSync } from "node:zlib";
 import { readFileSync } from "node:fs";
 
-function assert(condition: unknown, message: string) {
+function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);
   }
@@ -20,7 +20,7 @@ assert(jsFiles.some((file) => file.startsWith("vendor-")), "Stable vendor bundle
 
 const maxChunkRawBytes = 650 * 1024;
 const maxChunkGzipBytes = 160 * 1024;
-const maxTotalJsGzipBytes = 220 * 1024;
+const maxTotalJsGzipBytes = 230 * 1024;
 const maxTotalCssGzipBytes = 48 * 1024;
 let totalJsGzipBytes = 0;
 
@@ -32,6 +32,13 @@ for (const file of jsFiles) {
   assert(rawSize <= maxChunkRawBytes, `${file} raw size ${rawSize} exceeds ${maxChunkRawBytes}`);
   assert(gzipSize <= maxChunkGzipBytes, `${file} gzip size ${gzipSize} exceeds ${maxChunkGzipBytes}`);
 }
+
+const finderChunk = jsFiles.find((file) => file.startsWith("finder.lazy-"));
+assert(finderChunk, "Motion Finder route chunk is missing");
+assert(
+  gzipSync(readFileSync(path.join(assetsDir, finderChunk))).length <= 12 * 1024,
+  "Motion Finder route chunk exceeds 12 KiB gzip"
+);
 
 const totalCssGzipBytes = cssFiles.reduce((total, file) => {
   return total + gzipSync(readFileSync(path.join(assetsDir, file))).length;

--- a/scripts/check-seo.ts
+++ b/scripts/check-seo.ts
@@ -80,12 +80,13 @@ const sitemap = sitemapPaths();
 const expectedPaths = locales.flatMap((locale) => [
   pathFor(locale),
   pathFor(locale, ["catalog"]),
+  pathFor(locale, ["finder"]),
   pathFor(locale, ["vocabulary"]),
   ...categories.map((category) => pathFor(locale, [category.id])),
   ...canonicalMotionCatalog.map((item) => pathFor(locale, [item.categoryId, item.id]))
 ]);
 
-assert(expectedPaths.length === 118, `Expected 118 localized canonical paths, found ${expectedPaths.length}`);
+assert(expectedPaths.length === 120, `Expected 120 localized canonical paths, found ${expectedPaths.length}`);
 assert(staticPaths.length === expectedPaths.length, `Expected ${expectedPaths.length} static paths, found ${staticPaths.length}`);
 assert(sitemap.length === expectedPaths.length, `Expected ${expectedPaths.length} sitemap URLs, found ${sitemap.length}`);
 assert(new Set(staticPaths).size === staticPaths.length, "Static paths contain duplicates");

--- a/scripts/generate-public-artifacts.ts
+++ b/scripts/generate-public-artifacts.ts
@@ -13,7 +13,8 @@ const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
 const publicDir = path.join(rootDir, "public");
 const repositoryUrl = "https://github.com/Ryan-yang125/motion-lexicon";
 const schemaVersion = 1;
-const cliCommand = "npx github:Ryan-yang125/motion-lexicon";
+const cliCommand = "npx -y github:Ryan-yang125/motion-lexicon#v0.2.0";
+const cliRecommendCommand = `${cliCommand} recommend "describe the motion you want" --locale en --format json`;
 const skillCommand = "npx skills add Ryan-yang125/motion-lexicon --skill motion-lexicon";
 
 type Artifact = {
@@ -100,8 +101,8 @@ function catalogArtifact() {
     project: {
       name: "Motion Lexicon",
       description: {
-        zh: "可视、可调、可复制的界面动效词典。",
-        en: "A visual, tunable, and copy-ready lexicon for interface motion."
+        zh: "从模糊描述推荐候选，并提供可视、可调、可复制配方的界面动效词典。",
+        en: "An interface motion finder that turns fuzzy descriptions into comparable, tunable, and copy-ready recipes."
       },
       siteUrl,
       repositoryUrl,
@@ -110,6 +111,10 @@ function catalogArtifact() {
       skillCommand
     },
     endpoints: {
+      finder: {
+        zh: absoluteUrl(pathFor("zh", ["finder"])),
+        en: absoluteUrl(pathFor("en", ["finder"]))
+      },
       catalog: `${siteUrl}/data/v1/catalog.json`,
       vocabulary: `${siteUrl}/data/v1/vocabulary.json`,
       recipeTemplate: `${siteUrl}/data/v1/recipes/{id}.json`,
@@ -414,10 +419,12 @@ function llmsArtifact() {
   const lines = [
     "# Motion Lexicon",
     "",
-    "> A free, open-source, bilingual reference for choosing, tuning, reviewing, and implementing interface motion.",
+    "> A free, open-source, bilingual motion finder and recipe reference for choosing, comparing, tuning, reviewing, and implementing interface motion.",
     "",
     `- Website: ${siteUrl}/en/`,
     `- Chinese website: ${siteUrl}/zh/`,
+    `- Motion Finder: ${siteUrl}/en/finder/`,
+    `- 中文动效选择器: ${siteUrl}/zh/finder/`,
     `- Source: ${repositoryUrl}`,
     `- Pricing: ${siteUrl}/pricing.txt (free; no account required)`,
     `- Catalog JSON: ${siteUrl}/data/v1/catalog.json`,
@@ -428,6 +435,7 @@ function llmsArtifact() {
     "## Free tools",
     "",
     `- CLI: \`${cliCommand}\``,
+    `- Fuzzy recommendation: \`${cliRecommendCommand}\``,
     `- Agent Skill: \`${skillCommand}\``,
     "",
     "## Canonical recipes",
@@ -464,7 +472,7 @@ function pricingArtifact() {
 - Vocabulary and editorial content license: CC BY 4.0
 - Generated code snippets license: 0BSD
 - Usage: The public static website is available without an account. The CLI and Agent Skill run locally.
-- Last updated: 2026-07-23
+- Last updated: 2026-07-30
 `;
 }
 

--- a/skills/motion-lexicon/SKILL.md
+++ b/skills/motion-lexicon/SKILL.md
@@ -1,36 +1,41 @@
 ---
 name: motion-lexicon
-description: Search, compare, tune, review, and export Motion Lexicon UI motion recipes through the versioned CLI. Use for choosing an interface animation pattern, resolving animation vocabulary or aliases, obtaining canonical preview and data URLs, applying reduced-motion guidance, or producing portable Prompt, HTML, CSS, and JavaScript output.
+description: Recommend, compare, search, tune, review, and export Motion Lexicon UI motion recipes through the versioned CLI. Use when a user describes a vague motion feeling or interface goal, asks which animation pattern fits, wants to distinguish similar motions, names a motion term or alias, needs a canonical preview or compare URL, requests reduced-motion guidance, or wants portable Prompt, HTML, CSS, and JavaScript output.
 ---
 
 # Motion Lexicon
 
-Use the fixed Motion Lexicon v0.1.0 CLI as the catalog source of truth. Resolve every requested term through the CLI before recommending a recipe or producing implementation output.
+Use the fixed Motion Lexicon v0.2.0 CLI as the source of truth. Resolve every request through the CLI before recommending a recipe or producing implementation output.
 
 ## Workflow
 
 1. Read [references/cli.md](references/cli.md) before running a command.
 2. Choose `zh` or `en` from the user's language. Preserve an explicitly requested locale.
-3. Search the catalog when the user provides a goal, visual description, component, or unfamiliar term.
-4. Inspect the selected canonical recipe with `show`. Confirm its parameters, reduced-motion strategy, review notes, and live path.
-5. Run `export` only when the user requests Prompt, HTML, CSS, JavaScript, a bundle, or files.
-6. Return the canonical recipe ID, rationale, live preview URL, chosen parameter values, reduced-motion treatment, and requested output.
+3. Run `recommend` when the user provides a vague goal, feeling, visual description, or component behavior. Use the default Top 3 and retain each CLI-provided rank, reason, distinction, and preset.
+4. Return the CLI-provided `compareUrl` with the three candidates. Explain the meaningful choice in the user's language.
+5. Run `search` when the user provides a known term, canonical ID, alias, category filter, or wants broader exact catalog discovery. This preserves the v0.1 exact-search workflow.
+6. Inspect the chosen variant with `show <variantId>`. Confirm its canonical recipe, resolved preset, parameters, reduced-motion strategy, review notes, and live path.
+7. Run `export` when the user requests Prompt, HTML, CSS, JavaScript, a bundle, or files.
+8. Return the original intent, chosen variant and canonical recipe IDs, rationale, live preview URL, compare URL when applicable, chosen parameter values, reduced-motion treatment, and requested output.
 
 ## Required command base
 
 Run every CLI operation through this pinned command:
 
 ```bash
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0
 ```
 
-Prefer `--format json` for search and inspection so canonical IDs and parameter constraints remain machine-readable. Treat an exit code of `2` as a command or input error and report the stderr message directly.
+Prefer `--format json` for recommendation, search, and inspection so candidate reasons, canonical IDs, presets, and parameter constraints remain machine-readable. Treat an exit code of `2` as a command or input error and report the stderr message directly.
 
 ## Selection rules
 
-- Use `search` for intent discovery and `show` for exact validation.
+- Use `recommend` for fuzzy intent discovery, `search` for exact vocabulary discovery, and `show` for validation.
+- Preserve the CLI candidate order. Treat candidate `variantId` as the user-facing motion choice and `canonicalId` as its implementation workspace. Pass `variantId` to `show` and `export` so alias presets stay intact.
+- Use the CLI-provided `reason`, `distinction`, `matchedTerms`, and `confidence`; keep uncertainty visible.
+- Return `compareUrl` unchanged so the user receives the same Top 3 in the web Finder.
 - Resolve aliases to the CLI-provided canonical ID. Keep the user's original term in the explanation when it clarifies the mapping.
 - Keep default parameter values unless the user's context gives a concrete reason to tune them.
 - Include reduced-motion guidance for every implementation or review request.
 - Link to the localized live path returned by the CLI.
-- Generate output with `export`; never reconstruct catalog output from memory.
+- Generate output with `export`; always use catalog output from the current pinned CLI.

--- a/skills/motion-lexicon/agents/openai.yaml
+++ b/skills/motion-lexicon/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Motion Lexicon"
-  short_description: "Find and export portable UI motion recipes"
-  default_prompt: "Use $motion-lexicon to find the best UI motion recipe and return a live preview with portable implementation output."
+  short_description: "Turn vague motion intent into comparable recipes"
+  default_prompt: "Use $motion-lexicon to recommend three UI motion candidates with reasons and a compare URL, then inspect and export the selected recipe."

--- a/skills/motion-lexicon/evals/evals.json
+++ b/skills/motion-lexicon/evals/evals.json
@@ -1,0 +1,50 @@
+{
+  "skill_name": "motion-lexicon",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "我想让一张卡片弹出来时有重量感，最后能稳稳收住。帮我选一个合适的动效，并给我可以直接交给编码 Agent 的 Prompt。",
+      "expected_output": "Should run the pinned v0.2.0 recommend command in zh with JSON output, preserve the three ranked candidates and their CLI-provided reasons, provide the localized compare URL, select or confirm one candidate, inspect it with show, and obtain the final prompt through export. The answer should include the selected variant and canonical IDs, parameter values, and reduced-motion treatment.",
+      "assertions": [
+        "Runs npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 recommend with --locale zh --format json",
+        "Presents three candidates in the CLI-provided rank order",
+        "Includes a CLI-provided reason for each candidate",
+        "Returns the localized compareUrl from the recommendation document",
+        "Uses show on the selected variantId before implementation",
+        "Uses export with --format prompt for the requested Prompt",
+        "Includes resolved parameter values and reduced-motion guidance"
+      ],
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "The thumbnail should leave and the detail view should feel like the same object continuing in space. Compare the closest motion patterns and give me the best live reference.",
+      "expected_output": "Should treat the request as fuzzy intent, run recommend in English, and report the returned Top 3 with reasons and distinctions. It should preserve aliases or presets in variantId while using canonicalId for inspection, return the compare URL, then use show for the chosen candidate and include the preview URL plus reduced-motion guidance.",
+      "assertions": [
+        "Runs the pinned v0.2.0 recommend command with --locale en --format json",
+        "Reports exactly three ranked candidates when the CLI returns three",
+        "Preserves variantId separately from canonicalId",
+        "Includes CLI-provided distinctions when present",
+        "Returns compareUrl unchanged",
+        "Runs show for the chosen variantId",
+        "Includes the chosen previewUrl and reduced-motion guidance"
+      ],
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "I already know the term is shared element. Resolve the exact Motion Lexicon entry, set any preset it requires, and export a portable bundle.",
+      "expected_output": "Should preserve exact-search compatibility by using search for the explicit term, resolve the returned alias or canonical entry with show, preserve any CLI-provided preset query and values, and generate the bundle with export. The answer should name both the requested term and canonical ID and include the live preview plus reduced-motion treatment.",
+      "assertions": [
+        "Runs npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 search for shared element with JSON output",
+        "Uses the CLI-provided canonical ID",
+        "Runs show before export",
+        "Preserves presetQuery and preset values when provided",
+        "Runs export with --format bundle",
+        "Names the requested term and canonical recipe ID",
+        "Includes the localized preview URL and reduced-motion guidance"
+      ],
+      "files": []
+    }
+  ]
+}

--- a/skills/motion-lexicon/references/cli.md
+++ b/skills/motion-lexicon/references/cli.md
@@ -1,31 +1,50 @@
-# Motion Lexicon CLI v0.1.0
+# Motion Lexicon CLI v0.2.0
 
 Use this fixed command prefix for every operation:
 
 ```bash
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0
 ```
 
 The CLI writes normal results to stdout. Invalid commands, IDs, parameters, or formats write an actionable message to stderr and exit with status `2`.
 
-## Discover recipes
+## Recommend from vague intent
+
+Turn a natural-language feeling or interface goal into three ranked candidates:
+
+```bash
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 recommend "卡片弹出来要有重量，最后收得住" --locale zh --format json
+```
+
+`recommend` accepts `--limit 1..3` and defaults to three candidates. Its JSON document uses `schemaVersion: 1` and includes:
+
+- `query`, `locale`, `confidence`, `matchedTerms`, and an explainable `reason`.
+- `groupId` and `groupName` for the matched comparison set.
+- `finderPath`, `finderUrl`, `comparePath`, and `compareUrl` for the static web Finder.
+- `items[]` in ranked order with `rank`, `variantId`, `canonicalId`, `reason`, optional `distinction`, `confidence`, `matchedTerms`, presets, resolved values, and preview links.
+
+Keep `items[]` in CLI order. Use `variantId` with `show` and `export` so alias presets remain active; use `canonicalId` to identify the implementation workspace. Return `compareUrl` unchanged.
+
+## Discover exact recipes
+
+`search` remains available for exact motion terms, aliases, categories, surfaces, and broader catalog lookup.
 
 List the catalog:
 
 ```bash
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 catalog --locale en --format json
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 catalog --locale en --format json
 ```
 
 Filter by category or surface:
 
 ```bash
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 catalog --locale en --format json --category entrances --surface component
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 catalog --locale en --format json --category entrances --surface component
 ```
 
 Search from natural-language intent or a motion term:
 
 ```bash
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 search "drawer entrance" --locale en --format json --limit 5
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 search "shared element" --locale en --format json --limit 5
 ```
 
 Search JSON uses `schemaVersion: 1` and provides `items[].id`. Use those IDs for inspection.
@@ -35,13 +54,13 @@ Search JSON uses `schemaVersion: 1` and provides `items[].id`. Use those IDs for
 Resolve a canonical ID or alias:
 
 ```bash
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 show slide-in --locale en --format json
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 show slide-in --locale en --format json
 ```
 
 Apply validated parameter values with repeatable flags:
 
 ```bash
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 show slide-in --locale en --format json --param duration=260 --param direction=left
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 show slide-in --locale en --format json --param duration=260 --param direction=left
 ```
 
 Rely on `id`, `canonicalId`, `path`, `params`, `values`, `reducedMotion`, and `reviewNotes`. Alias results may also provide `requestedId`, `alias`, and `presetQuery`.
@@ -51,7 +70,7 @@ Rely on `id`, `canonicalId`, `path`, `params`, `values`, `reducedMotion`, and `r
 Export one format to stdout:
 
 ```bash
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 export slide-in --locale en --format css --param duration=260
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 export slide-in --locale en --format css --param duration=260
 ```
 
 Supported formats are `prompt`, `html`, `css`, `js`, `bundle`, `json`, and `files`.
@@ -60,7 +79,7 @@ The `bundle` format contains the Prompt, HTML, CSS, and any required JavaScript 
 Write a portable file set only when the user requests files and has authorized workspace edits:
 
 ```bash
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 export slide-in --locale en --format files --out ./motion-lexicon-export
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 export slide-in --locale en --format files --out ./motion-lexicon-export
 ```
 
 Use `--force` only with explicit overwrite permission.
@@ -68,10 +87,11 @@ Use `--force` only with explicit overwrite permission.
 ## Inspect schemas
 
 ```bash
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 schema recipe
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 schema catalog
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 schema search
-npx -y github:Ryan-yang125/motion-lexicon#v0.1.0 schema export
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 schema recipe
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 schema catalog
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 schema search
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 schema recommend
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 schema export
 ```
 
 Text and Markdown formats are intended for direct reading. JSON is the stable agent integration format.

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -26,6 +26,9 @@ export function Footer() {
         </div>
         <nav aria-label={t("footer.exploreLabel")}>
           <span>{t("footer.explore")}</span>
+          <Link to="/$locale/finder/" params={{ locale }}>
+            {t("nav.finder")}
+          </Link>
           <Link to="/$locale/catalog/" params={{ locale }} search={{ surface: "components" }}>
             {t("nav.components")}
           </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "@tanstack/react-router";
-import { Github, Menu, Search } from "lucide-react";
+import { Github, Menu, Sparkles } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { Locale } from "../data/types";
 import { ThemeLanguageControls } from "./ThemeLanguageControls";
@@ -18,6 +18,7 @@ export function Header({ locale }: HeaderProps) {
   const location = useLocation();
   const surface = new URLSearchParams(location.searchStr).get("surface") ?? "components";
   const isCatalog = /\/catalog\/?$/.test(location.pathname);
+  const isFinder = /\/finder\/?$/.test(location.pathname);
   const isVocabulary = /\/vocabulary\/?$/.test(location.pathname);
   const vocabularyLabel = locale === "zh" ? "动画词汇" : "Vocabulary";
 
@@ -38,6 +39,14 @@ export function Header({ locale }: HeaderProps) {
         </Link>
 
         <nav className="library-primary-nav" aria-label={t("nav.primaryLabel")}>
+          <Link
+            to="/$locale/finder/"
+            params={{ locale }}
+            className={isFinder ? "is-active" : undefined}
+            aria-current={isFinder ? "page" : undefined}
+          >
+            {t("nav.finder")}
+          </Link>
           {surfaces.map((item) => (
             <Link
               key={item}
@@ -63,15 +72,12 @@ export function Header({ locale }: HeaderProps) {
         <div className="library-header-actions">
           <Link
             className="library-search-link"
-            to="/$locale/catalog/"
+            to="/$locale/finder/"
             params={{ locale }}
-            search={{ surface: "components" }}
-            hash="catalog-search"
-            aria-label={t("nav.searchLibrary")}
+            aria-label={t("nav.openFinder")}
           >
-            <Search aria-hidden="true" size={15} strokeWidth={1.8} />
-            <span>{t("common.search")}</span>
-            <kbd>/</kbd>
+            <Sparkles aria-hidden="true" size={15} strokeWidth={1.8} />
+            <span>{t("nav.finderShort")}</span>
           </Link>
           <a
             className="icon-link"
@@ -89,6 +95,9 @@ export function Header({ locale }: HeaderProps) {
               <Menu aria-hidden="true" size={18} strokeWidth={1.8} />
             </summary>
             <nav aria-label={t("nav.mobileLabel")}>
+              <Link to="/$locale/finder/" params={{ locale }}>
+                {t("nav.finder")}
+              </Link>
               {surfaces.map((item) => (
                 <Link
                   key={item}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, Bot, Search, SlidersHorizontal, Terminal } from "lucide-react";
+import { ArrowRight, Bot, Search, Sparkles, Terminal } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { getCompactCatalogEntry } from "../data/compact-catalog";
 import type { Locale } from "../data/types";
@@ -25,33 +25,30 @@ export function Hero({ locale }: { locale: Locale }) {
         <div className="library-hero-actions">
           <Link
             className="library-button is-primary"
-            to="/$locale/catalog/"
+            to="/$locale/finder/"
             params={{ locale }}
-            search={{ surface: "components" }}
           >
-            {t("landing.browseComponents")}
+            <Sparkles aria-hidden="true" size={16} strokeWidth={1.8} />
+            {t("landing.openFinder")}
             <ArrowRight aria-hidden="true" size={16} strokeWidth={1.8} />
           </Link>
           <Link
             className="library-button"
             to="/$locale/catalog/"
             params={{ locale }}
-            search={{ surface: "playgrounds" }}
+            search={{ surface: "components" }}
           >
-            <SlidersHorizontal aria-hidden="true" size={16} strokeWidth={1.8} />
-            {t("landing.openPlaygrounds")}
+            {t("landing.browseComponents")}
           </Link>
         </div>
         <Link
           className="library-hero-search"
-          to="/$locale/catalog/"
+          to="/$locale/finder/"
           params={{ locale }}
-          search={{ surface: "components" }}
-          hash="catalog-search"
         >
           <Search aria-hidden="true" size={17} strokeWidth={1.8} />
-          <span>{t("landing.searchLibrary")}</span>
-          <kbd>/</kbd>
+          <span>{t("landing.finderExample")}</span>
+          <span aria-hidden="true">→</span>
         </Link>
         <a
           className="library-hero-search"

--- a/src/components/MotionCompare.tsx
+++ b/src/components/MotionCompare.tsx
@@ -1,0 +1,156 @@
+import { ArrowUpRight, Check, RotateCcw } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { Locale, ParamValues } from "../data/types";
+import {
+  buildRecipeCss,
+  buildRecipeHtml,
+  getMotionRuntimeConfig
+} from "../lib/motion-engine";
+import type { MotionFinderCandidate } from "../lib/motion-finder";
+import { mountMotionRuntime } from "../lib/motion-runtime";
+import { Button } from "./ui/button";
+
+type MotionCompareProps = {
+  locale: Locale;
+  candidates: MotionFinderCandidate[];
+  selectedId: string;
+  selectedValues: ParamValues | null;
+  onSelect: (candidate: MotionFinderCandidate) => void;
+};
+
+function CandidatePreview({
+  candidate,
+  locale,
+  replayKey,
+  values
+}: {
+  candidate: MotionFinderCandidate;
+  locale: Locale;
+  replayKey: number;
+  values: ParamValues;
+}) {
+  const runtimeHostRef = useRef<HTMLDivElement>(null);
+  const previousReplayRef = useRef(replayKey);
+  const output = useMemo(
+    () => ({
+      css: buildRecipeCss(candidate.recipe, values),
+      html: buildRecipeHtml(candidate.recipe, values, locale, candidate.name)
+    }),
+    [candidate.name, candidate.recipe, locale, values]
+  );
+
+  useEffect(() => {
+    const host = runtimeHostRef.current;
+    if (!host) return;
+    const shadow = host.shadowRoot ?? host.attachShadow({ mode: "open" });
+    const style = document.createElement("style");
+    const scene = document.createElement("div");
+    style.textContent = `:host { display: grid; place-items: center; width: 100%; height: 100%; }
+:host > div { display: grid; place-items: center; width: 100%; }
+${output.css}`;
+    scene.innerHTML = output.html;
+    shadow.replaceChildren(style, scene);
+    const root = scene.querySelector<HTMLElement>(".motion-demo");
+    if (!root) return;
+    const autoplay = previousReplayRef.current !== replayKey;
+    previousReplayRef.current = replayKey;
+    return mountMotionRuntime(
+      root,
+      getMotionRuntimeConfig(candidate.recipe, values, autoplay)
+    );
+  }, [candidate.recipe, output.css, output.html, replayKey, values]);
+
+  return (
+    <div
+      ref={runtimeHostRef}
+      className="finder-candidate-stage motion-runtime-stage"
+      aria-label={`${candidate.name} — ${candidate.description}`}
+    />
+  );
+}
+
+export function MotionCompare({
+  locale,
+  candidates,
+  selectedId,
+  selectedValues,
+  onSelect
+}: MotionCompareProps) {
+  const { t } = useTranslation();
+  const [replayKey, setReplayKey] = useState(0);
+
+  return (
+    <div className="finder-compare">
+      <div className="finder-compare-toolbar">
+        <span>{t("finder.resultCount", { count: candidates.length })}</span>
+        <Button
+          type="button"
+          variant="soft"
+          size="sm"
+          onClick={() => setReplayKey((current) => current + 1)}
+        >
+          <RotateCcw aria-hidden="true" size={15} strokeWidth={1.8} />
+          {t("finder.replayAll")}
+        </Button>
+      </div>
+
+      <div className="finder-candidate-grid" aria-live="polite">
+        {candidates.map((candidate) => {
+          const selected = candidate.variantId === selectedId;
+          const previewValues = selected && selectedValues ? selectedValues : candidate.values;
+          return (
+            <article
+              className={selected ? "finder-candidate is-selected" : "finder-candidate"}
+              key={candidate.variantId}
+              data-variant-id={candidate.variantId}
+            >
+              <header className="finder-candidate-header">
+                <div>
+                  <span>{t("finder.candidateLabel", { rank: candidate.rank })}</span>
+                  <h3>{candidate.name}</h3>
+                  <p>{candidate.description}</p>
+                </div>
+              </header>
+
+              <CandidatePreview
+                candidate={candidate}
+                locale={locale}
+                replayKey={replayKey}
+                values={previewValues}
+              />
+
+              <div className="finder-candidate-body">
+                <p>{candidate.reason}</p>
+                {candidate.distinction ? (
+                  <div className="finder-distinction">
+                    <span>{t("finder.distinction")}</span>
+                    <p>{candidate.distinction}</p>
+                  </div>
+                ) : null}
+              </div>
+
+              <footer className="finder-candidate-actions">
+                <button
+                  type="button"
+                  className={selected ? "finder-select is-selected" : "finder-select"}
+                  aria-pressed={selected}
+                  onClick={() => onSelect(candidate)}
+                >
+                  {selected ? <Check aria-hidden="true" size={15} /> : null}
+                  {selected
+                    ? t("finder.selected")
+                    : t("finder.select", { name: candidate.name })}
+                </button>
+                <a href={candidate.recipePath}>
+                  {t("finder.openRecipe")}
+                  <ArrowUpRight aria-hidden="true" size={14} />
+                </a>
+              </footer>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/data/motion-intents.ts
+++ b/src/data/motion-intents.ts
@@ -1,0 +1,168 @@
+import type { LocalizedText } from "./types";
+
+export type LocalizedPhrases = Record<"zh" | "en", readonly string[]>;
+
+export type MotionIntentVariant = {
+  variantId: string;
+  reason: LocalizedText;
+  signals: LocalizedPhrases;
+};
+
+export type MotionIntentGroup = {
+  id: string;
+  name: LocalizedText;
+  reason: LocalizedText;
+  signals: LocalizedPhrases;
+  variants: readonly MotionIntentVariant[];
+};
+
+const localized = (zh: string, en: string): LocalizedText => ({ zh, en });
+
+/**
+ * Curated ambiguity groups for the first Motion Finder release. The signal
+ * lists intentionally contain words people use to describe what they see and
+ * feel, while each variant keeps a precise glossary identity.
+ */
+export const motionIntentGroups: readonly MotionIntentGroup[] = [
+  {
+    id: "entrance-feel",
+    name: localized("入场手感", "Entrance feel"),
+    reason: localized(
+      "这段描述关注元素出现时的尺寸变化、弹性与落点手感。",
+      "This description focuses on scale, elasticity, and settling during an entrance."
+    ),
+    signals: {
+      zh: ["出现", "入场", "弹出来", "弹出", "卡片", "按钮", "浮层", "放大", "缩放", "落到位"],
+      en: ["appear", "entrance", "enter", "card", "button", "popover", "grow", "scale", "settle"]
+    },
+    variants: [
+      {
+        variantId: "scale-in",
+        reason: localized(
+          "缩放入场从较小尺寸直接抵达最终状态，适合克制、稳定的出现。",
+          "Scale in grows directly to the final size, fitting a restrained and stable entrance."
+        ),
+        signals: {
+          zh: ["缩放入场", "缩放", "放大", "克制", "稳定", "平稳", "直接停住", "轻微"],
+          en: ["scale in", "scale", "grow", "restrained", "stable", "steady", "subtle", "direct"]
+        }
+      },
+      {
+        variantId: "pop-in",
+        reason: localized(
+          "弹入带一次轻微过冲和回落，适合紧凑、活泼的强调。",
+          "Pop in adds one compact overshoot and settle, fitting a playful accent."
+        ),
+        signals: {
+          zh: ["弹入", "弹一下", "回弹", "过冲", "活泼", "俏皮", "轻快", "弹出来"],
+          en: ["pop in", "pop", "overshoot", "bounce", "playful", "lively", "snappy"]
+        }
+      },
+      {
+        variantId: "spring",
+        reason: localized(
+          "弹簧通过质量、刚度与阻尼表现重量、惯性和收敛过程。",
+          "Spring uses mass, stiffness, and damping to express weight, inertia, and settlement."
+        ),
+        signals: {
+          zh: ["弹簧", "有重量", "重量", "沉", "惯性", "物理", "阻尼", "收得住", "弹性", "自然"],
+          en: ["spring", "springy", "weight", "heavy", "inertia", "physics", "damping", "settle", "elastic", "natural"]
+        }
+      }
+    ]
+  },
+  {
+    id: "state-continuity",
+    name: localized("状态连续性", "State continuity"),
+    reason: localized(
+      "这段描述关注两个状态之间如何保持视觉关联。",
+      "This description focuses on preserving a visual relationship between two states."
+    ),
+    signals: {
+      zh: ["状态切换", "切换", "变成", "变化", "前后", "连续", "同一个元素", "页面", "详情", "展开"],
+      en: ["state change", "switch", "turn into", "transform", "before and after", "continuity", "same element", "page", "detail", "expand"]
+    },
+    variants: [
+      {
+        variantId: "crossfade",
+        reason: localized(
+          "交叉淡入淡出让同一位置的两个状态交换透明度，适合结构接近的内容替换。",
+          "Crossfade exchanges opacity between overlapping states, fitting similarly structured content."
+        ),
+        signals: {
+          zh: ["交叉淡入淡出", "淡入淡出", "叠化", "同一位置", "透明度", "渐隐", "渐现"],
+          en: ["crossfade", "cross fade", "fade", "same spot", "overlap", "opacity", "dissolve"]
+        }
+      },
+      {
+        variantId: "morph",
+        reason: localized(
+          "形变连续插值几何形状，适合一个轮廓平滑变成另一个轮廓。",
+          "Morph interpolates geometry continuously, fitting one shape becoming another."
+        ),
+        signals: {
+          zh: ["形变", "变形", "形状", "轮廓", "灵动岛", "一个变成另一个"],
+          en: ["morph", "shape", "reshape", "geometry", "dynamic island", "one shape into another"]
+        }
+      },
+      {
+        variantId: "shared-element-transition",
+        reason: localized(
+          "共享元素过渡让同一个对象跨布局移动并改变尺寸，适合缩略图展开等空间连续场景。",
+          "A shared element transition moves and resizes the same object across layouts, fitting thumbnail-to-detail flows."
+        ),
+        signals: {
+          zh: ["共享元素", "同一个元素", "缩略图", "卡片展开", "跨页面", "跨布局", "移动并放大", "详情页", "空间连续"],
+          en: ["shared element", "same element", "thumbnail", "card expands", "across pages", "across layouts", "moves and grows", "detail page", "spatial continuity"]
+        }
+      }
+    ]
+  },
+  {
+    id: "sequence-timing",
+    name: localized("顺序与编排", "Sequence and timing"),
+    reason: localized(
+      "这段描述关注多个动作的开始时间、先后关系与整体节奏。",
+      "This description focuses on start times, ordering, and the rhythm of multiple motions."
+    ),
+    signals: {
+      zh: ["时间", "开始", "先后", "多个", "一组", "列表", "节奏", "顺序", "动画之间"],
+      en: ["timing", "start", "order", "multiple", "group", "list", "rhythm", "sequence", "between animations"]
+    },
+    variants: [
+      {
+        variantId: "delay",
+        reason: localized(
+          "延迟控制单段动画在触发后等待多久再开始。",
+          "Delay controls how long one animation waits after its trigger before starting."
+        ),
+        signals: {
+          zh: ["延迟", "等一下", "晚一点", "稍后", "等待", "过一会", "触发后"],
+          en: ["delay", "wait", "later", "after a pause", "after trigger", "hold before"]
+        }
+      },
+      {
+        variantId: "stagger",
+        reason: localized(
+          "交错动画让同组项目依次启动，适合列表和卡片形成清晰级联。",
+          "Stagger starts related items in sequence, creating a readable cascade for lists and cards."
+        ),
+        signals: {
+          zh: ["交错", "依次", "一个接一个", "逐个", "列表", "卡片组", "级联", "排队出现"],
+          en: ["stagger", "one by one", "in sequence", "sequentially", "list", "card grid", "cascade"]
+        }
+      },
+      {
+        variantId: "orchestration",
+        reason: localized(
+          "动效编排协调多段动作的开始、重叠与结束，让它们共同表达一次事件。",
+          "Orchestration coordinates the starts, overlaps, and finishes of multiple motions as one event."
+        ),
+        signals: {
+          zh: ["动效编排", "编排", "多段", "协调", "整体动作", "先后配合", "重叠", "时间线", "一整套"],
+          en: ["orchestration", "choreography", "multiple motions", "coordinate", "coordinated", "overlap", "timeline", "whole sequence"]
+        }
+      }
+    ]
+  }
+];

--- a/src/data/site.ts
+++ b/src/data/site.ts
@@ -47,6 +47,7 @@ export function sitemapPaths() {
   for (const locale of ["zh", "en"] as const) {
     paths.add(pathFor(locale));
     paths.add(pathFor(locale, ["catalog"]));
+    paths.add(pathFor(locale, ["finder"]));
     paths.add(pathFor(locale, ["vocabulary"]));
 
     for (const category of categories) {

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -6,6 +6,9 @@ export const resources = {
       nav: {
         primaryLabel: "主导航",
         mobileLabel: "移动端导航",
+        finder: "动效选择器",
+        finderShort: "Finder",
+        openFinder: "打开动效选择器",
         components: "动效组件",
         playgrounds: "参数工具",
         guides: "指南",
@@ -64,9 +67,11 @@ export const resources = {
         searchPlaceholder: "搜索 fade、slide、stagger、press"
       },
       landing: {
-        heroStatus: "用于产品界面的动效组件库",
-        heroTitle: "看得见、调得动，\n复制就能用的动效库。",
-        heroCopy: "从按钮反馈到页面过渡，每个条目都提供实时预览、参数控制、CSS、HTML、行为所需的 JS 和可交给 Agent 的提示词。",
+        heroStatus: "Motion Finder v0.2 · 免费开源",
+        heroTitle: "说出你要的感觉，\n找到准确动效。",
+        heroCopy: "输入一句模糊需求，获得三个最接近的动效候选；同场景比较、选择、调参，再复制 Prompt、CSS、HTML 和行为所需的 JS。",
+        openFinder: "开始描述动效",
+        finderExample: "卡片弹出来要有重量，最后收得住",
         browseComponents: "浏览动效组件",
         openPlaygrounds: "打开参数工具",
         searchLibrary: "搜索 fade、spring、drag 或 reduced motion",
@@ -136,6 +141,45 @@ export const resources = {
         notFoundTitle: "这个分类还没有内容",
         notFoundCopy: "返回动效库，选择一个已有分类继续浏览。"
       },
+      finder: {
+        eyebrow: "Motion Finder / 动效选择器",
+        title: "描述感觉，找到准确动效。",
+        copy: "写下界面、动作和你期待的质感。Motion Lexicon 会给出三个候选，让你在同一节奏里比较、选择并复制实现。",
+        formLabel: "描述你想要的动效",
+        placeholder: "例如：卡片弹出来要有重量，最后收得住",
+        submit: "查找候选",
+        shortcut: "按 Enter 查找",
+        examplesLabel: "试试这些描述",
+        examples: {
+          weight: "卡片弹出来要有重量，最后收得住",
+          continuity: "两个页面里的同一个元素要连贯地移动过去",
+          sequence: "一组列表依次出现，节奏清楚一点"
+        },
+        emptyTitle: "从一句真实需求开始",
+        emptyCopy: "描述界面里谁在动、怎么动，以及你希望它给人的感觉。",
+        resultEyebrow: "候选比较",
+        resultTitle: "同场景比较三个候选",
+        resultCount: "已找到 {{count}} 个候选",
+        confidence: {
+          high: "高度匹配",
+          medium: "可用匹配",
+          low: "探索性匹配"
+        },
+        lowConfidence: "这段描述比较宽泛。候选会先覆盖最接近的意图，你可以补充界面对象、方向或节奏。",
+        matchedTerms: "匹配线索",
+        replayAll: "同步重播",
+        candidateLabel: "候选 {{rank}}",
+        select: "选择 {{name}}",
+        selected: "已选择",
+        distinction: "辨析",
+        openRecipe: "打开完整条目",
+        tuneEyebrow: "确认与导出",
+        tuneTitle: "调节 {{name}}",
+        tuneCopy: "参数、预览和复制输出保持同步；链接会保存当前选择。",
+        paramsLabel: "当前候选参数",
+        readyStatus: "当前选择已同步到链接",
+        changeHint: "你可以继续比较候选，或调好参数后复制实现。"
+      },
       workspace: {
         kicker: "交互式条目",
         title: "条目预览",
@@ -181,12 +225,14 @@ export const resources = {
         staticProduct: "静态构建 · 中英文 · 支持减弱动效"
       },
       seo: {
-        homeTitle: "Motion Lexicon | 可复制的产品动效库",
-        homeDescription: "浏览产品动效组件，实时调节参数，并复制 CSS、HTML、行为所需的 JS 和 Agent 提示词。",
+        homeTitle: "Motion Lexicon | 从模糊描述找到准确动效",
+        homeDescription: "描述产品动效的感觉，比较三个候选，实时调节参数，并复制 Prompt、CSS、HTML 和行为所需的 JS。",
         catalogTitle: "动效目录 | Motion Lexicon",
         catalogDescription: "按动效组件、参数工具和指南浏览 Motion Lexicon。",
         playgroundTitle: "参数工具 | Motion Lexicon",
-        playgroundDescription: "比较和调整动效参数，并复制可用输出。"
+        playgroundDescription: "比较和调整动效参数，并复制可用输出。",
+        finderTitle: "动效选择器 | Motion Lexicon",
+        finderDescription: "描述你想要的动效感觉，比较三个候选，调节参数并复制 Prompt、CSS、HTML 和 JS。"
       }
     }
   },
@@ -195,6 +241,9 @@ export const resources = {
       nav: {
         primaryLabel: "Primary navigation",
         mobileLabel: "Mobile navigation",
+        finder: "Motion Finder",
+        finderShort: "Finder",
+        openFinder: "Open Motion Finder",
         components: "Components",
         playgrounds: "Playgrounds",
         guides: "Guides",
@@ -253,9 +302,11 @@ export const resources = {
         searchPlaceholder: "Search fade, slide, stagger, press"
       },
       landing: {
-        heroStatus: "A motion component library for product interfaces",
-        heroTitle: "See it. Tune it.\nCopy motion that is ready to use.",
-        heroCopy: "From button feedback to page transitions, every entry includes a live preview, focused controls, CSS, HTML, behavior-ready JS when required, and an agent-ready prompt.",
+        heroStatus: "Motion Finder v0.2 · free and open source",
+        heroTitle: "Describe the feel.\nFind the right motion.",
+        heroCopy: "Turn one fuzzy request into three close motion candidates. Compare them in one scene, choose, tune, and copy the prompt, CSS, HTML, and behavior-ready JavaScript.",
+        openFinder: "Describe your motion",
+        finderExample: "Make the card arrive with weight and settle cleanly",
         browseComponents: "Browse components",
         openPlaygrounds: "Open playgrounds",
         searchLibrary: "Search fade, spring, drag, or reduced motion",
@@ -325,6 +376,45 @@ export const resources = {
         notFoundTitle: "This category has no content yet",
         notFoundCopy: "Return to the motion library and choose an available category."
       },
+      finder: {
+        eyebrow: "Motion Finder / intent to motion",
+        title: "Describe the feel. Find the right motion.",
+        copy: "Name the interface, the action, and the quality you want. Motion Lexicon returns three candidates to compare, choose, tune, and copy.",
+        formLabel: "Describe the motion you want",
+        placeholder: "For example: make the card arrive with weight and settle cleanly",
+        submit: "Find candidates",
+        shortcut: "Press Enter to find",
+        examplesLabel: "Try an example",
+        examples: {
+          weight: "Make the card arrive with weight and settle cleanly",
+          continuity: "Move the same element smoothly between two screens",
+          sequence: "Bring in a list item by item with a clear rhythm"
+        },
+        emptyTitle: "Start with a real interface need",
+        emptyCopy: "Describe what moves, how it moves, and the quality the interaction should convey.",
+        resultEyebrow: "Candidate comparison",
+        resultTitle: "Compare three candidates in one scene",
+        resultCount: "{{count}} candidates found",
+        confidence: {
+          high: "High match",
+          medium: "Useful match",
+          low: "Exploratory match"
+        },
+        lowConfidence: "This description is broad. The candidates cover the closest intent; add the interface object, direction, or rhythm for a tighter match.",
+        matchedTerms: "Matched cues",
+        replayAll: "Replay together",
+        candidateLabel: "Candidate {{rank}}",
+        select: "Choose {{name}}",
+        selected: "Selected",
+        distinction: "Distinction",
+        openRecipe: "Open full entry",
+        tuneEyebrow: "Confirm and export",
+        tuneTitle: "Tune {{name}}",
+        tuneCopy: "Parameters, preview, and copied output stay in sync. The link preserves your selection.",
+        paramsLabel: "Current candidate parameters",
+        readyStatus: "Current selection synced to URL",
+        changeHint: "Keep comparing candidates, or tune this one and copy the implementation."
+      },
       workspace: {
         kicker: "Interactive entry",
         title: "Entry preview",
@@ -370,12 +460,14 @@ export const resources = {
         staticProduct: "Static build · bilingual · reduced-motion ready"
       },
       seo: {
-        homeTitle: "Motion Lexicon | Copyable product motion library",
-        homeDescription: "Browse product motion components, tune parameters live, and copy CSS, HTML, behavior-ready JS when required, or agent-ready prompts.",
+        homeTitle: "Motion Lexicon | Find the right motion from a fuzzy description",
+        homeDescription: "Describe the feel of a product motion, compare three candidates, tune parameters live, and copy the prompt, CSS, HTML, and behavior-ready JavaScript.",
         catalogTitle: "Motion catalog | Motion Lexicon",
         catalogDescription: "Browse Motion Lexicon by components, playgrounds, and guides.",
         playgroundTitle: "Motion playgrounds | Motion Lexicon",
-        playgroundDescription: "Compare and tune motion parameters, then copy usable output."
+        playgroundDescription: "Compare and tune motion parameters, then copy usable output.",
+        finderTitle: "Motion Finder | Motion Lexicon",
+        finderDescription: "Describe the motion you want, compare three candidates, tune parameters, and copy a prompt, CSS, HTML, and JavaScript."
       }
     }
   }

--- a/src/lib/motion-engine.ts
+++ b/src/lib/motion-engine.ts
@@ -771,12 +771,13 @@ function surfaceMarkup(label: string) {
 export function buildRecipeHtml(
   recipe: MotionRecipe,
   inputValues: ParamValues = {},
-  locale: Locale = "en"
+  locale: Locale = "en",
+  labelOverride?: string
 ) {
   const spec = getMotionSpec(recipe);
   const id = spec.canonicalId;
   const values = resolvedValues(recipe, inputValues);
-  const label = escapeHtml(text(recipe.name, locale));
+  const label = escapeHtml(labelOverride ?? text(recipe.name, locale));
   const root = `motion-demo motion-demo--${classToken(id)}`;
   const copy = locale === "zh"
     ? {

--- a/src/lib/motion-finder.ts
+++ b/src/lib/motion-finder.ts
@@ -1,0 +1,222 @@
+import { getGlossaryTerm } from "../data/glossary";
+import {
+  motionIntentGroups,
+  type LocalizedPhrases,
+  type MotionIntentGroup,
+  type MotionIntentVariant
+} from "../data/motion-intents";
+import { aliasMetadata } from "../data/motion-catalog";
+import { getCanonicalRecipe } from "../data/recipes";
+import type { Locale, MotionRecipe, ParamValue, ParamValues } from "../data/types";
+import { getDefaultParamValues } from "./motion-engine";
+
+export type MotionFinderConfidence = "high" | "medium" | "low";
+
+export type MotionFinderCandidate = {
+  rank: number;
+  variantId: string;
+  canonicalId: string;
+  recipe: MotionRecipe;
+  name: string;
+  description: string;
+  reason: string;
+  distinction?: string;
+  score: number;
+  confidence: number;
+  matchedTerms: string[];
+  presetQuery?: string;
+  presetValues: ParamValues;
+  values: ParamValues;
+  recipePath: string;
+};
+
+export type MotionFinderResult = {
+  query: string;
+  locale: Locale;
+  confidence: MotionFinderConfidence;
+  confidenceScore: number;
+  matchedTerms: string[];
+  groupId: string;
+  groupName: string;
+  reason: string;
+  finderPath: string;
+  comparePath: string;
+  candidates: MotionFinderCandidate[];
+};
+
+type Match = { score: number; terms: string[] };
+
+const aliasById = new Map(aliasMetadata.map((alias) => [alias.entryId, alias]));
+
+function normalize(value: string) {
+  return value
+    .normalize("NFKC")
+    .toLocaleLowerCase()
+    .replace(/[\s_./]+/g, " ")
+    .replace(/[-–—]+/g, " ")
+    .replace(/[，。！？、；：,.!?;:()[\]{}"']/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function scorePhrases(query: string, phrases: LocalizedPhrases): Match {
+  const normalizedQuery = normalize(query);
+  const matches = new Map<string, number>();
+  for (const phrase of [...phrases.zh, ...phrases.en]) {
+    const normalizedPhrase = normalize(phrase);
+    if (!normalizedPhrase) continue;
+    const exact = normalizedQuery === normalizedPhrase;
+    const contained = normalizedQuery.includes(normalizedPhrase);
+    const reverseContained = normalizedPhrase.length >= 4 && normalizedPhrase.includes(normalizedQuery);
+    if (!exact && !contained && !reverseContained) continue;
+    const specificity = Math.min(10, Array.from(normalizedPhrase.replaceAll(" ", "")).length);
+    const weight = specificity + (exact ? 10 : contained ? 4 : 1);
+    matches.set(phrase, Math.max(matches.get(phrase) ?? 0, weight));
+  }
+  return {
+    score: Array.from(matches.values()).reduce((sum, value) => sum + value, 0),
+    terms: Array.from(matches.keys())
+  };
+}
+
+function variantMatch(query: string, variant: MotionIntentVariant) {
+  return scorePhrases(query, variant.signals);
+}
+
+function groupMatch(query: string, group: MotionIntentGroup) {
+  const direct = scorePhrases(query, group.signals);
+  const variants = group.variants.map((variant) => variantMatch(query, variant));
+  const strongestVariant = Math.max(0, ...variants.map((match) => match.score));
+  const supportingVariants = variants.reduce((sum, match) => sum + match.score, 0);
+  return {
+    group,
+    direct,
+    variants,
+    score: direct.score + strongestVariant * 0.8 + supportingVariants * 0.08
+  };
+}
+
+function presetValue(recipe: MotionRecipe, id: string, raw: string): ParamValue {
+  const param = recipe.params.find((candidate) => candidate.id === id);
+  if (!param) return raw;
+  if (param.kind === "range") return Number(raw);
+  if (param.kind === "toggle") return raw === "true" || raw === "1";
+  return raw;
+}
+
+function resolveVariant(variantId: string) {
+  const recipe = getCanonicalRecipe(variantId);
+  if (!recipe) throw new Error(`Motion intent variant has no recipe: ${variantId}`);
+  const alias = aliasById.get(variantId);
+  const presetValues: ParamValues = {};
+  if (alias?.query) {
+    for (const [id, raw] of new URLSearchParams(alias.query)) {
+      presetValues[id] = presetValue(recipe, id, raw);
+    }
+  }
+  return {
+    recipe,
+    presetQuery: alias?.query,
+    presetValues,
+    values: { ...getDefaultParamValues(recipe), ...presetValues }
+  };
+}
+
+function recipePath(recipe: MotionRecipe, locale: Locale, presetQuery?: string) {
+  const base = `/${locale}/${recipe.categoryId}/${recipe.canonicalId}/`;
+  return presetQuery ? `${base}?${presetQuery}` : base;
+}
+
+function finderPath(query: string, locale: Locale, variants?: readonly string[]) {
+  const params = new URLSearchParams({ q: query });
+  if (variants?.length) params.set("compare", variants.join(","));
+  return `/${locale}/finder/?${params.toString()}`;
+}
+
+function roundConfidence(value: number) {
+  return Number(Math.max(0, Math.min(0.99, value)).toFixed(2));
+}
+
+export function recommendMotions(
+  query: string,
+  locale: Locale = "en",
+  limit = 3
+): MotionFinderResult {
+  const cleanQuery = query.trim();
+  if (!cleanQuery) throw new Error("A motion description is required.");
+  if (locale !== "zh" && locale !== "en") {
+    throw new Error(`Unsupported locale: ${String(locale)}. Use zh or en.`);
+  }
+  if (!Number.isInteger(limit) || limit < 1 || limit > 3) {
+    throw new Error("Motion Finder limit must be an integer from 1 to 3.");
+  }
+
+  const rankedGroups = motionIntentGroups
+    .map((group, index) => ({ ...groupMatch(cleanQuery, group), index }))
+    .sort((a, b) => b.score - a.score || a.index - b.index);
+  const selected = rankedGroups[0];
+  const directTerms = selected.direct.terms;
+  const allMatchedTerms = Array.from(
+    new Set([...directTerms, ...selected.variants.flatMap((match) => match.terms)])
+  );
+  const bestVariantScore = Math.max(0, ...selected.variants.map((match) => match.score));
+  const confidenceScore = roundConfidence(
+    0.18 + Math.min(0.45, selected.direct.score / 50) + Math.min(0.34, bestVariantScore / 45)
+  );
+  const confidence: MotionFinderConfidence = confidenceScore >= 0.72
+    ? "high"
+    : confidenceScore >= 0.42
+      ? "medium"
+      : "low";
+
+  const candidates = selected.group.variants
+    .map((variant, index) => {
+      const matched = selected.variants[index];
+      const resolved = resolveVariant(variant.variantId);
+      const glossary = getGlossaryTerm(variant.variantId);
+      const evidence = matched.score + selected.direct.score * 0.25;
+      const score = Math.round(Math.min(100, 32 + evidence * 2.2));
+      const candidateConfidence = roundConfidence(
+        0.24 + Math.min(0.55, matched.score / 42) + Math.min(0.16, selected.direct.score / 70)
+      );
+      return {
+        sourceIndex: index,
+        evidence,
+        candidate: {
+          rank: 0,
+          variantId: variant.variantId,
+          canonicalId: resolved.recipe.canonicalId,
+          recipe: resolved.recipe,
+          name: glossary?.name[locale] ?? resolved.recipe.name[locale],
+          description: glossary?.definition[locale] ?? resolved.recipe.definition[locale],
+          reason: variant.reason[locale],
+          ...(glossary?.distinction ? { distinction: glossary.distinction[locale] } : {}),
+          score,
+          confidence: candidateConfidence,
+          matchedTerms: Array.from(new Set([...directTerms, ...matched.terms])),
+          ...(resolved.presetQuery ? { presetQuery: resolved.presetQuery } : {}),
+          presetValues: resolved.presetValues,
+          values: resolved.values,
+          recipePath: recipePath(resolved.recipe, locale, resolved.presetQuery)
+        } satisfies MotionFinderCandidate
+      };
+    })
+    .sort((a, b) => b.evidence - a.evidence || a.sourceIndex - b.sourceIndex)
+    .slice(0, limit)
+    .map(({ candidate }, index) => ({ ...candidate, rank: index + 1 }));
+
+  const variants = candidates.map((candidate) => candidate.variantId);
+  return {
+    query: cleanQuery,
+    locale,
+    confidence,
+    confidenceScore,
+    matchedTerms: allMatchedTerms,
+    groupId: selected.group.id,
+    groupName: selected.group.name[locale],
+    reason: selected.group.reason[locale],
+    finderPath: finderPath(cleanQuery, locale),
+    comparePath: finderPath(cleanQuery, locale, variants),
+    candidates
+  };
+}

--- a/src/library.css
+++ b/src/library.css
@@ -2631,3 +2631,488 @@ kbd {
     animation: none !important;
   }
 }
+
+/* Motion Finder */
+.finder-hero {
+  padding: 4.75rem 0 3.5rem;
+  border-bottom: 1px solid var(--library-line);
+}
+
+.finder-hero-copy {
+  max-width: 820px;
+}
+
+.finder-hero-copy > span,
+.finder-results-heading > div:first-child > span,
+.finder-tune .library-doc-section-heading > div > span {
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.finder-hero-copy h1 {
+  max-width: 800px;
+  margin: 0.85rem 0 1rem;
+  font-size: clamp(3rem, 6.5vw, 5.6rem);
+  line-height: 0.98;
+  letter-spacing: -0.06em;
+  text-wrap: balance;
+}
+
+.finder-hero-copy p {
+  max-width: 68ch;
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 1rem;
+  line-height: 1.75;
+}
+
+.finder-search {
+  max-width: 1040px;
+  margin-top: 2.6rem;
+}
+
+.finder-search > label,
+.finder-examples > span {
+  display: block;
+  margin-bottom: 0.55rem;
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+}
+
+.finder-search-field {
+  min-height: 68px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.8rem;
+  border: 1px solid var(--library-line-strong);
+  border-radius: 9px;
+  padding: 0.45rem 0.45rem 0.45rem 1rem;
+  background: var(--panel-solid);
+  box-shadow: 0 10px 36px color-mix(in srgb, var(--ink) 7%, transparent);
+}
+
+.finder-search-field:focus-within {
+  border-color: var(--accent-strong);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 16%, transparent);
+}
+
+.finder-search-field > svg { color: var(--ink-dim); }
+
+.finder-search-field input {
+  min-width: 0;
+  min-height: 54px;
+  border: 0;
+  outline: 0;
+  color: var(--ink);
+  background: transparent;
+  font-size: 1rem;
+}
+
+.finder-search-field input::placeholder { color: var(--ink-dim); }
+
+.finder-search-field button {
+  min-height: 52px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  border: 1px solid var(--ink);
+  border-radius: 7px;
+  padding: 0 1.1rem;
+  color: var(--bg);
+  background: var(--ink);
+  font-size: 0.8rem;
+  font-weight: 650;
+}
+
+.finder-search > small {
+  display: block;
+  margin-top: 0.5rem;
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  text-align: end;
+}
+
+.finder-examples {
+  max-width: 1040px;
+  margin-top: 1.35rem;
+}
+
+.finder-examples > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.finder-examples button {
+  min-height: 44px;
+  border: 1px solid var(--library-line);
+  border-radius: 999px;
+  padding: 0 0.85rem;
+  color: var(--ink-dim);
+  background: transparent;
+  font-size: 0.72rem;
+  text-align: start;
+}
+
+.finder-examples button:hover {
+  border-color: var(--library-line-strong);
+  color: var(--ink);
+  background: var(--library-subtle);
+}
+
+.finder-empty {
+  min-height: 300px;
+  display: grid;
+  place-items: center;
+  align-content: center;
+  gap: 0.6rem;
+  border-bottom: 1px solid var(--library-line);
+  text-align: center;
+}
+
+.finder-empty > svg {
+  width: 44px;
+  height: 44px;
+  padding: 11px;
+  border: 1px solid var(--library-line);
+  border-radius: 9px;
+  color: var(--accent);
+  background: var(--library-subtle);
+}
+
+.finder-empty h2,
+.finder-empty p { margin: 0; }
+.finder-empty h2 { font-size: 1.15rem; }
+.finder-empty p { color: var(--ink-soft); }
+
+.finder-results,
+.finder-tune {
+  padding: 3.5rem 0;
+  border-bottom: 1px solid var(--library-line);
+}
+
+.finder-results-heading {
+  align-items: start;
+}
+
+.finder-results-heading h2,
+.finder-tune .library-doc-section-heading h2 {
+  margin-top: 0.65rem;
+  font-size: 1.8rem;
+  letter-spacing: -0.035em;
+}
+
+.finder-match-summary {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.finder-match-summary > strong {
+  width: max-content;
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: 1px solid var(--library-line);
+  border-radius: 999px;
+  padding: 0 0.65rem;
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  font-weight: 600;
+}
+
+.finder-match-summary > strong.is-high {
+  border-color: color-mix(in srgb, var(--accent) 38%, var(--library-line));
+  color: var(--accent-strong);
+  background: color-mix(in srgb, var(--accent) 7%, transparent);
+}
+
+.finder-match-summary > p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+  line-height: 1.65;
+}
+
+.finder-match-summary > div {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.finder-match-summary > div > span,
+.finder-match-summary > div > small {
+  font-family: var(--mono);
+  font-size: 0.6rem;
+}
+
+.finder-match-summary > div > span { color: var(--ink-dim); }
+.finder-match-summary > div > small {
+  border: 1px solid var(--library-line);
+  border-radius: 4px;
+  padding: 0.15rem 0.35rem;
+  color: var(--ink);
+  background: var(--library-subtle);
+}
+
+.finder-low-confidence {
+  margin: 0 0 1rem;
+  border-inline-start: 2px solid var(--accent);
+  padding: 0.75rem 1rem;
+  color: var(--ink-soft);
+  background: var(--library-subtle);
+  font-size: 0.76rem;
+  line-height: 1.6;
+}
+
+.finder-compare {
+  overflow: hidden;
+  border: 1px solid var(--library-line);
+  border-radius: 9px;
+}
+
+.finder-compare-toolbar {
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--library-line);
+  padding: 0.35rem 0.6rem 0.35rem 0.9rem;
+  background: var(--library-subtle);
+}
+
+.finder-compare-toolbar > span {
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  font-size: 0.64rem;
+}
+
+.finder-candidate-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.finder-candidate {
+  min-width: 0;
+  display: grid;
+  grid-template-rows: auto auto 1fr auto;
+  border-inline-end: 1px solid var(--library-line);
+  background: var(--panel-solid);
+  transition: box-shadow 160ms var(--ease), background-color 160ms var(--ease);
+}
+
+.finder-candidate:last-child { border-inline-end: 0; }
+.finder-candidate.is-selected {
+  background: color-mix(in srgb, var(--accent) 3%, var(--panel-solid));
+  box-shadow: inset 0 2px var(--accent);
+}
+
+.finder-candidate-header {
+  min-height: 132px;
+  padding: 1.1rem;
+}
+
+.finder-candidate-header span {
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  font-size: 0.6rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.finder-candidate-header h3 {
+  margin: 0.45rem 0 0.35rem;
+  font-size: 1.35rem;
+  line-height: 1.1;
+  letter-spacing: -0.035em;
+}
+
+.finder-candidate-header p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.72rem;
+  line-height: 1.5;
+}
+
+.finder-candidate-stage {
+  min-height: 282px;
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  border-top: 1px solid var(--library-line);
+  border-bottom: 1px solid var(--library-line);
+  padding: 1rem;
+  background:
+    radial-gradient(circle, color-mix(in srgb, var(--ink) 9%, transparent) 1px, transparent 1px),
+    var(--panel-raised);
+  background-size: 18px 18px;
+}
+
+.finder-candidate-body {
+  display: grid;
+  align-content: start;
+  gap: 0.85rem;
+  padding: 1rem 1.1rem;
+}
+
+.finder-candidate-body > p,
+.finder-distinction p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.75rem;
+  line-height: 1.65;
+}
+
+.finder-distinction {
+  display: grid;
+  gap: 0.3rem;
+  border-inline-start: 1px solid var(--library-line-strong);
+  padding-inline-start: 0.65rem;
+}
+
+.finder-distinction > span {
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  font-size: 0.58rem;
+}
+
+.finder-candidate-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.5rem;
+  border-top: 1px solid var(--library-line);
+  padding: 0.6rem;
+}
+
+.finder-select,
+.finder-candidate-actions a {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border-radius: 6px;
+  font-size: 0.7rem;
+  font-weight: 620;
+}
+
+.finder-select {
+  border: 1px solid var(--library-line-strong);
+  padding: 0 0.7rem;
+  color: var(--ink);
+  background: transparent;
+}
+
+.finder-select:hover { background: var(--library-subtle); }
+.finder-select.is-selected {
+  border-color: var(--ink);
+  color: var(--bg);
+  background: var(--ink);
+}
+
+.finder-candidate-actions a {
+  padding: 0 0.45rem;
+  color: var(--ink-dim);
+}
+
+.finder-candidate-actions a:hover { color: var(--ink); }
+
+.finder-workbench {
+  border-radius: 9px;
+}
+
+.finder-change-hint {
+  margin: 0.75rem 0 0;
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  text-align: end;
+}
+
+.finder-tune > .library-export {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+
+@media (max-width: 1100px) {
+  .finder-candidate-grid { grid-template-columns: 1fr; }
+  .finder-candidate {
+    grid-template-columns: minmax(190px, 0.48fr) minmax(280px, 0.72fr) minmax(220px, 0.6fr);
+    grid-template-rows: 1fr auto;
+    border-inline-end: 0;
+    border-bottom: 1px solid var(--library-line);
+  }
+  .finder-candidate:last-child { border-bottom: 0; }
+  .finder-candidate-header { min-height: 0; }
+  .finder-candidate-stage {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    border-top: 0;
+    border-bottom: 0;
+    border-inline: 1px solid var(--library-line);
+  }
+  .finder-candidate-body { grid-column: 3; }
+  .finder-candidate-actions { grid-column: 1; }
+}
+
+@media (max-width: 760px) {
+  .finder-hero { padding: 3.25rem 0 2.75rem; }
+  .finder-hero-copy h1 { font-size: clamp(2.8rem, 13vw, 4rem); }
+  .finder-search-field {
+    grid-template-columns: auto minmax(0, 1fr);
+    padding: 0.5rem;
+  }
+  .finder-search-field > svg { margin-inline-start: 0.35rem; }
+  .finder-search-field button {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+  .finder-search > small { display: none; }
+  .finder-examples button { width: 100%; }
+  .finder-results,
+  .finder-tune { padding: 2.75rem 0; }
+  .finder-candidate {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto auto;
+  }
+  .finder-candidate-stage {
+    grid-column: 1;
+    grid-row: auto;
+    min-height: 260px;
+    border: 0;
+    border-top: 1px solid var(--library-line);
+    border-bottom: 1px solid var(--library-line);
+  }
+  .finder-candidate-body,
+  .finder-candidate-actions { grid-column: 1; }
+  .finder-candidate-actions {
+    grid-template-columns: 1fr;
+  }
+  .finder-candidate-actions a { border: 1px solid var(--library-line); }
+  .finder-workbench { grid-template-columns: 1fr; }
+  .finder-workbench .library-parameter-panel {
+    border-inline-start: 0;
+    border-top: 1px solid var(--library-line);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .finder-candidate,
+  .finder-search-field,
+  .finder-search-field button,
+  .finder-select {
+    transition: none !important;
+  }
+}

--- a/src/pages/FinderPage.tsx
+++ b/src/pages/FinderPage.tsx
@@ -1,0 +1,375 @@
+import { ArrowRight, Search, Sparkles } from "lucide-react";
+import { useLocation, useNavigate } from "@tanstack/react-router";
+import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ExportPanel } from "../components/ExportPanel";
+import { MotionCompare } from "../components/MotionCompare";
+import { MotionPreview } from "../components/MotionPreview";
+import { ParameterControls } from "../components/ParameterControls";
+import { Seo } from "../components/Seo";
+import { pathFor, siteUrl } from "../data/site";
+import type { Locale, ParamValue, ParamValues } from "../data/types";
+import {
+  buildRecipeJs,
+  parseParamValues,
+  valuesToSearchParams
+} from "../lib/motion-engine";
+import {
+  recommendMotions,
+  type MotionFinderCandidate,
+  type MotionFinderResult
+} from "../lib/motion-finder";
+
+const exampleKeys = ["weight", "continuity", "sequence"] as const;
+
+function orderCandidates(
+  result: MotionFinderResult,
+  compareValue: string | null
+): MotionFinderCandidate[] {
+  const candidates = Array.from(result.candidates);
+  const requestedIds = Array.from(
+    new Set(
+      (compareValue ?? "")
+        .split(",")
+        .map((value) => value.trim())
+        .filter(Boolean)
+    )
+  );
+  if (requestedIds.length === 0) return candidates;
+
+  const byId = new Map(candidates.map((candidate) => [candidate.variantId, candidate]));
+  const requested = requestedIds
+    .map((id) => byId.get(id))
+    .filter((candidate): candidate is MotionFinderCandidate => Boolean(candidate));
+  const requestedSet = new Set(requested.map((candidate) => candidate.variantId));
+  return [
+    ...requested,
+    ...candidates.filter((candidate) => !requestedSet.has(candidate.variantId))
+  ].slice(0, 3);
+}
+
+function valuesFromUrl(
+  candidate: MotionFinderCandidate,
+  params: URLSearchParams
+): ParamValues {
+  const parsed = parseParamValues(candidate.recipe, params);
+  const values = { ...candidate.values };
+  for (const param of candidate.recipe.params) {
+    if (params.has(param.id)) values[param.id] = parsed[param.id];
+  }
+  return values;
+}
+
+export function FinderPage({ locale }: { locale: Locale }) {
+  const { t } = useTranslation();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const [input, setInput] = useState("");
+  const [result, setResult] = useState<MotionFinderResult | null>(null);
+  const [candidates, setCandidates] = useState<MotionFinderCandidate[]>([]);
+  const [selectedId, setSelectedId] = useState("");
+  const [values, setValues] = useState<ParamValues | null>(null);
+  const [isHydrated, setIsHydrated] = useState(false);
+  const valuesRef = useRef<ParamValues | null>(null);
+  const syncedQueryRef = useRef<string | null>(null);
+
+  const selectedCandidate = useMemo(
+    () => candidates.find((candidate) => candidate.variantId === selectedId) ?? null,
+    [candidates, selectedId]
+  );
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      const params = new URLSearchParams(window.location.search);
+      const query = params.get("q")?.trim() ?? "";
+      const previousQuery = syncedQueryRef.current;
+      const isInitialLocationSync = previousQuery === null;
+      syncedQueryRef.current = query;
+      if ((isInitialLocationSync && query) || (!isInitialLocationSync && previousQuery !== query)) {
+        setInput(query);
+      }
+
+      if (!query) {
+        setResult(null);
+        setCandidates([]);
+        setSelectedId("");
+        valuesRef.current = null;
+        setValues(null);
+        setIsHydrated(true);
+        return;
+      }
+
+      const nextResult = recommendMotions(query, locale, 3);
+      const nextCandidates = orderCandidates(nextResult, params.get("compare"));
+      const requestedSelected = params.get("selected");
+      const nextSelected =
+        nextCandidates.find((candidate) => candidate.variantId === requestedSelected) ??
+        nextCandidates[0] ??
+        null;
+      const nextValues = nextSelected ? valuesFromUrl(nextSelected, params) : null;
+
+      setResult(nextResult);
+      setCandidates(nextCandidates);
+      setSelectedId(nextSelected?.variantId ?? "");
+      valuesRef.current = nextValues;
+      setValues(nextValues);
+      setIsHydrated(true);
+    }, 0);
+    return () => window.clearTimeout(timeout);
+  }, [locale, location.searchStr]);
+
+  function finderUrl(
+    query: string,
+    nextCandidates: MotionFinderCandidate[],
+    selected: MotionFinderCandidate,
+    nextValues: ParamValues
+  ) {
+    const params = new URLSearchParams();
+    params.set("q", query);
+    params.set(
+      "compare",
+      nextCandidates.map((candidate) => candidate.variantId).join(",")
+    );
+    params.set("selected", selected.variantId);
+    const activeTab = new URLSearchParams(window.location.search).get("tab");
+    if (
+      activeTab === "html" ||
+      activeTab === "prompt" ||
+      (activeTab === "js" && buildRecipeJs(selected.recipe, nextValues).length > 0)
+    ) {
+      params.set("tab", activeTab);
+    }
+    const withValues = valuesToSearchParams(selected.recipe, nextValues, params);
+    return `${pathFor(locale, ["finder"])}?${withValues.toString()}`;
+  }
+
+  function writeFinderUrl(
+    query: string,
+    nextCandidates: MotionFinderCandidate[],
+    selected: MotionFinderCandidate,
+    nextValues: ParamValues
+  ) {
+    void navigate({
+      href: finderUrl(query, nextCandidates, selected, nextValues),
+      replace: true,
+      resetScroll: false,
+      hashScrollIntoView: false
+    });
+  }
+
+  function runFinder(query: string) {
+    const normalized = query.trim();
+    if (!normalized) {
+      setResult(null);
+      setCandidates([]);
+      setSelectedId("");
+      valuesRef.current = null;
+      setValues(null);
+      void navigate({
+        href: pathFor(locale, ["finder"]),
+        replace: true,
+        resetScroll: false,
+        hashScrollIntoView: false
+      });
+      return;
+    }
+
+    const nextResult = recommendMotions(normalized, locale, 3);
+    const nextCandidates = Array.from(nextResult.candidates).slice(0, 3);
+    const nextSelected = nextCandidates[0];
+    if (!nextSelected) return;
+
+    const nextValues = { ...nextSelected.values };
+    setInput(normalized);
+    setResult(nextResult);
+    setCandidates(nextCandidates);
+    setSelectedId(nextSelected.variantId);
+    valuesRef.current = nextValues;
+    setValues(nextValues);
+    writeFinderUrl(normalized, nextCandidates, nextSelected, nextValues);
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const submittedQuery = new FormData(event.currentTarget).get("q");
+    runFinder(typeof submittedQuery === "string" ? submittedQuery : input);
+  }
+
+  function selectCandidate(candidate: MotionFinderCandidate) {
+    const nextValues = { ...candidate.values };
+    setSelectedId(candidate.variantId);
+    valuesRef.current = nextValues;
+    setValues(nextValues);
+    writeFinderUrl(result?.query ?? input.trim(), candidates, candidate, nextValues);
+  }
+
+  function updateValue(paramId: string, value: ParamValue) {
+    if (!selectedCandidate || !valuesRef.current) return;
+    const nextValues = { ...valuesRef.current, [paramId]: value };
+    valuesRef.current = nextValues;
+    setValues(nextValues);
+    writeFinderUrl(result?.query ?? input.trim(), candidates, selectedCandidate, nextValues);
+  }
+
+  function resetValues() {
+    if (!selectedCandidate) return;
+    const nextValues = { ...selectedCandidate.values };
+    valuesRef.current = nextValues;
+    setValues(nextValues);
+    writeFinderUrl(result?.query ?? input.trim(), candidates, selectedCandidate, nextValues);
+  }
+
+  return (
+    <>
+      <Seo
+        locale={locale}
+        title={t("seo.finderTitle")}
+        description={t("seo.finderDescription")}
+        path={pathFor(locale, ["finder"])}
+        structuredData={[
+          {
+            "@context": "https://schema.org",
+            "@type": "WebApplication",
+            name: "Motion Finder",
+            description: t("seo.finderDescription"),
+            url: `${siteUrl}${pathFor(locale, ["finder"])}`,
+            applicationCategory: "DesignApplication",
+            operatingSystem: "Any",
+            inLanguage: locale === "zh" ? "zh-CN" : "en",
+            isAccessibleForFree: true
+          }
+        ]}
+      />
+
+      <section className="finder-hero" aria-labelledby="finder-title">
+        <div className="finder-hero-copy">
+          <span>{t("finder.eyebrow")}</span>
+          <h1 id="finder-title">{t("finder.title")}</h1>
+          <p>{t("finder.copy")}</p>
+        </div>
+
+        <form className="finder-search" role="search" onSubmit={handleSubmit}>
+          <label htmlFor="finder-query">{t("finder.formLabel")}</label>
+          <div className="finder-search-field">
+            <Search aria-hidden="true" size={20} strokeWidth={1.7} />
+            <input
+              id="finder-query"
+              name="q"
+              type="search"
+              autoComplete="off"
+              disabled={!isHydrated}
+              value={input}
+              onChange={(event) => setInput(event.currentTarget.value)}
+              placeholder={t("finder.placeholder")}
+            />
+            <button type="submit" disabled={!isHydrated}>
+              {t("finder.submit")}
+              <ArrowRight aria-hidden="true" size={16} />
+            </button>
+          </div>
+          <small>{t("finder.shortcut")}</small>
+        </form>
+
+        <div className="finder-examples" aria-label={t("finder.examplesLabel")}>
+          <span>{t("finder.examplesLabel")}</span>
+          <div>
+            {exampleKeys.map((key) => {
+              const example = t(`finder.examples.${key}`);
+              return (
+                <button type="button" key={key} onClick={() => runFinder(example)}>
+                  {example}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      {result && candidates.length > 0 ? (
+        <section className="finder-results" aria-labelledby="finder-results-title">
+          <div className="library-doc-section-heading finder-results-heading">
+            <div>
+              <span>{t("finder.resultEyebrow")}</span>
+              <h2 id="finder-results-title">{t("finder.resultTitle")}</h2>
+            </div>
+            <div className="finder-match-summary">
+              <strong className={`is-${result.confidence}`}>
+                <Sparkles aria-hidden="true" size={14} />
+                {t(`finder.confidence.${result.confidence}`)}
+              </strong>
+              <p>{result.reason}</p>
+              {result.matchedTerms.length > 0 ? (
+                <div>
+                  <span>{t("finder.matchedTerms")}</span>
+                  {result.matchedTerms.map((term) => <small key={term}>{term}</small>)}
+                </div>
+              ) : null}
+            </div>
+          </div>
+
+          {result.confidence === "low" ? (
+            <p className="finder-low-confidence" role="note">{t("finder.lowConfidence")}</p>
+          ) : null}
+
+          <MotionCompare
+            locale={locale}
+            candidates={candidates}
+            selectedId={selectedId}
+            selectedValues={values}
+            onSelect={selectCandidate}
+          />
+        </section>
+      ) : (
+        <section className="finder-empty" aria-labelledby="finder-empty-title">
+          <Sparkles aria-hidden="true" size={20} strokeWidth={1.6} />
+          <h2 id="finder-empty-title">{t("finder.emptyTitle")}</h2>
+          <p>{t("finder.emptyCopy")}</p>
+        </section>
+      )}
+
+      {selectedCandidate && values ? (
+        <section className="finder-tune" aria-labelledby="finder-tune-title">
+          <div className="library-doc-section-heading">
+            <div>
+              <span>{t("finder.tuneEyebrow")}</span>
+              <h2 id="finder-tune-title">
+                {t("finder.tuneTitle", { name: selectedCandidate.name })}
+              </h2>
+            </div>
+            <p>{t("finder.tuneCopy")}</p>
+          </div>
+
+          <div className="library-workbench finder-workbench">
+            <div className="library-preview-frame">
+              <MotionPreview
+                locale={locale}
+                recipe={selectedCandidate.recipe}
+                values={values}
+              />
+            </div>
+            <aside className="library-parameter-panel" aria-label={t("finder.paramsLabel")}>
+              <div className="library-sync-status">
+                <i aria-hidden="true" />
+                {t("finder.readyStatus")}
+              </div>
+              <ParameterControls
+                locale={locale}
+                recipe={selectedCandidate.recipe}
+                values={values}
+                onChange={updateValue}
+                onReset={resetValues}
+              />
+            </aside>
+          </div>
+
+          <p className="finder-change-hint">{t("finder.changeHint")}</p>
+          <ExportPanel
+            locale={locale}
+            recipe={selectedCandidate.recipe}
+            values={values}
+          />
+        </section>
+      ) : null}
+    </>
+  );
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -86,6 +86,11 @@ const vocabularyRoute = createRoute({
   path: "$locale/vocabulary"
 }).lazy(() => import("./routes/vocabulary.lazy").then((module) => module.Route));
 
+const finderRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "$locale/finder"
+}).lazy(() => import("./routes/finder.lazy").then((module) => module.Route));
+
 const recipeRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "$locale/$categoryId/$recipeId"
@@ -102,6 +107,7 @@ const routeTree = rootRoute.addChildren([
   catalogRoute,
   playgroundRoute,
   vocabularyRoute,
+  finderRoute,
   recipeRoute,
   categoryRoute
 ]);

--- a/src/routes/finder.lazy.tsx
+++ b/src/routes/finder.lazy.tsx
@@ -1,0 +1,11 @@
+import { createLazyRoute } from "@tanstack/react-router";
+import { FinderPage } from "../pages/FinderPage";
+import { useRouteLocale } from "./route-locale";
+
+function FinderRoute() {
+  return <FinderPage locale={useRouteLocale()} />;
+}
+
+export const Route = createLazyRoute("/$locale/finder")({
+  component: FinderRoute
+});

--- a/tests/cli/core.spec.ts
+++ b/tests/cli/core.spec.ts
@@ -5,14 +5,21 @@ import { describe, expect, it } from "vitest";
 import {
   catalog,
   exportRecipe,
+  getSchema,
+  recommend,
   resolveRecipe,
   runCli,
   search,
   show,
+  version,
   writeRecipeFiles
 } from "motion-lexicon";
 
 describe("Motion Lexicon CLI API", () => {
+  it("reports the v0.2.0 release version", () => {
+    expect(version).toBe("0.2.0");
+  });
+
   it("returns the 44 canonical recipes with schema version 1", () => {
     const result = catalog({ locale: "zh" });
     expect(result.schemaVersion).toBe(1);
@@ -28,6 +35,29 @@ describe("Motion Lexicon CLI API", () => {
     expect(search("弹簧", { locale: "zh" }).items[0].id).toBe("spring");
     expect(search("pop-in", { locale: "en" }).items[0].id).toBe("scale-in");
     expect(search("shared element", { locale: "en" }).items[0].id).toBe("morph");
+  });
+
+  it("recommends three explainable variants with shareable finder links", () => {
+    const result = recommend("卡片弹出来要有重量、最后收得住", {
+      locale: "zh"
+    });
+    expect(result).toMatchObject({
+      schemaVersion: 1,
+      groupId: "entrance-feel",
+      confidence: "high",
+      count: 3
+    });
+    expect(result.items.map((item) => item.variantId)).toEqual([
+      "spring",
+      "pop-in",
+      "scale-in"
+    ]);
+    expect(result.compareUrl).toContain("/zh/finder/?q=");
+    expect(result.compareUrl).toContain("compare=spring%2Cpop-in%2Cscale-in");
+    expect(getSchema("recommend")).toMatchObject({
+      schemaVersion: 1,
+      title: "Motion Lexicon recommend schema"
+    });
   });
 
   it("resolves aliases and preserves their preset values", () => {
@@ -101,6 +131,26 @@ describe("runCli", () => {
     const output = capture();
     expect(await runCli(["show", "pop-in", "--format", "json"], output.io)).toBe(0);
     expect(JSON.parse(output.stdout())).toMatchObject({ schemaVersion: 1, id: "scale-in" });
+    expect(output.stderr()).toBe("");
+  });
+
+  it("prints machine-readable recommendations", async () => {
+    const output = capture();
+    expect(
+      await runCli(
+        ["recommend", "same thumbnail expands into detail", "--format", "json"],
+        output.io
+      )
+    ).toBe(0);
+    const result = JSON.parse(output.stdout());
+    expect(result).toMatchObject({
+      groupId: "state-continuity",
+      count: 3
+    });
+    expect(result.items[0]).toMatchObject({
+      variantId: "shared-element-transition",
+      canonicalId: "morph"
+    });
     expect(output.stderr()).toBe("");
   });
 

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -3,7 +3,11 @@ import { expect, test } from "@playwright/test";
 test("desktop landing page renders without horizontal overflow", async ({ page }) => {
   await page.goto("/zh/");
   await expect(page).toHaveTitle(/Motion Lexicon/);
-  await expect(page.getByRole("heading", { name: /看得见、调得动/ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /说出你要的感觉/ })).toBeVisible();
+  await expect(page.getByRole("link", { name: /开始描述动效/ })).toHaveAttribute(
+    "href",
+    "/zh/finder/"
+  );
   await expect(page.locator(".library-card")).toHaveCount(6);
 
   const hasHorizontalOverflow = await page.evaluate(() => {
@@ -14,7 +18,7 @@ test("desktop landing page renders without horizontal overflow", async ({ page }
 
 test("english landing page renders english copy", async ({ page }) => {
   await page.goto("/en/");
-  await expect(page.getByRole("heading", { name: /See it\. Tune it\./ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: /Describe the feel/ })).toBeVisible();
   await expect(page.getByText("一个能看")).toHaveCount(0);
 });
 

--- a/tests/e2e/finder.spec.ts
+++ b/tests/e2e/finder.spec.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "@playwright/test";
+
+const query = "卡片弹出来要有重量，最后收得住";
+
+test("Finder restores a shared comparison and keeps variant CSS isolated", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "The complete comparison contract runs once on desktop.");
+
+  const runtimeErrors: string[] = [];
+  page.on("pageerror", (error) => runtimeErrors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error") runtimeErrors.push(message.text());
+  });
+
+  await page.goto(
+    `/zh/finder/?q=${encodeURIComponent(query)}&compare=scale-in,pop-in,spring&selected=pop-in`
+  );
+
+  await expect(page).toHaveTitle(/动效选择器/);
+  await expect(page.getByRole("heading", { level: 1 })).toHaveCount(1);
+  await expect(page.locator(".finder-candidate")).toHaveCount(3);
+  await expect(page.locator(".finder-candidate").nth(0)).toHaveAttribute("data-variant-id", "scale-in");
+  await expect(page.locator("[data-variant-id='pop-in']")).toHaveClass(/is-selected/);
+
+  const isolatedStyles = await page.locator(".finder-candidate-stage").evaluateAll((stages) =>
+    stages.map((stage) => ({
+      hasShadowRoot: Boolean(stage.shadowRoot),
+      css: stage.shadowRoot?.querySelector("style")?.textContent ?? ""
+    }))
+  );
+  expect(isolatedStyles.every((stage) => stage.hasShadowRoot)).toBe(true);
+  expect(isolatedStyles[0].css).toContain("scale(0.92)");
+  expect(isolatedStyles[1].css).toContain("scale(0.86)");
+  const previewLabels = await page.locator(".finder-candidate-stage").evaluateAll((stages) =>
+    stages.map((stage) => stage.shadowRoot?.querySelector("strong")?.textContent ?? "")
+  );
+  expect(previewLabels).toEqual(["缩放入场", "弹入", "弹簧"]);
+
+  await page.getByRole("button", { name: "同步重播" }).click();
+  await expect(page.getByRole("heading", { level: 2, name: /调节.*弹入/ })).toBeVisible();
+
+  await page.goto(
+    `/zh/finder/?q=${encodeURIComponent(query)}&compare=scale-in,scale-in,pop-in&selected=scale-in`
+  );
+  await expect(page.locator(".finder-candidate")).toHaveCount(3);
+  const normalizedVariants = await page.locator(".finder-candidate").evaluateAll((candidates) =>
+    candidates.map((candidate) => candidate.getAttribute("data-variant-id"))
+  );
+  expect(normalizedVariants).toEqual(["scale-in", "pop-in", "spring"]);
+  expect(new Set(normalizedVariants).size).toBe(3);
+  expect(runtimeErrors).toEqual([]);
+});
+
+test("Finder creates a shareable selection and parameter state", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Form, selection, and parameters run once on desktop.");
+
+  await page.goto("/zh/finder/");
+  const finderInput = page.getByRole("searchbox", { name: "描述你想要的动效" });
+  await expect(finderInput).toBeEnabled();
+  await finderInput.fill(query);
+  await page.getByRole("button", { name: "查找候选" }).click();
+
+  await expect(page).toHaveURL(/q=/);
+  await expect(page).toHaveURL(/compare=/);
+  await expect(page).toHaveURL(/selected=spring/);
+
+  await page.getByRole("button", { name: /选择.*弹入/ }).click();
+  await expect(page).toHaveURL(/selected=pop-in/);
+  await expect(page.locator("[data-variant-id='pop-in']")).toHaveClass(/is-selected/);
+
+  const firstSlider = page.locator(".finder-tune").getByRole("slider").first();
+  await firstSlider.press("ArrowRight");
+  await expect(page).toHaveURL(/duration=/);
+
+  await page.getByRole("tab", { name: "Prompt" }).click();
+  await expect(page).toHaveURL(/tab=prompt/);
+  await firstSlider.press("ArrowRight");
+  await expect(page).toHaveURL(/tab=prompt/);
+  await page.reload();
+  await expect(page.getByRole("tab", { name: "Prompt" })).toHaveAttribute("aria-selected", "true");
+
+  const draft = "列表需要更轻、更连续地出现";
+  await page.getByRole("searchbox", { name: "描述你想要的动效" }).fill(draft);
+  await page.locator(".finder-tune").getByRole("slider").first().press("ArrowRight");
+  await expect(page.getByRole("searchbox", { name: "描述你想要的动效" })).toHaveValue(draft);
+
+  const selectButton = page.locator("[data-variant-id='pop-in'] .finder-select");
+  const box = await selectButton.boundingBox();
+  expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
+});
+
+test("Finder remains readable on a mobile viewport", async ({ page }, testInfo) => {
+  test.skip(!testInfo.project.name.includes("mobile"), "Mobile layout runs once in the mobile project.");
+
+  await page.goto(`/en/finder/?q=${encodeURIComponent("bring in a list one by one")}`);
+  await expect(page.getByRole("heading", { level: 1, name: /Describe the feel/ })).toBeVisible();
+  await expect(page.locator(".finder-candidate")).toHaveCount(3);
+
+  const hasHorizontalOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > window.innerWidth
+  );
+  expect(hasHorizontalOverflow).toBe(false);
+});

--- a/tests/e2e/vocabulary.spec.ts
+++ b/tests/e2e/vocabulary.spec.ts
@@ -19,6 +19,7 @@ test("vocabulary publishes all 91 independently maintained terms", async ({ page
 
 test("vocabulary search finds aliases and links to their working component", async ({ page }) => {
   await page.goto("/zh/vocabulary/");
+  await expect(page.getByRole("combobox", { name: "主题" })).toBeEnabled();
   const search = page.getByRole("searchbox", { name: "搜索动画词汇" });
   await search.fill("共享元素");
 

--- a/tests/unit/finder-surface.spec.ts
+++ b/tests/unit/finder-surface.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { resources } from "../../src/i18n/resources";
+import { getStaticPaths, pathFor, sitemapPaths } from "../../src/data/site";
+import { recommendMotions } from "../../src/lib/motion-finder";
+
+describe("Motion Finder public surface", () => {
+  it("publishes localized, indexable Finder routes", () => {
+    expect(getStaticPaths()).toContain(pathFor("zh", ["finder"]));
+    expect(getStaticPaths()).toContain(pathFor("en", ["finder"]));
+    expect(sitemapPaths()).toContain("/zh/finder/");
+    expect(sitemapPaths()).toContain("/en/finder/");
+    expect(resources.zh.translation.seo.finderTitle).not.toBe(
+      resources.en.translation.seo.finderTitle
+    );
+  });
+
+  it("creates a Finder URL that the web interface can restore", () => {
+    const result = recommendMotions(
+      "卡片弹出来要有重量，最后收得住",
+      "zh"
+    );
+    const url = new URL(result.comparePath, "https://motion-lexicon.pages.dev");
+
+    expect(url.pathname).toBe("/zh/finder/");
+    expect(url.searchParams.get("q")).toBe("卡片弹出来要有重量，最后收得住");
+    expect(url.searchParams.get("compare")?.split(",")).toEqual(
+      result.candidates.map((candidate) => candidate.variantId)
+    );
+    expect(result.candidates).toHaveLength(3);
+  });
+});

--- a/tests/unit/motion-finder.spec.ts
+++ b/tests/unit/motion-finder.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { recommendMotions } from "../../src/lib/motion-finder";
+
+describe("Motion Finder", () => {
+  it("maps a Chinese weighted entrance description to the entrance trio", () => {
+    const result = recommendMotions(
+      "卡片弹出来要有重量、最后收得住",
+      "zh"
+    );
+
+    expect(result).toMatchObject({
+      groupId: "entrance-feel",
+      confidence: "high"
+    });
+    expect(result.candidates.map((item) => item.variantId)).toEqual([
+      "spring",
+      "pop-in",
+      "scale-in"
+    ]);
+    expect(result.comparePath).toContain("compare=spring%2Cpop-in%2Cscale-in");
+  });
+
+  it("preserves the Pop in alias identity and typed preset values", () => {
+    const popIn = recommendMotions("轻快地弹出来", "zh").candidates.find(
+      (item) => item.variantId === "pop-in"
+    );
+
+    expect(popIn).toMatchObject({
+      canonicalId: "scale-in",
+      presetQuery: "scale=86&overshoot=true",
+      presetValues: { scale: 86, overshoot: true },
+      values: { scale: 86, overshoot: true }
+    });
+  });
+
+  it("recognizes state continuity language in English", () => {
+    const result = recommendMotions(
+      "The same thumbnail expands into the detail page",
+      "en"
+    );
+
+    expect(result.groupId).toBe("state-continuity");
+    expect(result.candidates[0]).toMatchObject({
+      variantId: "shared-element-transition",
+      canonicalId: "morph",
+      presetValues: { mode: "shared" }
+    });
+    expect(result.candidates.map((item) => item.variantId).sort()).toEqual(
+      ["crossfade", "morph", "shared-element-transition"].sort()
+    );
+  });
+
+  it("distinguishes delay, stagger, and orchestration intent", () => {
+    expect(recommendMotions("触发后等一下再开始", "zh").candidates[0]).toMatchObject({
+      variantId: "delay",
+      canonicalId: "duration",
+      presetValues: { delay: 120 }
+    });
+    expect(recommendMotions("列表一个接一个出现", "zh").candidates[0].variantId).toBe(
+      "stagger"
+    );
+    expect(
+      recommendMotions("coordinate multiple motions on a timeline", "en").candidates[0]
+        .variantId
+    ).toBe("orchestration");
+  });
+
+  it("returns a deterministic low-confidence trio for an uncovered phrase", () => {
+    const first = recommendMotions("make it delightful", "en");
+    const second = recommendMotions("make it delightful", "en");
+
+    expect(first.confidence).toBe("low");
+    expect(first.candidates).toHaveLength(3);
+    expect(second).toEqual(first);
+  });
+});

--- a/tests/unit/public-artifacts.spec.ts
+++ b/tests/unit/public-artifacts.spec.ts
@@ -71,13 +71,15 @@ describe("public machine-readable artifacts", () => {
 
   it("advertises the free CLI and Agent Skill in both LLM indexes", async () => {
     const expectedCommands = [
-      "npx github:Ryan-yang125/motion-lexicon",
+      "npx -y github:Ryan-yang125/motion-lexicon#v0.2.0",
+      "recommend \"describe the motion you want\" --locale en --format json",
       "npx skills add Ryan-yang125/motion-lexicon --skill motion-lexicon"
     ];
 
     for (const filename of ["llms.txt", "llms-full.txt"]) {
       const content = await readArtifact(filename);
       for (const command of expectedCommands) expect(content, filename).toContain(command);
+      expect(content, filename).toContain("https://motion-lexicon.pages.dev/en/finder/");
     }
   });
 


### PR DESCRIPTION
## Summary

- add the bilingual Motion Finder with explainable Top 3 recommendations, synchronized previews, shareable selection and parameter state
- add the offline `recommend` CLI/API contract and keep alias presets intact through show/export
- update the Motion Lexicon Agent Skill, public artifacts, SEO, product docs, and version to 0.2.0
- add Finder unit/browser coverage, hydration and URL-state regression tests, bundle budget, and Skill evals

## Verification

- lint, typecheck, 49 unit tests, 11 CLI tests
- i18n, vocabulary, SEO, motion, accessibility, build, bundle, dist crawl
- Playwright: 29 passed, 9 planned device skips
- Skill validation and v0.1/v0.2 benchmark
- npm audit: 0 vulnerabilities

## Release

After merge, publish the static site, GitHub v0.2.0 release assets, CLI, and Skill.