### PR TITLE
Fix Motion Finder narrow viewport header

### DIFF
--- a/src/library.css
+++ b/src/library.css
@@ -2070,6 +2070,8 @@ kbd {
 }
 
 @media (max-width: 580px) {
+  .library-header-actions > .library-search-link { display: none; }
+
   .library-hero { padding: 3.5rem 0; }
   .library-hero h1 { font-size: 2.2rem; letter-spacing: -0.035em; }
   .library-hero-actions { display: grid; }

--- a/tests/e2e/finder.spec.ts
+++ b/tests/e2e/finder.spec.ts
@@ -100,3 +100,16 @@ test("Finder remains readable on a mobile viewport", async ({ page }, testInfo) 
   );
   expect(hasHorizontalOverflow).toBe(false);
 });
+
+test("Finder header fits a narrow desktop viewport", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Narrow desktop layout runs once in the desktop project.");
+
+  await page.setViewportSize({ width: 390, height: 900 });
+  await page.goto(`/zh/finder/?q=${encodeURIComponent(query)}`);
+  await expect(page.locator(".finder-candidate")).toHaveCount(3);
+
+  const hasHorizontalOverflow = await page.evaluate(
+    () => document.documentElement.scrollWidth > window.innerWidth
+  );
+  expect(hasHorizontalOverflow).toBe(false);
+});


### PR DESCRIPTION
## Summary

- hide the redundant Finder shortcut below 580px while keeping GitHub, language, theme, menu, and the full brand available
- add a 390px narrow-desktop Finder regression check alongside the mobile-device test

## Verification

- lint and typecheck
- focused Finder and open-source-entry Playwright checks
- full Playwright run exercises the new narrow viewport contract
- Impeccable detector clean