### PR TITLE
feat: redesign product around the Motion Finder

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,18 +1,35 @@
-# Motion Lexicon v0.2 Design
+# Motion Lexicon Product Design
 
-## Product Shape
+## Experience Model
 
-Motion Lexicon is a static, SEO-friendly motion finder and recipe library. The catalog curates 91 motion terms into 44 canonical units: 31 components, 9 playgrounds, and 4 guides. v0.2 adds an explainable decision surface for moving from vague intent to three comparable variants.
+Motion Lexicon is a static, SEO-friendly motion finder and recipe library. The catalog curates 91 motion terms into 44 canonical units: 31 components, 9 playgrounds, and 4 guides. The interface turns that depth into one calm, continuous journey:
 
-The user-facing structure is:
+```txt
+Describe → Choose → Tune → Use
+```
 
-- `/zh/` and `/en/`: landing pages with a curated component-library surface.
-- `/:locale/finder/`: bilingual natural-language recommendation, synchronized Top 3 comparison, variant selection, parameter tuning, and portable output.
-- `/:locale/catalog/`: shareable Components, Playgrounds, and Guides catalog filters.
-- `/:locale/vocabulary/`: the complete 91-term bilingual vocabulary and distinction layer.
-- `/:locale/:categoryId/`: indexable category collections.
-- `/:locale/:categoryId/:recipeId/`: canonical detail workspaces with preview, parameters, Prompt, HTML, CSS, and portable JavaScript where interaction requires it.
+- **Describe:** the landing page and Finder share one natural-language intake, three grounded examples, and the same product promise. A landing query continues to the Finder with `q` in the URL.
+- **Choose:** the Finder focuses the strongest current candidate and keeps two alternatives visible. One synchronized replay action expands all three into a direct comparison.
+- **Tune:** the selected recipe stays on the main stage while its parameters update the preview, URL, Prompt, HTML, CSS, and JavaScript together.
+- **Use:** Copy Prompt is the primary completion action. Portable output remains available through a disclosure in the same workspace.
+
+The intended emotional result is calm confidence. Purpose, Agency, Simplicity, and Craft guide the hierarchy, feedback, responsive behavior, and visual details.
+
+## Information Architecture
+
+The product header exposes two primary destinations:
+
+- **Find motion:** `/:locale/` and `/:locale/finder/` form one experiential layer. Home carries the Finder intake and representative preview; Finder carries recommendation, comparison, tuning, and export.
+- **Library:** `/:locale/catalog/` is the unified browsing entry for components, playgrounds, and guides. Search, surface, and category filters share one toolbar.
+
+Supporting routes preserve discovery depth and static acquisition value:
+
+- `/:locale/vocabulary/`: complete 91-term bilingual vocabulary and distinction layer.
+- `/:locale/:categoryId/`: indexable motion-family collection.
+- `/:locale/:categoryId/:recipeId/`: canonical recipe workspace.
 - Legacy term and playground URLs: generated redirects to canonical destinations or presets.
+
+GitHub stays visible in the desktop header. CLI, Agent Skill, JSON data, vocabulary, theme, and locale live in the resources layer and footer. Mobile keeps Library and the resources menu immediately reachable.
 
 ## Technical Stack
 
@@ -28,20 +45,59 @@ The user-facing structure is:
 - ESLint and TypeScript build mode for quality gates.
 - Playwright for browser acceptance checks.
 
+`src/styles.css` and `src/library.css` provide shared primitives and library foundations. `src/apple-redesign.css` loads after them and defines the current product shell, workspaces, materials, responsive layouts, and accessibility adaptations. `prototype/motion-lexicon-prototype.html` remains an archived phase-one artifact.
+
+## Layout System
+
+### Product shell
+
+- The 64px header uses a translucent floating material, a centered Find motion / Library control, and a source-anchored resources popover.
+- Desktop page width is capped at 1240px with 48px outer breathing room. Mobile uses a 28px total outer gutter.
+- The landing hero uses the first viewport for the description input, three example requests, product proof, and one representative live scene. The following section introduces three featured recipes and the complete Library link.
+- Footer content stays compact and groups product navigation separately from open-source resources.
+
+### Finder workspace
+
+- An empty Finder gives the description field dominant visual weight.
+- A populated Finder compresses the intake and brings recommendation evidence plus the active workspace forward.
+- Focus mode uses one large selected candidate and two compact alternatives.
+- Compare mode displays three equal desktop columns with the same scene and a shared replay cycle.
+- Mobile focus mode places the selected candidate above two compact alternatives. Mobile compare mode uses three scan-friendly rows with concise labels, previews, and selection actions.
+- At widths above 1040px, the candidate stage and a 300–340px Inspector sit side by side. Narrower layouts stack the Inspector after the stage.
+
+### Recipe workspace
+
+- Recipe identity and Copy Prompt lead the page.
+- The preview stage and Inspector form the primary workbench. Common parameters appear first; additional parameters live in an Advanced controls disclosure.
+- Device simulation and reduced-motion preview controls remain attached to the stage.
+- Portable output, vocabulary, decision guidance, review criteria, accessibility guidance, parameter reference, and related entries use native disclosures.
+- Category and vocabulary acquisition pages use a calmer editorial shell and lead into canonical workspaces.
+
+### Library
+
+- One toolbar combines keyword search, Components / Playgrounds / Guides, and category filtering.
+- Results stay grouped by motion family, with the active result count and context visible near the controls.
+- Desktop uses a responsive card grid. Mobile uses horizontally scrollable, snap-aligned recipe rows to preserve useful preview size.
+
 ## Visual System
 
-The production interface follows the established grammar of mature component-library documentation, with shadcn/ui, Motion Primitives, Magic UI, and React Bits used as structural references:
+The interface applies Apple-inspired web principles through product hierarchy and interaction craft:
 
-- True white and chroma-zero gray surfaces in light mode; zinc-black surfaces in dark mode.
-- Black primary actions, one blue state color for focus, selection, progress, and accessibility cues.
-- Thin neutral borders, compact 6-10px radii, and low-contrast secondary text.
-- Geist/Inter/system sans-serif typography with small mono metadata and code labels.
-- A 60px product header, dense catalog navigation, sticky documentation sidebars, and a restrained page-width system.
-- Large grid-backed preview canvases that carry the visual expression of each entry.
-- Dark code blocks with fixed format tabs, filenames, copy status, and horizontal scrolling.
-- Static catalog thumbnails at rest with one deliberate animation cycle on fine-pointer hover or the featured preview; keyboard focus remains immediate and still.
+- **Purpose:** every state gives the next useful action the strongest position, contrast, and scale.
+- **Agency:** the original query remains editable; candidate selection, synchronized replay, parameter changes, reset, output formats, themes, and locales remain user-controlled.
+- **Simplicity:** common tasks appear first and advanced content opens in context.
+- **Craft:** typography, spacing, radii, focus states, materials, and transitions use deliberate values across desktop and mobile.
 
-`prototype/motion-lexicon-prototype.html` remains an archived phase-one artifact. `src/styles.css` and `src/library.css` define the current production system.
+The concrete visual grammar is:
+
+- Platform system typography: `-apple-system`, `BlinkMacSystemFont`, SF Pro where available, PingFang SC, Helvetica Neue, and Arial fallbacks.
+- Large headings use tight tracking and leading; body copy uses comfortable leading; mono typography is reserved for code and precise metadata.
+- Light mode uses warm chroma-zero gray with white surfaces. Dark mode uses black with elevated near-black surfaces.
+- One blue state color carries primary actions, focus, selection, readiness, and progress.
+- Whitespace, scale, surface elevation, and restrained shadows create hierarchy. Structural boundaries receive quiet lines.
+- Major preview surfaces use 22–28px radii; inputs and controls use smaller related radii.
+- Translucency is scoped to floating navigation, popovers, toolbars, and Inspectors. Preview canvases and code surfaces retain stable legibility.
+- Real motion scenes provide visual character. Supporting chrome stays quiet, predictable, and content-led.
 
 ## Data And URL State
 
@@ -77,25 +133,33 @@ Finder query state preserves a vague request, comparison variants, and the curre
 
 The CLI provides `q` plus the ordered `compare` list. The Finder selects the first variant by default and writes `selected` after a user choice. Any non-default recipe parameters follow in the same query string. The canonical Finder URL remains `/:locale/finder/`. Web and CLI recommendations use the same intent data and ranking implementation.
 
+## Interaction And Motion
+
+- Buttons and candidate selectors respond during press with a short scale treatment and retain visible keyboard focus.
+- Finder candidates share scene dimensions and replay state, keeping comparison visually direct.
+- Selecting a candidate returns the deck to focus mode and updates the URL-backed tuning state.
+- Popovers originate near their trigger and use short scale, position, and opacity transitions.
+- Workbench controls update their affected preview and generated output immediately.
+- UI transitions use restrained, smooth settle curves. Existing gesture recipes keep their Pointer Events, capture, damping, cancellation, velocity-aware settlement, and keyboard alternatives.
+- Hover motion runs behind fine-pointer media queries.
+- `prefers-reduced-motion` replaces large transitions and illustrative movement with short opacity or color feedback.
+- `prefers-reduced-transparency` turns floating materials into solid surfaces and removes backdrop blur.
+- `prefers-contrast: more` strengthens key boundaries on the landing experience.
+
+## Accessibility
+
+- Primary mobile controls and navigation targets maintain a 44px minimum touch size.
+- Native links, buttons, forms, `details`, and `summary` elements preserve keyboard and assistive-technology semantics.
+- Finder status, result count, selection, replay, copy completion, and errors use visible text or appropriate live-region behavior.
+- Light and dark themes maintain readable text and state contrast.
+- Reduced-motion preview remains directly controllable inside each recipe workspace.
+- Layouts support desktop and mobile without horizontal page overflow.
+
 ## SEO
 
 The build pipeline renders static HTML for 120 localized canonical routes. Each route receives a self canonical, reciprocal hreflang set, Open Graph metadata, and static JSON-LD. The vocabulary routes publish a `DefinedTermSet` containing all 91 terms. Finder query variations canonicalize to their localized Finder route.
 
-Landing, Finder, catalog, category, and canonical detail pages are indexable. Alias and Finder query variations stay out of the sitemap.
-
-## Motion Rules
-
-Each recipe uses one semantic motion specification for its parameter schema, preview markup, generated CSS, generated HTML, Prompt, and reduced-motion behavior. The motion craft rules are:
-
-- Prefer transform and opacity, and use clip, filter, or layout properties only when the named pattern requires them.
-- Use custom cubic-bezier curves.
-- Keep UI interaction feedback short.
-- Keep motion interruptible and directly tied to the named behavior.
-- Respect `prefers-reduced-motion` by removing movement and keeping a short fade.
-- Gate hover movement behind fine pointer media queries.
-- Use Pointer Events and velocity-aware settlement for gesture components.
-- Keep keyboard-initiated navigation and repeated parameter editing visually immediate.
-- Replay Finder candidates from one synchronized control and use the same scene dimensions and content for direct comparison.
+Landing, Finder, catalog, category, and canonical detail pages are indexable. Alias and Finder query variations stay out of the sitemap. The focused product navigation changes visible wayfinding while preserving every static acquisition route.
 
 ## Launch Acceptance
 
@@ -114,5 +178,8 @@ Launch is complete when:
 - `npm run crawl:dist` passes.
 - `npm run test:visual` passes on desktop and mobile.
 - Web and CLI recommendations agree on ordered variants, reasons, presets, and shareable compare state.
+- Focus mode shows one selected candidate with two alternatives, and synchronized comparison remains one action away.
+- Desktop workspaces pair the active stage with the Inspector; mobile comparison remains concise and free of horizontal page overflow.
+- Landing, Finder, Library, vocabulary, category, and recipe routes keep complete Chinese and English metadata and content.
 - Both localized Finder routes are prerendered, canonicalized, crawlable, and free of horizontal overflow.
 - The local dev server runs and the site is available for manual review.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -2,12 +2,13 @@
 
 ## Product Promise
 
-Motion Lexicon turns motion vocabulary into visible, tunable, copy-ready recipes.
+Motion Lexicon turns vague interface intent into visible, explainable, tunable, copy-ready motion recipes.
 
-The product helps a user move from a vague motion idea to a precise recipe they can share with another person or hand to an agent. Every important page should answer three questions quickly:
+The primary journey is **Describe → Choose → Tune → Use**. The product helps a user move from a feeling to a precise recipe they can share with another person or hand to an agent. Every primary surface should answer four questions quickly:
 
+- What can I describe in my own words?
 - What does this motion look like?
-- When should I use it?
+- Which close motion fits this situation?
 - How do I reproduce it with prompt text or portable HTML/CSS/JavaScript?
 
 ## Primary Users
@@ -18,16 +19,14 @@ The product helps a user move from a vague motion idea to a precise recipe they 
 
 ## Product Structure
 
-The site is a static, SEO-friendly application with these public surfaces:
+The site is a static, SEO-friendly application with two primary destinations and supporting acquisition surfaces:
 
-- Landing page: introduces the library and highlights representative motion recipes.
-- Motion Finder: turns a vague bilingual description into three ranked variants, explains their differences, compares them in one scene, and continues into tuning and export.
-- Components: 31 copy-ready patterns with real previews, relevant controls, and synchronized exports.
-- Playgrounds: 9 focused labs for timing, easing, spring physics, transforms, scroll, and review principles.
-- Guides: 4 reference hubs for performance, purposeful motion, perceived performance, and reduced motion.
-- Vocabulary: all 91 motion terms with original English technical definitions, accurate Chinese translations, and close-term distinctions.
-- Category pages: stable, indexable collections for each motion family.
-- Alias routes: preserve the 91-term vocabulary and resolve each legacy term to a canonical unit.
+- **Find motion:** the landing experience carries the Finder intake directly. A bilingual description produces three ranked variants, focuses the strongest current choice, offers synchronized comparison through one action, and continues into tuning and export.
+- **Library:** one browsing destination for 31 copy-ready components, 9 focused playgrounds, and 4 guides. Search, surface, and category controls reveal the catalog progressively.
+- **Recipe workspace:** a selected motion opens as a dominant preview stage with nearby controls, a primary Prompt action, portable output, and deeper reference material.
+- **Vocabulary and category pages:** stable, indexable acquisition pages that preserve all 91 terms, close-term distinctions, and every motion family, then lead into canonical workspaces.
+- **Alias routes:** preserve legacy vocabulary URLs and resolve each related term to a canonical unit or meaningful preset.
+- **Open-source resources:** CLI, Agent Skill, versioned JSON, schemas, and repository links remain accessible from the utility layer and project footer.
 
 Recipe URLs are canonical content URLs. Query parameters carry only tunable state such as duration, delay, distance, and easing.
 
@@ -45,10 +44,14 @@ The v0.2 release adds Motion Finder as the decision layer above that catalog:
 
 The recommendation engine, web Finder, CLI `recommend` command, and Agent Skill share one versioned intent model. The entire path runs locally in the static frontend or CLI and requires no account or runtime server.
 
+The current product experience unifies the landing intake and Finder language, establishes Find motion and Library as the primary navigation, and applies focused workspaces plus progressive disclosure across Finder, catalog, and recipe pages. This redesign preserves the v0.2 data model, URLs, exports, CLI, Skill, and SEO surface.
+
 ## Content Principles
 
 - Show the motion before explaining it.
 - Keep labels concrete and short.
+- Present the common path first and place advanced parameters, code, review guidance, and reference material one level deeper.
+- Keep one primary action visually dominant in each state: submit a description, select a candidate, tune the motion, or copy the result.
 - Pair every visual behavior with purpose, frequency, trigger, enter/exit, interruptibility, gesture rules, review notes, and reduced-motion guidance.
 - Keep preview, controls, Prompt, HTML, CSS, and JavaScript driven by one motion specification.
 - Maintain an original, implementation-oriented English definition for every vocabulary term and display concise product summaries as a separate layer.
@@ -64,27 +67,32 @@ The recommendation engine, web Finder, CLI `recommend` command, and Agent Skill 
 
 ## Interaction Principles
 
+- Keep the main journey continuous: Describe → Choose → Tune → Use.
+- Focus one recommended candidate and show two compact alternatives. Keep synchronized three-way comparison available through one action.
+- Pair the preview stage and Inspector on desktop. Stack the Inspector after the stage on narrower layouts, and condense mobile comparison into compact scan-friendly rows.
 - Controls must update preview, generated CSS, generated HTML, generated prompt, and URL state together.
 - Gesture components must perform the named behavior in the preview and copied output, with pointer capture, multi-touch protection, damping, velocity-aware settlement, cancellation, and keyboard parity where applicable.
 - The current recipe should stay shareable through its URL.
 - Finder URLs should preserve the original query, candidate comparison, selected variant, and non-default parameter values.
 - Finder candidates should replay from one control and use a shared scene so visual differences remain directly comparable.
 - Copy actions need explicit success and failure states.
+- Buttons, links, inputs, and disclosures need immediate press, focus, and completion feedback.
 - Touch targets should meet 44px on mobile and remain comfortable on desktop.
-- Motion controls should respect `prefers-reduced-motion` while preserving meaning.
+- Motion controls should respect `prefers-reduced-motion` while preserving meaning. Translucent chrome should also adapt to `prefers-reduced-transparency`, with stronger boundaries available under increased contrast preferences.
 
 ## Visual Principles
 
-The production design uses a formal component-library visual system:
+The production design adapts Apple-inspired foundations to Motion Lexicon's own web product language:
 
-- Chroma-zero white, gray, and black establish the page hierarchy in both themes.
-- Black primary actions and a single blue state color keep emphasis predictable.
-- Thin borders, compact 6-10px radii, and disciplined type sizes create a dense documentation surface.
-- Small mono labels support metadata, controls, file names, and catalog structure.
-- Real animation previews carry the visual character; navigation and documentation remain stable and quiet.
-- Home, catalog, category, and detail pages share the same spacing, card, toolbar, search, and focus rules.
-
-Avoid generic SaaS decoration, oversized marketing card stacks, ornamental gradients, multi-accent palettes, and visual patterns that make the product feel detached from animation vocabulary.
+- **Purpose:** each screen makes the next useful action obvious and gives the motion preview the strongest visual weight.
+- **Agency:** users can revise the original request, switch candidates, replay all candidates, change parameters, reset values, open deeper references, and copy the output they need.
+- **Simplicity:** Find motion and Library form the primary navigation. Shared workspaces reveal output, advanced controls, vocabulary, decisions, review guidance, accessibility, and related material progressively.
+- **Craft:** platform system fonts, size-specific tracking, deliberate leading, stable spacing, responsive focus states, and carefully scoped transitions create a calm, confident interface.
+- Chroma-zero light and dark neutrals establish depth, while a single blue state color carries focus, selection, readiness, and primary actions.
+- Whitespace, scale, and surface elevation provide hierarchy. Borders appear at structural boundaries, and larger preview surfaces use more generous radii.
+- Translucent material is reserved for floating navigation, utility popovers, toolbars, and Inspectors. Solid preview surfaces preserve legibility and visual comparison.
+- Mono typography is reserved for code, IDs, filenames, and precise values.
+- Real animation scenes carry the product character. Supporting chrome remains quiet and predictable.
 
 ## Quality Bar
 
@@ -96,6 +104,9 @@ Before a change is considered done:
 - Recipe pages contain a real H1 and stable canonical path.
 - Desktop and mobile have no horizontal overflow.
 - Functional text passes accessible contrast in light and dark themes.
-- Mobile puts the active recipe workflow within the first meaningful viewport.
+- Landing and Finder make the natural-language intake the clear first action.
+- Finder focus mode presents one primary candidate and two alternatives; synchronized comparison remains one action away.
+- Desktop places the active preview beside the Inspector; narrow layouts preserve the stage-first reading order.
+- Recipe pages show preview, common controls, and the primary Prompt action before deeper output and reference material.
 - Reduced-motion mode removes position, scale, looping, and parallax movement while retaining short opacity or color feedback that preserves meaning.
 - `npm run lint`, `npm run typecheck`, `npm run test`, `npm run i18n:check`, `npm run vocabulary:check`, `npm run seo:check`, `npm run motion:check`, `npm run a11y:check`, `npm run build`, `npm run bundle:check`, `npm run crawl:dist`, and `npm run test:visual` pass.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,18 @@
 
 **[Live website](https://motion-lexicon.pages.dev/)** · **[Motion Finder](https://motion-lexicon.pages.dev/en/finder/)** · **[44-recipe catalog](https://motion-lexicon.pages.dev/en/catalog/)** · **[91-term vocabulary](https://motion-lexicon.pages.dev/en/vocabulary/)** · **[Versioned JSON API](https://motion-lexicon.pages.dev/data/v1/catalog.json)**
 
-Motion Lexicon is a visual motion finder and recipe library. Describe a vague interface feeling or goal to receive three explainable candidates, compare them in one scene, select and tune a recipe, then copy agent-ready prompt text plus portable HTML, CSS, and interaction JavaScript.
+Motion Lexicon is a visual motion finder and recipe library organized around one continuous path: **Describe → Choose → Tune → Use**. Describe a vague interface feeling or goal, receive three explainable candidates, focus on the strongest match, compare all three in one scene, tune the selected recipe, then copy agent-ready prompt text plus portable HTML, CSS, and interaction JavaScript.
 
 The launch catalog contains 44 canonical units across 12 categories: 31 copy-ready components, 9 focused playgrounds, and 4 guides. A dedicated bilingual vocabulary surface covers all 91 motion terms with original English technical definitions, accurate Chinese translations, and close-term distinctions. The 47 related terms resolve into the curated workspaces without duplicating components.
 
 ## Current Status
 
 - Static React + TypeScript application is implemented.
-- The bilingual Motion Finder turns vague intent into three ranked candidates with reasons, synchronized previews, shareable comparison state, and the existing tune-and-export workflow.
+- The landing experience and bilingual Motion Finder share the same natural-language intake, examples, and product promise. A landing query continues directly into the Finder workspace.
+- The Finder presents one focused candidate with two compact alternatives. Synchronized comparison remains available through one action, followed by tuning and export in the same workspace.
+- Desktop workspaces pair a dominant preview stage with a nearby Inspector. Mobile keeps the selected candidate prominent and condenses the three-way comparison into scan-friendly rows.
+- The product header exposes Find motion and Library as the two primary destinations. Components, playgrounds, guides, vocabulary, CLI, Skill, data, theme, and locale remain available through contextual controls and the resources menu.
+- Recipe output and long-form reference material use progressive disclosures, keeping preview, common controls, and the primary copy action visually dominant.
 - 44 canonical catalog units and all 91 source terms are available in Chinese and English.
 - Motion Lexicon independently maintains all 91 English definitions; every term includes a specific Chinese translation and every alias includes a bilingual distinction.
 - Preview, parameters, prompt, HTML, CSS, JavaScript, and reduced-motion output share one semantic motion specification.
@@ -28,10 +32,11 @@ The launch catalog contains 44 canonical units across 12 categories: 31 copy-rea
 ## Documentation
 
 - `PRODUCT.md`: product promise, users, phase strategy, content rules, interaction rules, and quality bar.
-- `DESIGN.md`: launch design, routing, SEO plan, motion rules, and acceptance criteria.
+- `DESIGN.md`: experience model, visual system, routing, SEO plan, motion rules, accessibility, and acceptance criteria.
 - `AGENTS.md`: working instructions for future agents.
 - `prototype/motion-lexicon-prototype.html`: archived phase-one visual reference.
-- `src/styles.css` and `src/library.css`: current neutral component-library design system.
+- `src/styles.css` and `src/library.css`: shared primitives and library foundations.
+- `src/apple-redesign.css`: current product shell, focused Finder, unified Library, recipe workbench, materials, responsive layouts, and accessibility adaptations.
 
 ## Free CLI and Agent Skill
 
@@ -211,7 +216,7 @@ npx impeccable --json src
 Current expected test surface:
 
 - Unit tests verify recommendation ranking, web/CLI consistency, motion parameters, and export generation.
-- Playwright checks Finder comparison, desktop and mobile rendering, URL state updates, copy behavior, and horizontal overflow.
+- Playwright checks the focused Finder, synchronized comparison, desktop Inspector, mobile rendering, URL state updates, copy behavior, and horizontal overflow.
 - Static checks verify i18n coverage, SEO route coverage, motion rules, accessibility baseline, bundle budget, and built dist crawl.
 
 ## Content Standards

--- a/src/apple-redesign.css
+++ b/src/apple-redesign.css
@@ -1,0 +1,2807 @@
+/* Motion Lexicon — calm, direct, Apple-inspired product shell. */
+:root {
+  --apple-bg: #f5f5f7;
+  --apple-surface: #ffffff;
+  --apple-surface-raised: rgba(255, 255, 255, 0.82);
+  --apple-surface-soft: #ececf0;
+  --apple-ink: #1d1d1f;
+  --apple-secondary: #6e6e73;
+  --apple-tertiary: #86868b;
+  --apple-line: rgba(29, 29, 31, 0.1);
+  --apple-line-strong: rgba(29, 29, 31, 0.18);
+  --apple-blue: #1671d9;
+  --apple-blue-hover: #0f62c5;
+  --apple-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.03), 0 8px 24px rgba(0, 0, 0, 0.05);
+  --apple-shadow-lg: 0 2px 8px rgba(0, 0, 0, 0.04), 0 30px 80px rgba(0, 0, 0, 0.1);
+  --apple-spring: cubic-bezier(0.22, 1, 0.36, 1);
+  --bg: var(--apple-bg);
+  --panel: var(--apple-surface);
+  --panel-solid: var(--apple-surface);
+  --panel-raised: var(--apple-surface-soft);
+  --ink: var(--apple-ink);
+  --ink-soft: var(--apple-secondary);
+  --ink-dim: var(--apple-tertiary);
+  --ink-faint: var(--apple-line);
+  --accent: var(--apple-blue);
+  --accent-strong: var(--apple-blue-hover);
+  --library-line: var(--apple-line);
+  --library-line-strong: var(--apple-line-strong);
+  --library-subtle: var(--apple-surface-soft);
+  --library-sidebar: rgba(255, 255, 255, 0.58);
+  --library-max: 1240px;
+  --library-content: 920px;
+  --library-header-height: 64px;
+  --sans: -apple-system, BlinkMacSystemFont, "SF Pro Text", "SF Pro Display", "PingFang SC", "Helvetica Neue", Arial, sans-serif;
+}
+
+:root.dark {
+  --apple-bg: #000000;
+  --apple-surface: #1c1c1e;
+  --apple-surface-raised: rgba(36, 36, 38, 0.82);
+  --apple-surface-soft: #2c2c2e;
+  --apple-ink: #f5f5f7;
+  --apple-secondary: #aeaeb2;
+  --apple-tertiary: #8e8e93;
+  --apple-line: rgba(255, 255, 255, 0.12);
+  --apple-line-strong: rgba(255, 255, 255, 0.2);
+  --apple-blue: #2997ff;
+  --apple-blue-hover: #52a9ff;
+  --apple-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.24), 0 10px 28px rgba(0, 0, 0, 0.28);
+  --apple-shadow-lg: 0 2px 8px rgba(0, 0, 0, 0.28), 0 32px 84px rgba(0, 0, 0, 0.48);
+  --bg: var(--apple-bg);
+  --panel: var(--apple-surface);
+  --panel-solid: var(--apple-surface);
+  --panel-raised: var(--apple-surface-soft);
+  --ink: var(--apple-ink);
+  --ink-soft: var(--apple-secondary);
+  --ink-dim: var(--apple-tertiary);
+  --ink-faint: var(--apple-line);
+  --accent: var(--apple-blue);
+  --accent-strong: var(--apple-blue-hover);
+  --library-line: var(--apple-line);
+  --library-line-strong: var(--apple-line-strong);
+  --library-subtle: var(--apple-surface-soft);
+  --library-sidebar: rgba(28, 28, 30, 0.72);
+}
+
+html {
+  background: var(--apple-bg);
+  scroll-padding-top: calc(var(--library-header-height) + 20px);
+}
+
+body {
+  color: var(--apple-ink);
+  background: var(--apple-bg);
+  font-family: var(--sans);
+  font-size: 1rem;
+  line-height: 1.5;
+  letter-spacing: 0;
+  font-optical-sizing: auto;
+}
+
+.page {
+  width: min(var(--library-max), calc(100% - 48px));
+}
+
+button,
+a,
+input,
+summary {
+  -webkit-tap-highlight-color: transparent;
+}
+
+.library-button,
+.ml-button,
+.finder-select,
+.apple-hero-finder button,
+.apple-hero-examples button {
+  transition:
+    transform 120ms ease-out,
+    color 180ms ease,
+    background-color 180ms ease,
+    border-color 180ms ease,
+    box-shadow 240ms var(--apple-spring);
+}
+
+.library-button:active,
+.ml-button:active,
+.finder-select:active,
+.apple-hero-finder button:active,
+.apple-hero-examples button:active {
+  transform: scale(0.97);
+  transition-duration: 80ms;
+}
+
+/* Home / Finder entry */
+.apple-hero.library-hero {
+  min-height: calc(100dvh - var(--library-header-height));
+  grid-template-columns: minmax(0, 1.05fr) minmax(480px, 0.95fr);
+  gap: clamp(3rem, 5vw, 5rem);
+  padding: clamp(4.5rem, 8vh, 7.5rem) 0;
+  border: 0;
+}
+
+.apple-hero-copy {
+  max-width: 610px;
+}
+
+.apple-status-line.library-status-line {
+  min-height: auto;
+  gap: 0.4rem;
+  border: 0;
+  padding: 0;
+  color: var(--apple-blue);
+  font-family: var(--sans);
+  font-size: 0.78rem;
+  font-weight: 650;
+  letter-spacing: 0.01em;
+}
+
+.apple-status-line svg {
+  fill: color-mix(in srgb, var(--apple-blue) 12%, transparent);
+}
+
+.apple-hero.library-hero h1 {
+  max-width: 10em;
+  margin: 1.25rem 0 1.3rem;
+  font-size: clamp(3.65rem, 4.75vw, 4.35rem);
+  font-weight: 650;
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+.apple-hero .apple-hero-copy > p {
+  max-width: 34em;
+  color: var(--apple-secondary);
+  font-size: 1.08rem;
+  line-height: 1.62;
+}
+
+.apple-hero-finder {
+  margin-top: 2.2rem;
+}
+
+.apple-hero-finder > label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+.apple-hero-finder > div {
+  min-height: 64px;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.8rem;
+  border: 1px solid color-mix(in srgb, var(--apple-line-strong) 85%, transparent);
+  border-radius: 18px;
+  padding: 0.45rem 0.45rem 0.45rem 1rem;
+  background: var(--apple-surface);
+  box-shadow: var(--apple-shadow-sm);
+  transition: border-color 180ms ease, box-shadow 240ms var(--apple-spring), transform 240ms var(--apple-spring);
+}
+
+.apple-hero-finder > div:focus-within {
+  border-color: color-mix(in srgb, var(--apple-blue) 58%, transparent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--apple-blue) 12%, transparent), var(--apple-shadow-sm);
+  transform: translateY(-1px);
+}
+
+.apple-hero-finder svg {
+  color: var(--apple-tertiary);
+}
+
+.apple-hero-finder input {
+  min-width: 0;
+  height: 52px;
+  border: 0;
+  outline: 0;
+  color: var(--apple-ink);
+  background: transparent;
+  font-size: 1rem;
+}
+
+.apple-hero-finder input::placeholder {
+  color: var(--apple-tertiary);
+}
+
+.apple-hero-finder button {
+  min-height: 50px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  border: 0;
+  border-radius: 13px;
+  padding: 0 1.05rem;
+  color: #fff;
+  background: var(--apple-blue);
+  font-size: 0.88rem;
+  font-weight: 650;
+  box-shadow: 0 8px 22px color-mix(in srgb, var(--apple-blue) 22%, transparent);
+}
+
+.apple-hero-finder button:hover {
+  background: var(--apple-blue-hover);
+}
+
+.apple-hero-examples {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.8rem;
+}
+
+.apple-hero-examples button {
+  min-height: 36px;
+  border: 0;
+  border-radius: 999px;
+  padding: 0 0.8rem;
+  color: var(--apple-secondary);
+  background: color-mix(in srgb, var(--apple-surface) 74%, transparent);
+  font-size: 0.73rem;
+  white-space: nowrap;
+}
+
+.apple-hero-examples button:hover {
+  color: var(--apple-ink);
+  background: var(--apple-surface);
+  box-shadow: 0 0 0 1px var(--apple-line);
+}
+
+.apple-hero-proof {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 1.35rem;
+  color: var(--apple-tertiary);
+  font-size: 0.74rem;
+}
+
+.apple-hero-proof span {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+}
+
+.apple-hero-proof strong {
+  color: var(--apple-ink);
+  font-size: 0.82rem;
+  font-weight: 650;
+}
+
+.apple-hero-proof > i {
+  width: 3px;
+  height: 3px;
+  border-radius: 50%;
+  background: var(--apple-line-strong);
+}
+
+.apple-hero-preview.library-hero-preview {
+  border: 1px solid color-mix(in srgb, var(--apple-line-strong) 72%, transparent);
+  border-radius: 28px;
+  background: var(--apple-surface-raised);
+  box-shadow: var(--apple-shadow-lg);
+  transform: translateZ(0);
+  transition: transform 420ms var(--apple-spring), box-shadow 420ms var(--apple-spring);
+}
+
+.apple-hero-preview:hover {
+  transform: translateY(-5px) scale(1.006);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.05), 0 42px 96px rgba(0, 0, 0, 0.13);
+}
+
+.apple-hero-preview .apple-preview-toolbar,
+.apple-hero-preview .apple-preview-footer {
+  min-height: 52px;
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0 1.1rem;
+  color: var(--apple-tertiary);
+  font-size: 0.73rem;
+}
+
+.apple-hero-preview .apple-preview-toolbar {
+  justify-content: space-between;
+  border-bottom: 1px solid var(--apple-line);
+}
+
+.apple-hero-preview .apple-preview-toolbar > span:first-child {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--apple-secondary);
+  font-weight: 600;
+}
+
+.apple-hero-preview .apple-preview-toolbar i {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #30d158;
+  box-shadow: 0 0 0 4px color-mix(in srgb, #30d158 12%, transparent);
+}
+
+.apple-preview-scene {
+  min-height: 430px;
+  display: grid;
+  grid-template-columns: 84px 1fr;
+  overflow: hidden;
+  background: var(--apple-surface-soft);
+}
+
+.apple-scene-sidebar {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.05rem;
+  border-right: 1px solid var(--apple-line);
+  padding: 1.35rem 0;
+  background: color-mix(in srgb, var(--apple-surface) 72%, transparent);
+}
+
+.apple-scene-sidebar span,
+.apple-scene-sidebar i {
+  display: block;
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--apple-ink) 9%, transparent);
+}
+
+.apple-scene-sidebar span {
+  width: 34px;
+  height: 34px;
+  margin-bottom: 0.35rem;
+  background: var(--apple-ink);
+}
+
+.apple-scene-sidebar i {
+  width: 28px;
+  height: 9px;
+}
+
+.apple-scene-content {
+  display: grid;
+  align-content: center;
+  gap: 1.15rem;
+  padding: clamp(2rem, 5vw, 4rem);
+}
+
+.apple-scene-heading {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.apple-scene-heading span,
+.apple-scene-heading i,
+.apple-scene-card div > i {
+  display: block;
+  height: 7px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--apple-ink) 11%, transparent);
+}
+
+.apple-scene-heading span { width: 42%; height: 13px; }
+.apple-scene-heading i { width: 68%; }
+
+.apple-scene-card {
+  min-height: 108px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1rem;
+  border: 1px solid color-mix(in srgb, var(--apple-line-strong) 75%, transparent);
+  border-radius: 20px;
+  padding: 1.1rem;
+  background: var(--apple-surface);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.09);
+  animation: apple-scene-arrive 720ms var(--apple-spring) both;
+}
+
+.apple-hero-preview:hover .apple-scene-card {
+  animation: apple-scene-arrive 720ms var(--apple-spring) both;
+}
+
+.apple-scene-avatar {
+  width: 46px;
+  height: 46px;
+  border-radius: 14px;
+  background: var(--apple-blue);
+  box-shadow: inset 0 0 0 8px color-mix(in srgb, white 18%, transparent);
+}
+
+.apple-scene-card div {
+  min-width: 0;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.apple-scene-card strong {
+  overflow: hidden;
+  color: var(--apple-ink);
+  font-size: 0.86rem;
+  font-weight: 650;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.apple-scene-card div > i { width: 86%; height: 5px; }
+.apple-scene-card div > i:last-child { width: 58%; }
+.apple-scene-card b { font-size: 1.1rem; font-weight: 500; }
+
+.apple-scene-list {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.75rem;
+}
+
+.apple-scene-list span {
+  height: 70px;
+  border-radius: 15px;
+  background: color-mix(in srgb, var(--apple-surface) 72%, transparent);
+  box-shadow: inset 0 0 0 1px var(--apple-line);
+}
+
+.apple-hero-preview .apple-preview-footer {
+  border-top: 1px solid var(--apple-line);
+}
+
+.apple-hero-preview .apple-preview-footer strong {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-inline-start: auto;
+  color: var(--apple-blue);
+  font-weight: 600;
+}
+
+@keyframes apple-scene-arrive {
+  0% { opacity: 0; transform: translateX(34px) scale(0.97); }
+  100% { opacity: 1; transform: translateX(0) scale(1); }
+}
+
+/* Quiet second screen */
+.apple-home-library {
+  padding: clamp(5.5rem, 9vw, 8rem) 0 clamp(6rem, 10vw, 9rem);
+}
+
+.apple-home-library-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 0.6fr);
+  align-items: end;
+  gap: clamp(2rem, 6vw, 6rem);
+  margin-bottom: 2.4rem;
+}
+
+.apple-home-library-heading > div:first-child > span {
+  color: var(--apple-blue);
+  font-size: 0.74rem;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+}
+
+.apple-home-library-heading h2 {
+  max-width: 12em;
+  margin: 0.8rem 0 0;
+  font-size: clamp(2.4rem, 4vw, 4rem);
+  font-weight: 630;
+  line-height: 1.04;
+  letter-spacing: -0.045em;
+}
+
+.apple-home-library-heading p {
+  margin: 0 0 1.15rem;
+  color: var(--apple-secondary);
+  font-size: 0.98rem;
+  line-height: 1.6;
+}
+
+.apple-home-library-heading a {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--apple-blue);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.apple-home-card-grid.library-card-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.apple-motion-card.library-card {
+  overflow: hidden;
+  border: 0;
+  border-radius: 24px;
+  background: var(--apple-surface);
+  box-shadow: var(--apple-shadow-sm);
+  transition: transform 360ms var(--apple-spring), box-shadow 360ms var(--apple-spring);
+}
+
+.apple-motion-card.library-card:hover {
+  border-color: transparent;
+  transform: translateY(-4px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04), 0 24px 56px rgba(0, 0, 0, 0.09);
+}
+
+.apple-motion-card .motion-thumb {
+  aspect-ratio: 16 / 11;
+  border: 0;
+  border-radius: 0;
+  background-color: var(--apple-surface-soft);
+  background-image: none;
+}
+
+.apple-motion-card .library-card-body {
+  min-height: 132px;
+  padding: 1.15rem 1.2rem 1.3rem;
+}
+
+.apple-motion-card .library-card-body h3 {
+  font-size: 1.05rem;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+}
+
+.apple-motion-card .library-card-body p {
+  color: var(--apple-secondary);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+@media (max-width: 1040px) {
+  .apple-hero.library-hero {
+    grid-template-columns: 1fr;
+    gap: 4rem;
+    padding-top: 5rem;
+  }
+
+  .apple-hero-copy { max-width: 720px; }
+  .apple-hero-preview.library-hero-preview { width: min(100%, 820px); }
+  .apple-home-library-heading { grid-template-columns: 1fr; gap: 1.4rem; }
+  .apple-home-library-heading > div:last-child { max-width: 620px; }
+}
+
+@media (max-width: 720px) {
+  .page { width: min(100% - 28px, var(--library-max)); }
+
+  .apple-hero.library-hero {
+    min-height: auto;
+    gap: 3rem;
+    padding: 4.25rem 0 3.5rem;
+  }
+
+  .apple-hero.library-hero h1 {
+    max-width: 9em;
+    font-size: clamp(2.65rem, 12vw, 3.65rem);
+    line-height: 0.99;
+    letter-spacing: -0.052em;
+  }
+
+  .apple-hero .apple-hero-copy > p {
+    font-size: 0.98rem;
+    line-height: 1.62;
+  }
+
+  .apple-hero-finder > div {
+    grid-template-columns: auto 1fr;
+    gap: 0.6rem;
+    padding: 0.45rem 0.55rem 0.55rem 0.9rem;
+  }
+
+  .apple-hero-finder button {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
+  .apple-hero-examples {
+    display: grid;
+  }
+
+  .apple-hero-examples button {
+    min-height: 44px;
+    overflow: hidden;
+    text-align: start;
+    text-overflow: ellipsis;
+  }
+
+  .apple-hero-proof { gap: 0.55rem; }
+
+  .apple-hero-preview.library-hero-preview {
+    border-radius: 22px;
+  }
+
+  .apple-preview-scene {
+    min-height: 310px;
+    grid-template-columns: 52px 1fr;
+  }
+
+  .apple-scene-sidebar { gap: 0.8rem; padding-top: 1rem; }
+  .apple-scene-sidebar span { width: 28px; height: 28px; border-radius: 8px; }
+  .apple-scene-sidebar i { width: 20px; }
+  .apple-scene-content { padding: 1.3rem; }
+  .apple-scene-card { min-height: 96px; gap: 0.7rem; padding: 0.85rem; border-radius: 17px; }
+  .apple-scene-avatar { width: 38px; height: 38px; border-radius: 11px; }
+  .apple-scene-card strong { font-size: 0.73rem; }
+  .apple-scene-list span { height: 48px; }
+  .apple-hero-preview .apple-preview-footer span:nth-child(2),
+  .apple-hero-preview .apple-preview-footer span:nth-child(3) { display: none; }
+
+  .apple-home-library {
+    padding: 5rem 0 6rem;
+  }
+
+  .apple-home-library-heading h2 {
+    font-size: clamp(2.35rem, 10vw, 3rem);
+  }
+
+  .apple-home-card-grid.library-card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .apple-scene-card {
+    animation: apple-scene-fade 180ms ease both;
+  }
+
+  .apple-hero-preview,
+  .apple-motion-card,
+  .apple-hero-finder > div {
+    transition: opacity 180ms ease, border-color 180ms ease, box-shadow 180ms ease;
+    transform: none !important;
+  }
+}
+
+@keyframes apple-scene-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .apple-hero-preview.library-hero-preview {
+    background: var(--apple-surface);
+  }
+}
+
+@media (prefers-contrast: more) {
+  .apple-hero-finder > div,
+  .apple-hero-preview.library-hero-preview,
+  .apple-motion-card.library-card {
+    border: 1px solid currentColor;
+  }
+}
+
+/* Floating product navigation */
+.library-header.library-header-compact {
+  min-height: var(--library-header-height);
+  border: 0;
+  background: color-mix(in srgb, var(--apple-bg) 76%, transparent);
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--apple-line) 75%, transparent);
+  backdrop-filter: blur(24px) saturate(170%);
+  -webkit-backdrop-filter: blur(24px) saturate(170%);
+}
+
+.library-header-compact .library-header-inner {
+  width: min(var(--library-max), calc(100% - 48px));
+  grid-template-columns: minmax(190px, 1fr) auto minmax(190px, 1fr);
+  gap: 1rem;
+}
+
+.library-header-compact .library-brand {
+  gap: 0.55rem;
+  font-size: 0.88rem;
+  font-weight: 650;
+}
+
+.library-header-compact .library-brand-mark {
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 8px;
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, white 14%, transparent);
+}
+
+.library-header-compact .library-primary-nav {
+  gap: 0.15rem;
+  border-radius: 999px;
+  padding: 0.2rem;
+  background: color-mix(in srgb, var(--apple-ink) 5%, transparent);
+}
+
+.library-header-compact .library-primary-nav a {
+  min-height: 36px;
+  border-radius: 999px;
+  padding: 0 1rem;
+  color: var(--apple-secondary);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.library-header-compact .library-primary-nav a:hover {
+  color: var(--apple-ink);
+  background: color-mix(in srgb, var(--apple-surface) 56%, transparent);
+}
+
+.library-header-compact .library-primary-nav a.is-active {
+  color: var(--apple-ink);
+  background: var(--apple-surface);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.05);
+}
+
+.library-header-compact .library-header-actions {
+  gap: 0.35rem;
+}
+
+.library-header-compact .library-github-link,
+.library-utility-menu > summary {
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  border: 0;
+  border-radius: 999px;
+  padding: 0 0.78rem;
+  color: var(--apple-secondary);
+  background: transparent;
+  font-size: 0.75rem;
+  font-weight: 560;
+  list-style: none;
+  cursor: pointer;
+}
+
+.library-header-compact .library-github-link:hover,
+.library-utility-menu > summary:hover,
+.library-utility-menu[open] > summary {
+  color: var(--apple-ink);
+  background: color-mix(in srgb, var(--apple-ink) 6%, transparent);
+}
+
+.library-utility-menu {
+  position: relative;
+}
+
+.library-utility-menu > summary::-webkit-details-marker {
+  display: none;
+}
+
+.library-utility-popover {
+  position: absolute;
+  inset-block-start: calc(100% + 12px);
+  inset-inline-end: 0;
+  width: min(320px, calc(100vw - 28px));
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--apple-line-strong) 72%, transparent);
+  border-radius: 22px;
+  padding: 0.55rem;
+  background: color-mix(in srgb, var(--apple-surface-raised) 92%, transparent);
+  box-shadow: var(--apple-shadow-lg);
+  backdrop-filter: blur(30px) saturate(170%);
+  -webkit-backdrop-filter: blur(30px) saturate(170%);
+  transform-origin: top right;
+  animation: apple-popover-in 240ms var(--apple-spring) both;
+}
+
+.library-utility-popover nav {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.25rem;
+}
+
+.library-utility-popover nav a {
+  min-height: 46px;
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  border-radius: 13px;
+  padding: 0 0.75rem;
+  color: var(--apple-secondary);
+  font-size: 0.78rem;
+}
+
+.library-utility-popover nav a:hover,
+.library-utility-popover nav a.is-active {
+  color: var(--apple-ink);
+  background: color-mix(in srgb, var(--apple-ink) 6%, transparent);
+}
+
+.library-utility-settings {
+  display: grid;
+  gap: 0.55rem;
+  margin-top: 0.45rem;
+  border-top: 1px solid var(--apple-line);
+  padding: 0.8rem 0.45rem 0.35rem;
+}
+
+.library-utility-settings > span {
+  color: var(--apple-tertiary);
+  font-size: 0.67rem;
+  font-weight: 600;
+}
+
+.library-utility-settings .header-controls {
+  width: 100%;
+  justify-content: stretch;
+}
+
+.library-utility-settings .theme-select,
+.library-utility-settings .icon-link {
+  min-height: 40px;
+  flex: 1;
+  justify-content: center;
+  border: 1px solid var(--apple-line);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--apple-surface) 68%, transparent);
+}
+
+@keyframes apple-popover-in {
+  from { opacity: 0; transform: translateY(-5px) scale(0.96); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* Motion Finder workspace */
+.apple-finder-intake.finder-hero {
+  min-height: min(720px, calc(100dvh - var(--library-header-height)));
+  display: grid;
+  align-content: center;
+  border: 0;
+  padding: 5.5rem 0;
+}
+
+.apple-finder-intake .finder-hero-copy {
+  max-width: 780px;
+}
+
+.apple-finder-intake .finder-hero-copy > span {
+  color: var(--apple-blue);
+  font-family: var(--sans);
+  font-size: 0.74rem;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+}
+
+.apple-finder-intake .finder-hero-copy h1 {
+  max-width: 8.8em;
+  margin: 1rem 0 1.15rem;
+  font-size: clamp(3.8rem, 6vw, 5.7rem);
+  font-weight: 640;
+  line-height: 0.98;
+  letter-spacing: -0.057em;
+}
+
+.apple-finder-intake .finder-hero-copy p {
+  max-width: 44em;
+  color: var(--apple-secondary);
+  font-size: 1.05rem;
+  line-height: 1.62;
+}
+
+.apple-search-pill.finder-search {
+  max-width: 980px;
+  margin-top: 2.5rem;
+}
+
+.apple-search-pill .finder-search-field {
+  min-height: 68px;
+  grid-template-columns: auto 1fr auto;
+  border: 1px solid color-mix(in srgb, var(--apple-line-strong) 82%, transparent);
+  border-radius: 19px;
+  padding: 0.45rem 0.45rem 0.45rem 1rem;
+  background: var(--apple-surface);
+  box-shadow: var(--apple-shadow-sm);
+}
+
+.apple-search-pill .finder-search-field:focus-within {
+  border-color: color-mix(in srgb, var(--apple-blue) 58%, transparent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--apple-blue) 12%, transparent), var(--apple-shadow-sm);
+}
+
+.apple-search-pill .finder-search-field input {
+  font-size: 1rem;
+}
+
+.apple-search-pill .finder-search-field button {
+  min-height: 50px;
+  border: 0;
+  border-radius: 13px;
+  padding: 0 1.15rem;
+  color: #fff;
+  background: var(--apple-blue);
+}
+
+.apple-search-pill .finder-search-field button:hover {
+  background: var(--apple-blue-hover);
+}
+
+.apple-finder-intake .finder-examples > span,
+.apple-search-pill > label,
+.apple-search-pill > small {
+  color: var(--apple-tertiary);
+  font-family: var(--sans);
+  font-size: 0.7rem;
+}
+
+.apple-finder-intake .finder-examples button {
+  min-height: 40px;
+  border: 0;
+  border-radius: 999px;
+  padding: 0 0.9rem;
+  color: var(--apple-secondary);
+  background: color-mix(in srgb, var(--apple-surface) 74%, transparent);
+}
+
+.apple-finder-intake.has-result {
+  min-height: auto;
+  grid-template-columns: minmax(280px, 0.62fr) minmax(460px, 1.38fr);
+  align-items: end;
+  gap: clamp(2rem, 5vw, 5rem);
+  padding: 3.25rem 0 2.4rem;
+}
+
+.apple-finder-intake.has-result .finder-hero-copy h1 {
+  max-width: 9em;
+  margin: 0.65rem 0 0;
+  font-size: clamp(2.3rem, 3.8vw, 3.4rem);
+  line-height: 1;
+}
+
+.apple-finder-intake.has-result .finder-hero-copy p,
+.apple-finder-intake.has-result .finder-examples {
+  display: none;
+}
+
+.apple-finder-intake.has-result .apple-search-pill {
+  margin: 0;
+}
+
+.apple-finder-workspace.finder-results {
+  border: 0;
+  padding: 2.5rem 0 7rem;
+}
+
+.finder-workspace-heading {
+  align-items: start;
+  margin-bottom: 1.35rem;
+}
+
+.finder-workspace-heading h2 {
+  font-size: clamp(2rem, 3vw, 3rem);
+  font-weight: 630;
+  letter-spacing: -0.04em;
+}
+
+.finder-workspace-heading > div > span,
+.finder-inspector-heading span {
+  color: var(--apple-blue);
+  font-family: var(--sans);
+  font-size: 0.69rem;
+  font-weight: 650;
+  letter-spacing: 0.03em;
+}
+
+.finder-match-summary {
+  max-width: 480px;
+  color: var(--apple-secondary);
+}
+
+.finder-match-summary strong {
+  border: 0;
+  color: var(--apple-blue);
+  background: color-mix(in srgb, var(--apple-blue) 10%, transparent);
+}
+
+.apple-workspace-shell.finder-workspace-shell {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 340px);
+  align-items: start;
+  gap: 1rem;
+}
+
+.finder-workspace-stage {
+  min-width: 0;
+}
+
+.apple-motion-chooser.finder-compare {
+  overflow: hidden;
+  border: 0;
+  border-radius: 28px;
+  background: var(--apple-surface);
+  box-shadow: var(--apple-shadow-sm);
+}
+
+.apple-motion-chooser .finder-compare-toolbar {
+  min-height: 58px;
+  border-bottom: 1px solid var(--apple-line);
+  padding: 0 0.9rem 0 1.15rem;
+  background: color-mix(in srgb, var(--apple-surface-raised) 78%, transparent);
+}
+
+.finder-compare-status {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.finder-compare-status span {
+  color: var(--apple-tertiary);
+  font-size: 0.7rem;
+}
+
+.finder-compare-status strong {
+  border-radius: 999px;
+  padding: 0.25rem 0.5rem;
+  color: var(--apple-blue);
+  background: color-mix(in srgb, var(--apple-blue) 10%, transparent);
+  font-size: 0.66rem;
+  font-weight: 650;
+}
+
+.finder-compare-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.finder-compare-actions .ml-button {
+  min-height: 40px;
+  border: 0;
+  border-radius: 11px;
+  background: color-mix(in srgb, var(--apple-ink) 6%, transparent);
+}
+
+.finder-choice-deck.finder-candidate-grid {
+  gap: 0;
+  padding: 0;
+  background: var(--apple-line);
+}
+
+.finder-choice-deck[data-layout="focus"] {
+  grid-template-columns: minmax(0, 1fr) minmax(190px, 0.34fr);
+  grid-template-rows: auto auto;
+}
+
+.finder-choice-deck[data-layout="focus"] .finder-candidate.is-selected {
+  grid-column: 1;
+  grid-row: 1 / 3;
+}
+
+.finder-choice-deck[data-layout="compare"] {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-rows: 1fr;
+}
+
+.apple-motion-card.finder-candidate {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  border: 0;
+  border-radius: 0;
+  background: var(--apple-surface);
+  box-shadow: 0 0 0 0.5px var(--apple-line);
+  transition: background-color 220ms ease, opacity 220ms ease;
+}
+
+.apple-motion-card.finder-candidate.is-selected {
+  background: var(--apple-surface);
+  box-shadow: inset 0 3px 0 var(--apple-blue), 0 0 0 0.5px var(--apple-line);
+}
+
+.apple-motion-card .finder-candidate-header {
+  min-height: 126px;
+  padding: 1.25rem 1.25rem 1rem;
+}
+
+.apple-motion-card .finder-candidate-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.6rem;
+}
+
+.apple-motion-card .finder-candidate-meta span,
+.apple-motion-card .finder-candidate-meta strong {
+  color: var(--apple-tertiary);
+  font-family: var(--sans);
+  font-size: 0.65rem;
+  font-weight: 600;
+}
+
+.apple-motion-card .finder-candidate-meta strong {
+  color: var(--apple-blue);
+}
+
+.apple-motion-card .finder-candidate-header h3 {
+  margin-top: 0.55rem;
+  font-size: 1.55rem;
+  font-weight: 640;
+  letter-spacing: -0.035em;
+}
+
+.apple-motion-card .finder-candidate-header p {
+  color: var(--apple-secondary);
+  font-size: 0.77rem;
+  line-height: 1.5;
+}
+
+.apple-motion-card .finder-candidate-stage {
+  min-height: 340px;
+  border-block: 1px solid var(--apple-line);
+  background-color: var(--apple-surface-soft);
+  background-image: none;
+}
+
+.apple-motion-card .finder-candidate-body {
+  flex: 1;
+  padding: 1rem 1.25rem;
+  color: var(--apple-secondary);
+  font-size: 0.76rem;
+  line-height: 1.55;
+}
+
+.apple-motion-card .finder-distinction {
+  margin-top: 0.8rem;
+  border: 0;
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: var(--apple-surface-soft);
+}
+
+.apple-motion-card .finder-candidate-actions {
+  min-height: 60px;
+  gap: 0.5rem;
+  border-top: 1px solid var(--apple-line);
+  padding: 0.55rem 0.7rem;
+}
+
+.apple-motion-card .finder-select {
+  min-height: 44px;
+  border: 0;
+  border-radius: 12px;
+  color: var(--apple-ink);
+  background: var(--apple-surface-soft);
+}
+
+.apple-motion-card .finder-select.is-selected {
+  color: #fff;
+  background: var(--apple-blue);
+}
+
+.apple-motion-card .finder-candidate-actions a {
+  color: var(--apple-blue);
+}
+
+.finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-header {
+  min-height: auto;
+  padding: 1rem;
+}
+
+.finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-header h3 {
+  font-size: 1rem;
+}
+
+.finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-header p,
+.finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-body,
+.finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-actions a {
+  display: none;
+}
+
+.finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-stage {
+  height: 145px;
+  min-height: 145px;
+}
+
+.finder-choice-deck[data-layout="focus"] .apple-motion-primary .finder-candidate-stage {
+  height: 380px;
+  min-height: 380px;
+}
+
+.finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-actions {
+  min-height: 54px;
+  padding: 0.35rem 0.55rem;
+}
+
+.finder-choice-deck[data-layout="compare"] .apple-motion-card .finder-candidate-stage {
+  height: 270px;
+  min-height: 270px;
+}
+
+.finder-choice-deck[data-layout="compare"] .apple-motion-card .finder-candidate-header {
+  min-height: 132px;
+}
+
+.finder-choice-deck[data-layout="compare"] .apple-motion-card .finder-candidate-body {
+  min-height: 156px;
+}
+
+.apple-inspector.finder-inspector {
+  position: sticky;
+  inset-block-start: calc(var(--library-header-height) + 16px);
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--apple-line-strong) 75%, transparent);
+  border-radius: 24px;
+  padding: 1rem;
+  background: color-mix(in srgb, var(--apple-surface-raised) 88%, transparent);
+  box-shadow: var(--apple-shadow-sm);
+  backdrop-filter: blur(26px) saturate(150%);
+  -webkit-backdrop-filter: blur(26px) saturate(150%);
+}
+
+.finder-inspector-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.8rem;
+}
+
+.finder-inspector-heading h2 {
+  margin: 0.35rem 0 0;
+  font-size: 1.3rem;
+  font-weight: 640;
+  letter-spacing: -0.03em;
+}
+
+.finder-inspector-heading > svg {
+  box-sizing: content-box;
+  border-radius: 10px;
+  padding: 0.55rem;
+  color: var(--apple-blue);
+  background: color-mix(in srgb, var(--apple-blue) 10%, transparent);
+}
+
+.finder-inspector-copy {
+  margin: 0.75rem 0 0;
+  color: var(--apple-secondary);
+  font-size: 0.74rem;
+  line-height: 1.55;
+}
+
+.finder-inspector-status.library-sync-status {
+  margin-top: 0.9rem;
+  border: 0;
+  padding: 0;
+  color: var(--apple-tertiary);
+  background: transparent;
+  font-family: var(--sans);
+}
+
+.finder-inspector-controls {
+  max-height: min(52dvh, 570px);
+  overflow: auto;
+  margin: 0.9rem -0.35rem 0;
+  padding: 0 0.35rem;
+  overscroll-behavior: contain;
+}
+
+.finder-inspector-controls .controls-head {
+  padding-block: 0.4rem 0.75rem;
+}
+
+.finder-inspector-controls .control {
+  padding: 0.9rem 0;
+}
+
+.finder-inspector-controls .control-description {
+  display: none;
+}
+
+.finder-inspector-controls .control-number {
+  border: 0;
+  border-radius: 9px;
+  background: var(--apple-surface-soft);
+}
+
+.finder-primary-copy.apple-primary-action {
+  width: 100%;
+  min-height: 50px;
+  margin-top: 0.9rem;
+  border: 0;
+  border-radius: 14px;
+  color: #fff;
+  background: var(--apple-blue);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--apple-blue) 20%, transparent);
+}
+
+.finder-workspace-output {
+  margin-top: 1rem;
+}
+
+.finder-change-hint {
+  color: var(--apple-tertiary);
+  font-size: 0.72rem;
+  text-align: end;
+}
+
+.apple-export-disclosure {
+  overflow: hidden;
+  border: 1px solid var(--apple-line);
+  border-radius: 22px;
+  background: var(--apple-surface);
+  box-shadow: var(--apple-shadow-sm);
+}
+
+.apple-export-disclosure > summary {
+  min-height: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.8rem 1.1rem;
+  list-style: none;
+  cursor: pointer;
+}
+
+.apple-export-disclosure > summary::-webkit-details-marker { display: none; }
+
+.apple-export-disclosure > summary > span {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.apple-export-disclosure > summary strong {
+  font-size: 0.88rem;
+  font-weight: 640;
+}
+
+.apple-export-disclosure > summary small {
+  color: var(--apple-secondary);
+  font-size: 0.72rem;
+}
+
+.apple-export-disclosure > summary svg {
+  transition: transform 240ms var(--apple-spring);
+}
+
+.apple-export-disclosure[open] > summary svg { transform: rotate(180deg); }
+.apple-export-disclosure > .library-export { padding: 0 1rem 1rem; }
+.apple-export-disclosure > .library-export > .library-doc-section-heading { display: none; }
+.apple-export-disclosure .library-code-panel { border-radius: 16px; }
+
+/* Unified motion library */
+.library-catalog-hero-unified {
+  max-width: 900px;
+  padding: clamp(5rem, 9vw, 8rem) 0 2.8rem;
+}
+
+.library-catalog-hero-unified > span {
+  color: var(--apple-blue);
+  font-family: var(--sans);
+  font-size: 0.74rem;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+}
+
+.library-catalog-hero-unified h1 {
+  margin: 0.9rem 0 1.1rem;
+  font-size: clamp(3.7rem, 6vw, 5.6rem);
+  font-weight: 640;
+  line-height: 0.98;
+  letter-spacing: -0.057em;
+}
+
+.library-catalog-hero-unified p {
+  max-width: 42em;
+  color: var(--apple-secondary);
+  font-size: 1.05rem;
+  line-height: 1.62;
+}
+
+.library-catalog-toolbar {
+  border: 1px solid color-mix(in srgb, var(--apple-line-strong) 72%, transparent);
+  border-radius: 26px;
+  padding: 0.85rem;
+  background: color-mix(in srgb, var(--apple-surface-raised) 88%, transparent);
+  box-shadow: var(--apple-shadow-sm);
+  backdrop-filter: blur(24px) saturate(150%);
+  -webkit-backdrop-filter: blur(24px) saturate(150%);
+}
+
+.library-catalog-toolbar-primary {
+  display: grid;
+  grid-template-columns: minmax(280px, 1fr) auto;
+  gap: 0.75rem;
+}
+
+.library-catalog-toolbar .library-catalog-search {
+  min-height: 52px;
+  border: 0;
+  border-radius: 15px;
+  padding: 0 0.9rem;
+  background: var(--apple-surface);
+  box-shadow: inset 0 0 0 1px var(--apple-line);
+}
+
+.library-catalog-toolbar .library-catalog-search:focus-within {
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--apple-blue) 65%, transparent), 0 0 0 4px color-mix(in srgb, var(--apple-blue) 10%, transparent);
+}
+
+.library-surface-control.library-surface-tabs {
+  display: flex;
+  gap: 0.2rem;
+  border: 0;
+  border-radius: 15px;
+  padding: 0.25rem;
+  background: color-mix(in srgb, var(--apple-ink) 6%, transparent);
+}
+
+.library-surface-control.library-surface-tabs button {
+  min-height: 44px;
+  flex: 1;
+  border: 0;
+  border-radius: 12px;
+  padding: 0 0.8rem;
+  color: var(--apple-secondary);
+  background: transparent;
+}
+
+.library-surface-control.library-surface-tabs button.is-active {
+  color: var(--apple-ink);
+  background: var(--apple-surface);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.04);
+}
+
+.library-catalog-toolbar-secondary {
+  margin-top: 0.7rem;
+}
+
+.library-category-filter {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
+.library-category-filter-heading {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding-inline-start: 0.4rem;
+  color: var(--apple-tertiary);
+  font-size: 0.68rem;
+  white-space: nowrap;
+}
+
+.library-category-filter-options {
+  min-width: 0;
+  display: flex;
+  gap: 0.3rem;
+  overflow-x: auto;
+  padding: 0.15rem 0.2rem 0.25rem;
+  scrollbar-width: none;
+}
+
+.library-category-filter-options::-webkit-scrollbar { display: none; }
+
+.library-category-filter-options button {
+  min-height: 38px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 999px;
+  padding: 0 0.75rem;
+  color: var(--apple-secondary);
+  background: transparent;
+  font-size: 0.72rem;
+}
+
+.library-category-filter-options button:hover,
+.library-category-filter-options button.is-active {
+  color: var(--apple-ink);
+  background: var(--apple-surface);
+  box-shadow: inset 0 0 0 1px var(--apple-line);
+}
+
+.library-category-filter-options button small {
+  color: var(--apple-tertiary);
+  font-size: 0.63rem;
+}
+
+.library-catalog-toolbar .library-results-meta {
+  min-height: 72px;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1rem;
+  border-top: 1px solid var(--apple-line);
+  margin-top: 0.55rem;
+  padding: 0.7rem 0.5rem 0;
+}
+
+.library-catalog-toolbar .library-results-meta > div {
+  display: grid;
+  gap: 0.15rem;
+}
+
+.library-catalog-toolbar .library-results-meta strong {
+  font-size: 0.88rem;
+  font-weight: 640;
+}
+
+.library-catalog-toolbar .library-results-meta span,
+.library-catalog-toolbar .library-results-meta p {
+  color: var(--apple-tertiary);
+  font-size: 0.7rem;
+}
+
+.library-catalog-toolbar .library-results-meta p {
+  margin: 0;
+  text-align: center;
+}
+
+.library-catalog-toolbar .library-results-meta button {
+  min-height: 38px;
+  border: 0;
+  border-radius: 999px;
+  padding: 0 0.8rem;
+  color: var(--apple-blue);
+  background: color-mix(in srgb, var(--apple-blue) 10%, transparent);
+}
+
+.library-catalog-layout.is-unified {
+  display: block;
+  padding: 2rem 0 7rem;
+}
+
+.library-catalog-layout.is-unified .library-catalog-results {
+  min-width: 0;
+}
+
+.library-catalog-layout.is-unified .library-catalog-group {
+  padding: 2.7rem 0 1.2rem;
+}
+
+.library-catalog-layout.is-unified .library-section-heading h2 {
+  font-size: clamp(1.8rem, 3vw, 2.5rem);
+  font-weight: 630;
+  letter-spacing: -0.035em;
+}
+
+.library-catalog-layout.is-unified .library-section-heading > div > span {
+  color: var(--apple-tertiary);
+  font-family: var(--sans);
+}
+
+.library-catalog-layout.is-unified .library-section-heading > a {
+  color: var(--apple-blue);
+}
+
+.library-catalog-layout.is-unified .library-card-grid.is-component,
+.library-catalog-layout.is-unified .library-card-grid.is-playground,
+.library-catalog-layout.is-unified .library-card-grid.is-guide {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.library-catalog-layout.is-unified .library-card {
+  overflow: hidden;
+  border: 0;
+  border-radius: 20px;
+  background: var(--apple-surface);
+  box-shadow: var(--apple-shadow-sm);
+  transition: transform 320ms var(--apple-spring), box-shadow 320ms var(--apple-spring);
+}
+
+.library-catalog-layout.is-unified .library-card:hover {
+  border-color: transparent;
+  transform: translateY(-3px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04), 0 22px 50px rgba(0, 0, 0, 0.08);
+}
+
+.library-catalog-layout.is-unified .library-card .motion-thumb,
+.library-catalog-layout.is-unified .library-guide-art {
+  border: 0;
+  border-radius: 0;
+  background-color: var(--apple-surface-soft);
+  background-image: none;
+}
+
+.library-catalog-layout.is-unified .library-card-body {
+  min-height: 138px;
+  padding: 1rem 1.05rem 1.2rem;
+}
+
+.library-catalog-layout.is-unified .library-card-body h3 {
+  font-size: 1rem;
+  font-weight: 640;
+  letter-spacing: -0.02em;
+}
+
+.library-catalog-layout.is-unified .library-card-body p {
+  color: var(--apple-secondary);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+/* Compact open-source footer */
+.library-footer-compact.library-footer {
+  width: min(var(--library-max), calc(100% - 48px));
+  border-top: 1px solid var(--apple-line);
+  padding: 3.5rem 0 1.5rem;
+}
+
+.library-footer-compact .library-footer-main {
+  grid-template-columns: minmax(260px, 1.2fr) minmax(160px, 0.7fr) minmax(180px, 0.7fr);
+  gap: clamp(2rem, 6vw, 6rem);
+  padding: 0 0 3rem;
+}
+
+.library-footer-compact .library-footer-brand p {
+  max-width: 26em;
+  color: var(--apple-tertiary);
+  font-size: 0.75rem;
+}
+
+.library-footer-links,
+.library-footer-resources {
+  display: grid;
+  align-content: start;
+  gap: 0.75rem;
+}
+
+.library-footer-links a,
+.library-footer-resources a {
+  min-height: 28px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: var(--apple-secondary);
+  font-size: 0.75rem;
+}
+
+.library-footer-links a:hover,
+.library-footer-resources a:hover {
+  color: var(--apple-blue);
+}
+
+.library-footer-compact .library-footer-meta {
+  color: var(--apple-tertiary);
+  font-size: 0.67rem;
+}
+
+@media (max-width: 1040px) {
+  .apple-workspace-shell.finder-workspace-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .apple-inspector.finder-inspector {
+    position: relative;
+    inset-block-start: auto;
+  }
+
+  .finder-inspector-controls {
+    max-height: none;
+  }
+
+  .library-catalog-toolbar-primary {
+    grid-template-columns: 1fr;
+  }
+
+  .library-catalog-layout.is-unified .library-card-grid.is-component,
+  .library-catalog-layout.is-unified .library-card-grid.is-playground,
+  .library-catalog-layout.is-unified .library-card-grid.is-guide {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .library-header-compact .library-header-inner {
+    width: min(100% - 28px, var(--library-max));
+    grid-template-columns: 1fr auto auto;
+    gap: 0.25rem;
+  }
+
+  .library-header-compact .library-primary-nav {
+    border-radius: 12px;
+    padding: 0;
+    background: transparent;
+  }
+
+  .library-header-compact .library-primary-nav .is-finder {
+    display: none;
+  }
+
+  .library-header-compact .library-primary-nav .is-library {
+    min-width: 44px;
+    min-height: 44px;
+    border-radius: 12px;
+    padding: 0 0.65rem;
+    background: color-mix(in srgb, var(--apple-ink) 6%, transparent);
+  }
+
+  .library-header-compact .library-github-link {
+    display: none;
+  }
+
+  .library-utility-menu > summary {
+    width: 44px;
+    height: 44px;
+    border-radius: 12px;
+    padding: 0;
+    background: color-mix(in srgb, var(--apple-ink) 6%, transparent);
+  }
+
+  .library-utility-menu > summary span { display: none; }
+
+  .apple-finder-intake.finder-hero {
+    min-height: auto;
+    padding: 4.25rem 0 3.5rem;
+  }
+
+  .apple-finder-intake .finder-hero-copy h1 {
+    max-width: 8em;
+    font-size: clamp(2.75rem, 13vw, 3.8rem);
+  }
+
+  .apple-finder-intake .finder-hero-copy p {
+    font-size: 0.96rem;
+  }
+
+  .apple-finder-intake.has-result {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0;
+    padding: 1rem 0 0.75rem;
+  }
+
+  .apple-finder-intake.has-result .finder-hero-copy {
+    display: none;
+  }
+
+  .apple-finder-intake.has-result .apple-search-pill > label,
+  .apple-finder-intake.has-result .apple-search-pill > small {
+    display: none;
+  }
+
+  .apple-search-pill .finder-search-field {
+    grid-template-columns: auto 1fr;
+    padding: 0.5rem 0.55rem 0.55rem 0.9rem;
+  }
+
+  .apple-search-pill .finder-search-field button {
+    grid-column: 1 / -1;
+    width: 100%;
+  }
+
+  .apple-finder-intake.has-result .apple-search-pill .finder-search-field {
+    min-height: 58px;
+    grid-template-columns: auto 1fr auto;
+    padding: 0.25rem 0.3rem 0.25rem 0.85rem;
+  }
+
+  .apple-finder-intake.has-result .apple-search-pill .finder-search-field button {
+    width: 48px;
+    min-height: 48px;
+    grid-column: auto;
+    padding: 0;
+    font-size: 0;
+  }
+
+  .apple-finder-workspace.finder-results {
+    padding: 1.8rem 0 5rem;
+  }
+
+  .finder-workspace-heading {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
+    margin-bottom: 0.8rem;
+  }
+
+  .finder-workspace-heading > div > span {
+    display: none;
+  }
+
+  .finder-workspace-heading h2 {
+    margin: 0;
+    font-size: 1.65rem;
+  }
+
+  .finder-match-summary { max-width: none; }
+
+  .finder-match-summary > p {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .finder-match-summary > div {
+    display: none;
+  }
+
+  .apple-motion-chooser.finder-compare {
+    border-radius: 22px;
+  }
+
+  .apple-motion-chooser .finder-compare-toolbar {
+    align-items: center;
+    padding: 0.55rem 0.65rem 0.55rem 0.85rem;
+  }
+
+  .finder-compare-status strong { display: none; }
+
+  .finder-compare-actions .ml-button {
+    min-width: 44px;
+    padding: 0 0.65rem;
+  }
+
+  .finder-choice-deck[data-layout="focus"] {
+    grid-template-columns: 1fr 1fr;
+    grid-template-rows: auto auto;
+  }
+
+  .finder-choice-deck[data-layout="focus"] .finder-candidate.is-selected {
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+
+  .finder-choice-deck[data-layout="focus"] .apple-motion-alternative {
+    grid-row: 2;
+  }
+
+  .finder-choice-deck[data-layout="focus"] .apple-motion-primary .finder-candidate-stage {
+    height: 300px;
+    min-height: 300px;
+  }
+
+  .finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-stage {
+    height: 118px;
+    min-height: 118px;
+  }
+
+  .finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-meta span,
+  .finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-actions {
+    display: none;
+  }
+
+  .finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-header {
+    min-height: 76px;
+  }
+
+  .finder-choice-deck[data-layout="compare"] {
+    grid-template-columns: 1fr;
+  }
+
+  .finder-choice-deck[data-layout="compare"] .apple-motion-card {
+    display: grid;
+    grid-template-columns: minmax(110px, 0.6fr) minmax(0, 1.4fr);
+    grid-template-rows: auto auto;
+  }
+
+  .finder-choice-deck[data-layout="compare"] .finder-candidate-header {
+    min-height: auto;
+    padding: 0.8rem;
+  }
+
+  .finder-choice-deck[data-layout="compare"] .finder-candidate-header p,
+  .finder-choice-deck[data-layout="compare"] .finder-candidate-body {
+    display: none;
+  }
+
+  .finder-choice-deck[data-layout="compare"] .apple-motion-card .finder-candidate-stage {
+    height: 150px;
+    min-height: 150px;
+    grid-column: 2;
+    grid-row: 1 / 3;
+    border-block: 0;
+    border-left: 1px solid var(--apple-line);
+  }
+
+  .finder-choice-deck[data-layout="compare"] .finder-candidate-actions {
+    min-height: 52px;
+    border-top: 1px solid var(--apple-line);
+    padding: 0.3rem 0.4rem;
+  }
+
+  .finder-choice-deck[data-layout="compare"] .finder-candidate-actions a { display: none; }
+
+  .apple-inspector.finder-inspector {
+    border-radius: 22px;
+  }
+
+  .apple-export-disclosure > summary {
+    min-height: 78px;
+  }
+
+  .library-catalog-hero-unified {
+    padding: 4.5rem 0 2.2rem;
+  }
+
+  .library-catalog-hero-unified h1 {
+    font-size: clamp(3rem, 14vw, 4.2rem);
+  }
+
+  .library-catalog-toolbar {
+    border-radius: 22px;
+    padding: 0.65rem;
+  }
+
+  .library-surface-control.library-surface-tabs {
+    overflow-x: auto;
+  }
+
+  .library-surface-control.library-surface-tabs button {
+    flex: 0 0 auto;
+    padding: 0 0.7rem;
+  }
+
+  .library-surface-control.library-surface-tabs button small {
+    display: none;
+  }
+
+  .library-category-filter {
+    display: grid;
+    gap: 0.35rem;
+  }
+
+  .library-category-filter-heading {
+    padding: 0 0.35rem;
+  }
+
+  .library-catalog-toolbar .library-results-meta {
+    grid-template-columns: 1fr auto;
+  }
+
+  .library-catalog-toolbar .library-results-meta p {
+    display: none;
+  }
+
+  .library-catalog-layout.is-unified .library-card-grid.is-component,
+  .library-catalog-layout.is-unified .library-card-grid.is-playground,
+  .library-catalog-layout.is-unified .library-card-grid.is-guide {
+    display: flex;
+    gap: 0.75rem;
+    overflow-x: auto;
+    padding: 0.15rem 0.15rem 1rem;
+    scroll-padding-inline: 0.15rem;
+    scroll-snap-type: x proximity;
+    scrollbar-width: none;
+  }
+
+  .library-catalog-layout.is-unified .library-card-grid::-webkit-scrollbar {
+    display: none;
+  }
+
+  .library-catalog-layout.is-unified .library-card {
+    width: min(82vw, 300px);
+    flex: 0 0 min(82vw, 300px);
+    scroll-snap-align: start;
+  }
+
+  .library-footer-compact.library-footer {
+    width: min(100% - 28px, var(--library-max));
+  }
+
+  .library-footer-compact .library-footer-main {
+    grid-template-columns: 1fr 1fr;
+    gap: 2.25rem 1rem;
+  }
+
+  .library-footer-compact .library-footer-brand {
+    grid-column: 1 / -1;
+  }
+
+  .library-footer-compact .library-footer-meta {
+    align-items: flex-start;
+    gap: 0.8rem;
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .library-header.library-header-compact,
+  .library-utility-popover,
+  .library-catalog-toolbar,
+  .apple-inspector.finder-inspector {
+    background: var(--apple-surface);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .library-utility-popover {
+    animation: apple-fade-in 180ms ease both;
+  }
+
+  .apple-motion-card.finder-candidate,
+  .library-catalog-layout.is-unified .library-card,
+  .apple-export-disclosure > summary svg {
+    transition: opacity 180ms ease, color 180ms ease, background-color 180ms ease;
+    transform: none !important;
+  }
+}
+
+@keyframes apple-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* Recipe workspace */
+.apple-recipe-page {
+  padding: 0 0 7rem;
+}
+
+.apple-recipe-workspace.library-entry {
+  display: block;
+}
+
+.apple-recipe-main.library-entry-main {
+  width: 100%;
+  max-width: none;
+  min-width: 0;
+}
+
+.apple-recipe-breadcrumbs.library-breadcrumbs {
+  min-height: 44px;
+  gap: 0.55rem;
+  margin-top: 2rem;
+  color: var(--apple-tertiary);
+  font-size: 0.72rem;
+}
+
+.apple-recipe-breadcrumbs a:hover {
+  color: var(--apple-blue);
+}
+
+.apple-recipe-hero.library-entry-header {
+  min-height: 280px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 2rem;
+  border: 0;
+  padding: 3.2rem 0 3.5rem;
+}
+
+.apple-recipe-identity {
+  max-width: 820px;
+}
+
+.apple-recipe-meta.library-entry-meta {
+  gap: 0.6rem;
+  margin: 0;
+}
+
+.apple-recipe-meta span,
+.apple-recipe-meta code {
+  color: var(--apple-blue);
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  font-weight: 650;
+  letter-spacing: 0.03em;
+}
+
+.apple-recipe-meta code {
+  border-radius: 999px;
+  padding: 0.25rem 0.55rem;
+  color: var(--apple-tertiary);
+  background: color-mix(in srgb, var(--apple-ink) 6%, transparent);
+  font-family: var(--mono);
+  font-weight: 500;
+}
+
+.apple-recipe-hero h1,
+.apple-recipe-hero h2 {
+  max-width: 10em;
+  margin: 0.75rem 0 1rem;
+  font-size: clamp(3.8rem, 6vw, 5.8rem);
+  font-weight: 640;
+  line-height: 0.98;
+  letter-spacing: -0.057em;
+}
+
+.apple-recipe-hero p {
+  max-width: 42em;
+  margin: 0;
+  color: var(--apple-secondary);
+  font-size: 1.03rem;
+  line-height: 1.6;
+}
+
+.apple-recipe-primary-action .ml-button {
+  min-height: 50px;
+  border: 0;
+  border-radius: 14px;
+  padding: 0 1.1rem;
+  color: #fff;
+  background: var(--apple-blue);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--apple-blue) 20%, transparent);
+}
+
+.apple-recipe-primary-action .ml-button:hover {
+  background: var(--apple-blue-hover);
+}
+
+.apple-workbench-stage.library-preview-section {
+  border: 0;
+  padding: 0 0 1rem;
+}
+
+.apple-workbench-heading.library-doc-section-heading {
+  align-items: end;
+  margin-bottom: 1.25rem;
+}
+
+.apple-workbench-heading > div > span {
+  color: var(--apple-blue);
+  font-family: var(--sans);
+  font-size: 0.7rem;
+  font-weight: 650;
+}
+
+.apple-workbench-heading h2,
+.apple-workbench-heading h3 {
+  margin: 0.45rem 0 0;
+  font-size: clamp(1.9rem, 3vw, 2.75rem);
+  font-weight: 630;
+  letter-spacing: -0.04em;
+}
+
+.apple-workbench-heading p {
+  color: var(--apple-secondary);
+  font-size: 0.82rem;
+  line-height: 1.55;
+}
+
+.apple-workbench-stage .apple-preview-toolbar.library-preview-toolbar {
+  min-height: 52px;
+  border: 1px solid var(--apple-line);
+  border-bottom: 0;
+  border-radius: 18px 18px 0 0;
+  padding: 0 0.55rem;
+  background: color-mix(in srgb, var(--apple-surface-raised) 82%, transparent);
+  backdrop-filter: blur(20px) saturate(150%);
+  -webkit-backdrop-filter: blur(20px) saturate(150%);
+}
+
+.apple-workbench-stage .library-device-switcher {
+  border-radius: 12px;
+  padding: 0.15rem;
+  background: color-mix(in srgb, var(--apple-ink) 6%, transparent);
+}
+
+.apple-workbench-stage .library-device-switcher button {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+}
+
+.apple-workbench-stage .library-device-switcher button.is-active {
+  color: var(--apple-ink);
+  background: var(--apple-surface);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.04);
+}
+
+.apple-workbench-stage .library-reduced-toggle {
+  border-radius: 11px;
+  padding: 0 0.65rem;
+}
+
+.apple-workbench.library-workbench {
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 340px);
+  align-items: stretch;
+  gap: 1rem;
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.apple-preview-stage.library-preview-frame {
+  min-height: 650px;
+  overflow: hidden;
+  border: 1px solid var(--apple-line);
+  border-radius: 0 0 26px 26px;
+  padding: 1rem;
+  background: var(--apple-surface-soft);
+  background-image: none;
+  box-shadow: var(--apple-shadow-sm);
+}
+
+.apple-preview-stage.library-preview-frame .preview-panel {
+  overflow: hidden;
+  border-radius: 18px;
+}
+
+.apple-preview-stage.library-preview-frame .stage {
+  min-height: 520px;
+  border: 0;
+  border-radius: 18px;
+  background: var(--apple-surface);
+  box-shadow: inset 0 0 0 1px var(--apple-line);
+}
+
+.apple-preview-stage .preview-toolbar .ml-button {
+  min-height: 40px;
+  border: 0;
+  border-radius: 11px;
+  color: var(--apple-ink);
+  background: color-mix(in srgb, var(--apple-surface-raised) 88%, transparent);
+  box-shadow: var(--apple-shadow-sm);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.library-parameter-panel.apple-inspector {
+  align-self: stretch;
+  overflow: hidden;
+  border: 1px solid color-mix(in srgb, var(--apple-line-strong) 72%, transparent);
+  border-radius: 24px;
+  background: color-mix(in srgb, var(--apple-surface-raised) 90%, transparent);
+  box-shadow: var(--apple-shadow-sm);
+  backdrop-filter: blur(26px) saturate(150%);
+  -webkit-backdrop-filter: blur(26px) saturate(150%);
+}
+
+.library-parameter-panel .apple-inspector-status.library-sync-status {
+  min-height: 48px;
+  border-bottom: 1px solid var(--apple-line);
+  padding: 0 1rem;
+  color: var(--apple-tertiary);
+  font-family: var(--sans);
+}
+
+.library-parameter-panel.apple-inspector .controls-head {
+  padding: 0.9rem 1rem;
+}
+
+.library-parameter-panel.apple-inspector .control {
+  padding: 0.95rem 1rem;
+}
+
+.library-parameter-panel.apple-inspector .control-description {
+  display: none;
+}
+
+.library-parameter-panel.apple-inspector .control-number {
+  border: 0;
+  border-radius: 9px;
+  background: var(--apple-surface-soft);
+}
+
+.apple-inspector-disclosure {
+  border-top: 1px solid var(--apple-line);
+}
+
+.apple-inspector-disclosure > summary {
+  min-height: 52px;
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0 1rem;
+  color: var(--apple-secondary);
+  font-size: 0.74rem;
+  font-weight: 600;
+  list-style: none;
+  cursor: pointer;
+}
+
+.apple-inspector-disclosure > summary::-webkit-details-marker { display: none; }
+
+.apple-inspector-disclosure > summary small {
+  min-width: 22px;
+  height: 22px;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  color: var(--apple-tertiary);
+  background: var(--apple-surface-soft);
+}
+
+.apple-inspector-disclosure > summary svg {
+  transition: transform 240ms var(--apple-spring);
+}
+
+.apple-inspector-disclosure[open] > summary svg { transform: rotate(180deg); }
+
+.apple-inspector-disclosure-body {
+  border-top: 1px solid var(--apple-line);
+}
+
+.apple-inspector-disclosure-body .controls-head {
+  display: none;
+}
+
+.apple-output-disclosure {
+  margin-top: 1rem;
+}
+
+.apple-disclosure {
+  overflow: hidden;
+  border: 1px solid var(--apple-line);
+  border-radius: 20px;
+  background: var(--apple-surface);
+  box-shadow: var(--apple-shadow-sm);
+}
+
+.apple-disclosure-summary {
+  min-height: 84px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.2rem;
+  list-style: none;
+  cursor: pointer;
+}
+
+.apple-disclosure-summary::-webkit-details-marker { display: none; }
+
+.apple-disclosure-summary > span {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.apple-disclosure-summary small {
+  color: var(--apple-blue);
+  font-size: 0.65rem;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+}
+
+.apple-disclosure-summary strong {
+  color: var(--apple-ink);
+  font-size: 0.95rem;
+  font-weight: 640;
+}
+
+.apple-disclosure-summary em {
+  max-width: 60em;
+  color: var(--apple-secondary);
+  font-size: 0.72rem;
+  font-style: normal;
+  line-height: 1.45;
+}
+
+.apple-disclosure-summary > svg {
+  flex: 0 0 auto;
+  color: var(--apple-tertiary);
+  transition: transform 240ms var(--apple-spring);
+}
+
+.apple-disclosure[open] > .apple-disclosure-summary > svg {
+  transform: rotate(180deg);
+}
+
+.apple-disclosure-body {
+  border-top: 1px solid var(--apple-line);
+  padding: 1rem 1.2rem 1.3rem;
+  animation: apple-disclosure-in 240ms var(--apple-spring) both;
+}
+
+@keyframes apple-disclosure-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.apple-output-body .library-export {
+  border: 0;
+  padding: 0;
+}
+
+.apple-output-body .library-export > .library-doc-section-heading {
+  display: none;
+}
+
+.apple-output-body .library-code-panel {
+  border-radius: 17px;
+}
+
+.apple-reference-library {
+  padding: clamp(5rem, 8vw, 7rem) 0 2rem;
+}
+
+.apple-reference-library-heading {
+  margin-bottom: 1.25rem;
+}
+
+.apple-reference-library-heading h2,
+.apple-reference-library-heading h3 {
+  margin: 0;
+  font-size: clamp(2rem, 3.5vw, 3.2rem);
+  font-weight: 630;
+  letter-spacing: -0.04em;
+}
+
+.apple-reference-section.library-content-section {
+  border: 0;
+  padding: 0 0 0.7rem;
+}
+
+.apple-reference-section .library-vocabulary-list,
+.apple-reference-section .library-guidance-grid {
+  margin-top: 0;
+}
+
+.apple-reference-section .library-vocabulary-list article,
+.apple-reference-section .library-guidance-grid article,
+.apple-reference-section .library-accessibility-note {
+  border: 0;
+  border-radius: 16px;
+  background: var(--apple-surface-soft);
+}
+
+.apple-reference-section .library-check-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.apple-reference-section .library-check-list li {
+  border: 0;
+  border-radius: 14px;
+  background: var(--apple-surface-soft);
+}
+
+.apple-reference-section .library-parameter-table {
+  overflow: hidden;
+  border: 0;
+  border-radius: 14px;
+  background: var(--apple-surface-soft);
+}
+
+.apple-reference-section .library-related-links {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.apple-reference-section .library-related-links a {
+  border: 0;
+  border-radius: 14px;
+  background: var(--apple-surface-soft);
+}
+
+.apple-reference-section .library-inline-link {
+  color: var(--apple-blue);
+}
+
+.apple-recipe-pagination.library-entry-pagination {
+  gap: 0.75rem;
+  border: 0;
+  padding: 3rem 0 0;
+}
+
+.apple-recipe-pagination a {
+  min-height: 70px;
+  border: 0;
+  border-radius: 18px;
+  padding: 0.9rem 1rem;
+  background: var(--apple-surface);
+  box-shadow: var(--apple-shadow-sm);
+}
+
+.apple-recipe-pagination a:hover {
+  color: var(--apple-blue);
+}
+
+/* Category acquisition pages */
+.apple-category-page {
+  display: block;
+  padding: 2rem 0 7rem;
+}
+
+.apple-category-page .library-category-main {
+  min-width: 0;
+}
+
+.apple-category-page .library-category-header {
+  min-height: 360px;
+  display: grid;
+  align-content: center;
+  border: 0;
+  padding: 4rem 0;
+}
+
+.apple-category-page .library-category-header > span {
+  color: var(--apple-blue);
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  font-weight: 650;
+}
+
+.apple-category-page .library-category-header h1 {
+  margin: 0.8rem 0 1rem;
+  font-size: clamp(3.8rem, 6vw, 5.6rem);
+  font-weight: 640;
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+.apple-category-page .library-category-header p {
+  max-width: 42em;
+  color: var(--apple-secondary);
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.apple-category-page .library-category-stats {
+  width: max-content;
+  min-height: 48px;
+  border: 0;
+  border-radius: 999px;
+  margin-top: 1.4rem;
+  padding: 0 1rem;
+  background: var(--apple-surface);
+  box-shadow: var(--apple-shadow-sm);
+}
+
+.apple-category-page .library-category-group {
+  border: 0;
+  padding: 3rem 0 1rem;
+}
+
+.apple-category-page .library-card-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.apple-category-page .library-card {
+  overflow: hidden;
+  border: 0;
+  border-radius: 20px;
+  background: var(--apple-surface);
+  box-shadow: var(--apple-shadow-sm);
+}
+
+.apple-category-page .library-card .motion-thumb,
+.apple-category-page .library-guide-art {
+  border: 0;
+  border-radius: 0;
+  background-color: var(--apple-surface-soft);
+}
+
+/* Vocabulary keeps its long-form SEO value with a calmer editorial shell. */
+.vocabulary-page {
+  padding-bottom: 8rem;
+}
+
+.vocabulary-hero {
+  max-width: 920px;
+  padding: clamp(5rem, 9vw, 8rem) 0 3rem;
+}
+
+.vocabulary-hero > span {
+  color: var(--apple-blue);
+  font-family: var(--sans);
+  font-size: 0.72rem;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+}
+
+.vocabulary-hero h1 {
+  margin: 0.8rem 0 1rem;
+  font-size: clamp(3.8rem, 6vw, 5.6rem);
+  font-weight: 640;
+  line-height: 0.98;
+  letter-spacing: -0.055em;
+}
+
+.vocabulary-hero p {
+  max-width: 44em;
+  color: var(--apple-secondary);
+  font-size: 1.02rem;
+  line-height: 1.62;
+}
+
+.vocabulary-toolbar {
+  min-height: 70px;
+  border: 1px solid var(--apple-line);
+  border-radius: 22px;
+  padding: 0.7rem;
+  background: color-mix(in srgb, var(--apple-surface-raised) 88%, transparent);
+  box-shadow: var(--apple-shadow-sm);
+  backdrop-filter: blur(22px) saturate(150%);
+  -webkit-backdrop-filter: blur(22px) saturate(150%);
+}
+
+.vocabulary-toolbar label {
+  min-height: 48px;
+  border: 0;
+  border-radius: 14px;
+  background: var(--apple-surface);
+  box-shadow: inset 0 0 0 1px var(--apple-line);
+}
+
+.vocabulary-index {
+  overflow-x: auto;
+  border: 0;
+  margin: 1rem 0 0;
+  padding: 0.3rem;
+  background: transparent;
+  scrollbar-width: none;
+}
+
+.vocabulary-index::-webkit-scrollbar { display: none; }
+
+.vocabulary-index a {
+  min-height: 40px;
+  flex: 0 0 auto;
+  border: 0;
+  border-radius: 999px;
+  background: var(--apple-surface);
+  box-shadow: inset 0 0 0 1px var(--apple-line);
+}
+
+.vocabulary-group {
+  border: 0;
+  padding: 5rem 0 0;
+}
+
+.vocabulary-group > header {
+  border: 0;
+  padding: 0 0 1.4rem;
+}
+
+.vocabulary-group > header h2 {
+  font-size: clamp(2rem, 3.5vw, 3rem);
+  font-weight: 630;
+  letter-spacing: -0.04em;
+}
+
+.vocabulary-term-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.8rem;
+  border: 0;
+}
+
+.vocabulary-term-list article {
+  border: 0;
+  border-radius: 20px;
+  padding: 1.2rem;
+  background: var(--apple-surface);
+  box-shadow: var(--apple-shadow-sm);
+}
+
+.vocabulary-term-list article.is-canonical {
+  box-shadow: inset 0 3px 0 var(--apple-blue), var(--apple-shadow-sm);
+}
+
+.vocabulary-definition,
+.vocabulary-translation,
+.vocabulary-distinction {
+  border: 0;
+  border-radius: 13px;
+  background: var(--apple-surface-soft);
+}
+
+.vocabulary-open-link {
+  min-height: 44px;
+  color: var(--apple-blue);
+}
+
+@media (max-width: 1040px) {
+  .apple-workbench.library-workbench {
+    grid-template-columns: 1fr;
+  }
+
+  .library-parameter-panel.apple-inspector {
+    border-radius: 22px;
+  }
+
+  .apple-category-page .library-card-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 760px) {
+  .apple-recipe-breadcrumbs.library-breadcrumbs {
+    margin-top: 1.2rem;
+  }
+
+  .apple-recipe-hero.library-entry-header {
+    min-height: auto;
+    grid-template-columns: 1fr;
+    align-items: start;
+    padding: 3rem 0 2.8rem;
+  }
+
+  .apple-recipe-hero h1,
+  .apple-recipe-hero h2 {
+    font-size: clamp(3rem, 15vw, 4.25rem);
+  }
+
+  .apple-recipe-primary-action .ml-button {
+    width: 100%;
+  }
+
+  .apple-workbench-heading.library-doc-section-heading {
+    grid-template-columns: 1fr;
+    gap: 0.8rem;
+  }
+
+  .apple-workbench-stage .apple-preview-toolbar.library-preview-toolbar {
+    min-height: 56px;
+    border-radius: 16px 16px 0 0;
+  }
+
+  .apple-preview-stage.library-preview-frame {
+    min-height: 440px;
+    border-radius: 0 0 20px 20px;
+    padding: 0.65rem;
+  }
+
+  .apple-preview-stage.library-preview-frame .stage {
+    min-height: 350px;
+    border-radius: 15px;
+  }
+
+  .apple-preview-stage.library-preview-frame .preview-panel {
+    border-radius: 15px;
+  }
+
+  .library-parameter-panel.apple-inspector {
+    border-radius: 20px;
+  }
+
+  .apple-disclosure-summary {
+    min-height: 78px;
+    padding: 0.85rem 1rem;
+  }
+
+  .apple-disclosure-summary em {
+    max-width: 30em;
+  }
+
+  .apple-disclosure-body {
+    padding: 0.85rem 1rem 1rem;
+  }
+
+  .apple-reference-section .library-check-list,
+  .apple-reference-section .library-related-links,
+  .apple-category-page .library-card-grid,
+  .vocabulary-term-list {
+    grid-template-columns: 1fr;
+  }
+
+  .apple-category-page {
+    padding-top: 1rem;
+  }
+
+  .apple-category-page .library-category-header {
+    min-height: auto;
+    padding: 3rem 0;
+  }
+
+  .apple-category-page .library-category-header h1,
+  .vocabulary-hero h1 {
+    font-size: clamp(3rem, 14vw, 4.1rem);
+  }
+
+  .vocabulary-toolbar {
+    align-items: stretch;
+    border-radius: 19px;
+  }
+
+  .vocabulary-toolbar > span {
+    padding-inline: 0.45rem;
+  }
+
+  .vocabulary-group > header {
+    grid-template-columns: auto 1fr;
+  }
+
+  .vocabulary-group > header > small {
+    display: none;
+  }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .apple-workbench-stage .apple-preview-toolbar.library-preview-toolbar,
+  .library-parameter-panel.apple-inspector,
+  .vocabulary-toolbar {
+    background: var(--apple-surface);
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .apple-disclosure-body {
+    animation: apple-fade-in 180ms ease both;
+  }
+}

--- a/src/components/CatalogSidebar.tsx
+++ b/src/components/CatalogSidebar.tsx
@@ -14,6 +14,9 @@ type CatalogSidebarProps = {
   activeRecipeId?: string;
   compact?: boolean;
   surfaceType?: MotionSurfaceType;
+  filterMode?: boolean;
+  selectedCategoryId?: string;
+  onCategoryChange?: (categoryId?: string) => void;
 };
 
 export function CatalogSidebar({
@@ -21,7 +24,10 @@ export function CatalogSidebar({
   activeCategoryId,
   activeRecipeId,
   compact = false,
-  surfaceType
+  surfaceType,
+  filterMode = false,
+  selectedCategoryId,
+  onCategoryChange
 }: CatalogSidebarProps) {
   const { t } = useTranslation();
   const [query, setQuery] = useState("");
@@ -43,6 +49,40 @@ export function CatalogSidebar({
       entries: filteredRecipes.filter((recipe) => recipe.categoryId === category.id)
     }))
     .filter((group) => group.entries.length > 0);
+
+  if (filterMode) {
+    return (
+      <div className="library-category-filter" aria-label={t("common.category")}>
+        <div className="library-category-filter-heading">
+          <span>{t("common.category")}</span>
+          <small>{filteredRecipes.length}</small>
+        </div>
+        <div className="library-category-filter-options" role="group" aria-label={t("catalog.indexTitle")}>
+          <button
+            type="button"
+            className={!selectedCategoryId ? "is-active" : undefined}
+            aria-pressed={!selectedCategoryId}
+            onClick={() => onCategoryChange?.()}
+          >
+            <span>{t("common.allEntries")}</span>
+            <small>{filteredRecipes.length}</small>
+          </button>
+          {groupedCategories.map(({ category, entries }) => (
+            <button
+              type="button"
+              key={category.id}
+              className={selectedCategoryId === category.id ? "is-active" : undefined}
+              aria-pressed={selectedCategoryId === category.id}
+              onClick={() => onCategoryChange?.(category.id)}
+            >
+              <span>{text(category.name, locale)}</span>
+              <small>{entries.length}</small>
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <aside className={compact ? "library-sidebar is-compact" : "library-sidebar"} aria-label={t("catalog.indexTitle")}>

--- a/src/components/FinderExportDisclosure.tsx
+++ b/src/components/FinderExportDisclosure.tsx
@@ -1,0 +1,57 @@
+import { ChevronDown } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import type { Locale, MotionRecipe, ParamValues } from "../data/types";
+import { ExportPanel } from "./ExportPanel";
+
+type FinderExportDisclosureProps = {
+  locale: Locale;
+  recipe: MotionRecipe;
+  values: ParamValues;
+};
+
+export function FinderExportDisclosure({
+  locale,
+  recipe,
+  values
+}: FinderExportDisclosureProps) {
+  const { t } = useTranslation();
+  const [isOpen, setIsOpen] = useState(false);
+  const toggleLabel =
+    locale === "zh"
+      ? isOpen
+        ? "收起输出"
+        : "查看输出"
+      : isOpen
+        ? "Hide output"
+        : "View output";
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setIsOpen(Boolean(new URLSearchParams(window.location.search).get("tab")));
+    }, 0);
+    return () => window.clearTimeout(timeout);
+  }, [recipe.id]);
+
+  return (
+    <details
+      className={`finder-export-disclosure apple-export-disclosure ${
+        isOpen ? "is-open" : "is-closed"
+      }`}
+      open={isOpen}
+      onToggle={(event) => setIsOpen(event.currentTarget.open)}
+    >
+      <summary
+        aria-controls="exports"
+        aria-label={`${toggleLabel}: ${t("workspace.outputTitle")}`}
+      >
+        <span>
+          <small>{t("workspace.outputLabel")}</small>
+          <strong>{t("workspace.outputTitle")}</strong>
+        </span>
+        <ChevronDown aria-hidden="true" size={18} strokeWidth={1.7} />
+      </summary>
+      <ExportPanel locale={locale} recipe={recipe} values={values} />
+    </details>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import type { Locale } from "../data/types";
 
 const repositoryUrl = "https://github.com/Ryan-yang125/motion-lexicon";
+const cliUrl = `${repositoryUrl}#free-cli-and-agent-skill`;
 const skillUrl = `${repositoryUrl}/tree/main/skills/motion-lexicon`;
 
 export function Footer() {
@@ -11,7 +12,7 @@ export function Footer() {
   const locale: Locale = i18n.resolvedLanguage?.startsWith("en") ? "en" : "zh";
 
   return (
-    <footer className="library-footer">
+    <footer className="library-footer library-footer-compact">
       <div className="library-footer-main">
         <div className="library-footer-brand">
           <span className="library-brand-mark" aria-hidden="true">
@@ -24,33 +25,30 @@ export function Footer() {
             <p>{t("footer.description")}</p>
           </div>
         </div>
-        <nav aria-label={t("footer.exploreLabel")}>
-          <span>{t("footer.explore")}</span>
+        <nav className="library-footer-links" aria-label={t("footer.exploreLabel")}>
           <Link to="/$locale/finder/" params={{ locale }}>
-            {t("nav.finder")}
+            {locale === "zh" ? "找动效" : "Find motion"}
           </Link>
           <Link to="/$locale/catalog/" params={{ locale }} search={{ surface: "components" }}>
-            {t("nav.components")}
-          </Link>
-          <Link to="/$locale/catalog/" params={{ locale }} search={{ surface: "playgrounds" }}>
-            {t("nav.playgrounds")}
-          </Link>
-          <Link to="/$locale/catalog/" params={{ locale }} search={{ surface: "guides" }}>
-            {t("nav.guides")}
+            {locale === "zh" ? "动效库" : "Library"}
           </Link>
           <Link to="/$locale/vocabulary/" params={{ locale }}>
             {locale === "zh" ? "动画词汇" : "Vocabulary"}
           </Link>
-        </nav>
-        <div className="library-footer-output">
-          <span>{locale === "zh" ? "免费开放" : "FREE & OPEN"}</span>
-          <p>CSS · HTML · JS · Prompt</p>
           <Link to="/$locale/$categoryId/$recipeId/" params={{ locale, categoryId: "entrances", recipeId: "slide-in" }}>
             {t("footer.openExample")}
-            <ArrowUpRight aria-hidden="true" size={14} />
           </Link>
+        </nav>
+        <nav
+          className="library-footer-resources"
+          aria-label={locale === "zh" ? "开源资源" : "Open source resources"}
+        >
           <a href={repositoryUrl} target="_blank" rel="noreferrer">
             GitHub
+            <ArrowUpRight aria-hidden="true" size={14} />
+          </a>
+          <a href={cliUrl} target="_blank" rel="noreferrer">
+            CLI
             <ArrowUpRight aria-hidden="true" size={14} />
           </a>
           <a href={skillUrl} target="_blank" rel="noreferrer">
@@ -61,10 +59,10 @@ export function Footer() {
             Catalog JSON
             <ArrowUpRight aria-hidden="true" size={14} />
           </a>
-        </div>
+        </nav>
       </div>
       <div className="library-footer-meta">
-        <span>Motion Lexicon</span>
+        <span>{locale === "zh" ? "免费开放 · CSS · HTML · JS · Prompt" : "Free and open · CSS · HTML · JS · Prompt"}</span>
         <span>{t("footer.staticProduct")}</span>
       </div>
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "@tanstack/react-router";
-import { Github, Menu, Sparkles } from "lucide-react";
+import { BookOpen, Braces, Github, Menu, SlidersHorizontal, Terminal } from "lucide-react";
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type { Locale } from "../data/types";
 import { ThemeLanguageControls } from "./ThemeLanguageControls";
@@ -12,22 +13,43 @@ type Surface = "components" | "playgrounds" | "guides";
 
 const surfaces: Surface[] = ["components", "playgrounds", "guides"];
 const repositoryUrl = "https://github.com/Ryan-yang125/motion-lexicon";
+const cliUrl = `${repositoryUrl}#free-cli-and-agent-skill`;
+const skillUrl = `${repositoryUrl}/tree/main/skills/motion-lexicon`;
+
+const surfaceIcons = {
+  components: BookOpen,
+  playgrounds: SlidersHorizontal,
+  guides: BookOpen
+} satisfies Record<Surface, typeof BookOpen>;
 
 export function Header({ locale }: HeaderProps) {
   const { t } = useTranslation();
   const location = useLocation();
+  const utilityMenuRef = useRef<HTMLDetailsElement>(null);
   const surface = new URLSearchParams(location.searchStr).get("surface") ?? "components";
+  const pathSegments = location.pathname.split("/").filter(Boolean);
+  const isHome = pathSegments.length === 1;
   const isCatalog = /\/catalog\/?$/.test(location.pathname);
-  const isFinder = /\/finder\/?$/.test(location.pathname);
+  const isFinderRoute = /\/finder\/?$/.test(location.pathname);
+  const isFinder = isHome || isFinderRoute;
   const isVocabulary = /\/vocabulary\/?$/.test(location.pathname);
+  const isLibrary = !isFinder;
+  const finderLabel = locale === "zh" ? "找动效" : "Find motion";
+  const libraryLabel = locale === "zh" ? "动效库" : "Library";
+  const resourcesLabel = locale === "zh" ? "资源与设置" : "Resources and settings";
+  const settingsLabel = locale === "zh" ? "显示设置" : "Display settings";
   const vocabularyLabel = locale === "zh" ? "动画词汇" : "Vocabulary";
 
   function isActive(item: Surface) {
     return isCatalog && surface === item;
   }
 
+  useEffect(() => {
+    if (utilityMenuRef.current) utilityMenuRef.current.open = false;
+  }, [location.pathname, location.searchStr]);
+
   return (
-    <header className="library-header">
+    <header className="library-header library-header-compact">
       <div className="library-header-inner">
         <Link className="library-brand" to="/$locale/" params={{ locale }} aria-label={t("common.brand")}>
           <span className="library-brand-mark" aria-hidden="true">
@@ -42,45 +64,25 @@ export function Header({ locale }: HeaderProps) {
           <Link
             to="/$locale/finder/"
             params={{ locale }}
-            className={isFinder ? "is-active" : undefined}
-            aria-current={isFinder ? "page" : undefined}
+            className={`library-primary-link is-finder${isFinder ? " is-active" : ""}`}
+            aria-current={isFinderRoute ? "page" : undefined}
           >
-            {t("nav.finder")}
+            {finderLabel}
           </Link>
-          {surfaces.map((item) => (
-            <Link
-              key={item}
-              to="/$locale/catalog/"
-              params={{ locale }}
-              search={{ surface: item }}
-              className={isActive(item) ? "is-active" : undefined}
-              aria-current={isActive(item) ? "page" : undefined}
-            >
-              {t(`nav.${item}`)}
-            </Link>
-          ))}
           <Link
-            to="/$locale/vocabulary/"
+            to="/$locale/catalog/"
             params={{ locale }}
-            className={isVocabulary ? "is-active" : undefined}
-            aria-current={isVocabulary ? "page" : undefined}
+            search={{ surface: "components" }}
+            className={`library-primary-link is-library${isLibrary ? " is-active" : ""}`}
+            aria-current={isCatalog ? "page" : undefined}
           >
-            {vocabularyLabel}
+            {libraryLabel}
           </Link>
         </nav>
 
         <div className="library-header-actions">
-          <Link
-            className="library-search-link"
-            to="/$locale/finder/"
-            params={{ locale }}
-            aria-label={t("nav.openFinder")}
-          >
-            <Sparkles aria-hidden="true" size={15} strokeWidth={1.8} />
-            <span>{t("nav.finderShort")}</span>
-          </Link>
           <a
-            className="icon-link"
+            className="icon-link library-github-link"
             href={repositoryUrl}
             target="_blank"
             rel="noreferrer"
@@ -89,32 +91,57 @@ export function Header({ locale }: HeaderProps) {
             <Github aria-hidden="true" size={16} strokeWidth={1.8} />
             <span>GitHub</span>
           </a>
-          <ThemeLanguageControls locale={locale} />
-          <details className="library-mobile-menu">
-            <summary aria-label={t("nav.openMenu")}>
+          <details ref={utilityMenuRef} className="library-utility-menu">
+            <summary aria-label={resourcesLabel}>
               <Menu aria-hidden="true" size={18} strokeWidth={1.8} />
+              <span>{locale === "zh" ? "资源" : "Resources"}</span>
             </summary>
-            <nav aria-label={t("nav.mobileLabel")}>
-              <Link to="/$locale/finder/" params={{ locale }}>
-                {t("nav.finder")}
-              </Link>
-              {surfaces.map((item) => (
-                <Link
-                  key={item}
-                  to="/$locale/catalog/"
-                  params={{ locale }}
-                  search={{ surface: item }}
-                >
-                  {t(`nav.${item}`)}
+            <div className="library-utility-popover">
+              <nav aria-label={t("nav.mobileLabel")}>
+                <Link to="/$locale/finder/" params={{ locale }}>
+                  {finderLabel}
                 </Link>
-              ))}
-              <Link to="/$locale/vocabulary/" params={{ locale }}>
-                {vocabularyLabel}
-              </Link>
-              <a href={repositoryUrl} target="_blank" rel="noreferrer">
-                GitHub
-              </a>
-            </nav>
+                {surfaces.map((item) => {
+                  const Icon = surfaceIcons[item];
+                  return (
+                    <Link
+                      key={item}
+                      to="/$locale/catalog/"
+                      params={{ locale }}
+                      search={{ surface: item }}
+                      className={isActive(item) ? "is-active" : undefined}
+                    >
+                      <Icon aria-hidden="true" size={16} strokeWidth={1.7} />
+                      <span>{t(`nav.${item}`)}</span>
+                    </Link>
+                  );
+                })}
+                <Link
+                  to="/$locale/vocabulary/"
+                  params={{ locale }}
+                  className={isVocabulary ? "is-active" : undefined}
+                >
+                  <BookOpen aria-hidden="true" size={16} strokeWidth={1.7} />
+                  <span>{vocabularyLabel}</span>
+                </Link>
+                <a href={cliUrl} target="_blank" rel="noreferrer">
+                  <Terminal aria-hidden="true" size={16} strokeWidth={1.7} />
+                  <span>CLI</span>
+                </a>
+                <a href={skillUrl} target="_blank" rel="noreferrer">
+                  <Braces aria-hidden="true" size={16} strokeWidth={1.7} />
+                  <span>Agent Skill</span>
+                </a>
+                <a href="/data/v1/catalog.json">
+                  <Braces aria-hidden="true" size={16} strokeWidth={1.7} />
+                  <span>Catalog JSON</span>
+                </a>
+              </nav>
+              <div className="library-utility-settings" aria-label={settingsLabel}>
+                <span>{settingsLabel}</span>
+                <ThemeLanguageControls locale={locale} />
+              </div>
+            </div>
           </details>
         </div>
       </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,105 +1,117 @@
-import { Link } from "@tanstack/react-router";
-import { ArrowRight, Bot, Search, Sparkles, Terminal } from "lucide-react";
+import { Link, useNavigate } from "@tanstack/react-router";
+import { ArrowRight, Search, Sparkles } from "lucide-react";
+import type { FormEvent } from "react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { getCompactCatalogEntry } from "../data/compact-catalog";
 import type { Locale } from "../data/types";
-import { text } from "../data/site";
-import { MotionThumbnail } from "./MotionThumbnail";
+import { pathFor } from "../data/site";
 
-const repositoryUrl = "https://github.com/Ryan-yang125/motion-lexicon";
-const skillUrl = `${repositoryUrl}/tree/main/skills/motion-lexicon`;
+const exampleKeys = ["weight", "continuity", "sequence"] as const;
 
 export function Hero({ locale }: { locale: Locale }) {
   const { t } = useTranslation();
-  const featured = getCompactCatalogEntry("slide-in");
+  const navigate = useNavigate();
+  const [query, setQuery] = useState("");
+
+  function openFinder(nextQuery: string) {
+    const normalized = nextQuery.trim();
+    const params = new URLSearchParams();
+    if (normalized) params.set("q", normalized);
+    const search = params.toString();
+    void navigate({
+      href: `${pathFor(locale, ["finder"])}${search ? `?${search}` : ""}`
+    });
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    openFinder(query);
+  }
 
   return (
-    <section className="library-hero" aria-labelledby="hero-title">
-      <div className="library-hero-copy">
-        <span className="library-status-line">
-          <i aria-hidden="true" />
+    <section className="library-hero apple-hero" aria-labelledby="hero-title">
+      <div className="library-hero-copy apple-hero-copy">
+        <span className="library-status-line apple-status-line">
+          <Sparkles aria-hidden="true" size={14} strokeWidth={1.8} />
           {t("landing.heroStatus")}
         </span>
         <h1 id="hero-title">{t("landing.heroTitle")}</h1>
         <p>{t("landing.heroCopy")}</p>
-        <div className="library-hero-actions">
-          <Link
-            className="library-button is-primary"
-            to="/$locale/finder/"
-            params={{ locale }}
-          >
-            <Sparkles aria-hidden="true" size={16} strokeWidth={1.8} />
-            {t("landing.openFinder")}
-            <ArrowRight aria-hidden="true" size={16} strokeWidth={1.8} />
-          </Link>
-          <Link
-            className="library-button"
-            to="/$locale/catalog/"
-            params={{ locale }}
-            search={{ surface: "components" }}
-          >
-            {t("landing.browseComponents")}
-          </Link>
+
+        <form className="apple-hero-finder" role="search" onSubmit={handleSubmit}>
+          <label htmlFor="home-finder-query">{t("finder.formLabel")}</label>
+          <div>
+            <Search aria-hidden="true" size={20} strokeWidth={1.7} />
+            <input
+              id="home-finder-query"
+              name="q"
+              type="search"
+              value={query}
+              autoComplete="off"
+              onChange={(event) => setQuery(event.currentTarget.value)}
+              placeholder={t("landing.finderExample")}
+            />
+            <button type="submit">
+              <span>{t("landing.openFinder")}</span>
+              <ArrowRight aria-hidden="true" size={17} strokeWidth={1.9} />
+            </button>
+          </div>
+        </form>
+
+        <div className="apple-hero-examples" aria-label={t("finder.examplesLabel")}>
+          {exampleKeys.map((key) => {
+            const example = t(`finder.examples.${key}`);
+            return (
+              <button type="button" key={key} onClick={() => openFinder(example)}>
+                {example}
+              </button>
+            );
+          })}
         </div>
-        <Link
-          className="library-hero-search"
-          to="/$locale/finder/"
-          params={{ locale }}
-        >
-          <Search aria-hidden="true" size={17} strokeWidth={1.8} />
-          <span>{t("landing.finderExample")}</span>
-          <span aria-hidden="true">→</span>
-        </Link>
-        <a
-          className="library-hero-search"
-          href={repositoryUrl}
-          target="_blank"
-          rel="noreferrer"
-          aria-label={locale === "zh" ? "打开免费 Motion Lexicon CLI" : "Open the free Motion Lexicon CLI"}
-        >
-          <Terminal aria-hidden="true" size={17} strokeWidth={1.8} />
-          <code>npx github:<wbr />Ryan-yang125/<wbr />motion-lexicon</code>
-          <span aria-hidden="true">↗</span>
-        </a>
-        <a
-          className="library-hero-search"
-          href={skillUrl}
-          target="_blank"
-          rel="noreferrer"
-          aria-label={locale === "zh" ? "打开免费 Motion Lexicon Agent Skill" : "Open the free Motion Lexicon Agent Skill"}
-        >
-          <Bot aria-hidden="true" size={17} strokeWidth={1.8} />
-          <code>npx skills add Ryan-yang125/<wbr />motion-lexicon --skill motion-lexicon</code>
-          <span aria-hidden="true">↗</span>
-        </a>
-        <div className="library-output-row" aria-label={t("landing.outputLabel")}>
-          <span>{t("landing.outputLabel")}</span>
-          <strong>CSS</strong>
-          <strong>HTML</strong>
-          <strong>JS</strong>
-          <strong>Prompt</strong>
+
+        <div className="apple-hero-proof" aria-label={locale === "zh" ? "产品规模" : "Product scope"}>
+          <span><strong>44</strong>{locale === "zh" ? " 个动效配方" : " motion recipes"}</span>
+          <i aria-hidden="true" />
+          <span><strong>91</strong>{locale === "zh" ? " 个专业术语" : " vocabulary terms"}</span>
+          <i aria-hidden="true" />
+          <span>{locale === "zh" ? "免费 · 本地运行" : "Free · Runs locally"}</span>
         </div>
       </div>
 
-      {featured ? (
-        <Link
-          className="library-hero-preview"
-          to="/$locale/$categoryId/$recipeId/"
-          params={{ locale, categoryId: featured.categoryId, recipeId: featured.id }}
-        >
-          <div className="library-hero-preview-bar">
-            <span>{t("landing.livePreview")}</span>
-            <span>{text(featured.name, locale)}</span>
+      <Link
+        className="library-hero-preview apple-hero-preview"
+        to="/$locale/$categoryId/$recipeId/"
+        params={{ locale, categoryId: "entrances", recipeId: "slide-in" }}
+        aria-label={locale === "zh" ? "打开滑入动效示例" : "Open the Slide in motion example"}
+      >
+        <div className="apple-preview-toolbar">
+          <span><i aria-hidden="true" />{locale === "zh" ? "实时预览" : "Live preview"}</span>
+          <span>{locale === "zh" ? "滑入" : "Slide in"}</span>
+        </div>
+        <div className="apple-preview-scene" aria-hidden="true">
+          <div className="apple-scene-sidebar">
+            <span />
+            <i />
+            <i />
+            <i />
           </div>
-          <MotionThumbnail locale={locale} recipe={featured} />
-          <div className="library-hero-preview-meta">
-            <span>240ms</span>
-            <span>28px</span>
-            <span>cubic-bezier</span>
-            <span>{t("common.open")}</span>
+          <div className="apple-scene-content">
+            <div className="apple-scene-heading"><span /><i /></div>
+            <div className="apple-scene-card">
+              <span className="apple-scene-avatar" />
+              <div><strong>{locale === "zh" ? "设计评审已准备好" : "Design review is ready"}</strong><i /><i /></div>
+              <b>→</b>
+            </div>
+            <div className="apple-scene-list"><span /><span /><span /></div>
           </div>
-        </Link>
-      ) : null}
+        </div>
+        <div className="apple-preview-footer">
+          <span>240ms</span>
+          <span>28px</span>
+          <span>ease-out</span>
+          <strong>{locale === "zh" ? "打开配方" : "Open recipe"}<ArrowRight aria-hidden="true" size={14} /></strong>
+        </div>
+      </Link>
     </section>
   );
 }

--- a/src/components/MotionCompare.tsx
+++ b/src/components/MotionCompare.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, Check, RotateCcw } from "lucide-react";
+import { ArrowUpRight, Check, Minimize2, RotateCcw } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { Locale, ParamValues } from "../data/types";
@@ -21,11 +21,13 @@ type MotionCompareProps = {
 
 function CandidatePreview({
   candidate,
+  compact,
   locale,
   replayKey,
   values
 }: {
   candidate: MotionFinderCandidate;
+  compact: boolean;
   locale: Locale;
   replayKey: number;
   values: ParamValues;
@@ -46,9 +48,15 @@ function CandidatePreview({
     const shadow = host.shadowRoot ?? host.attachShadow({ mode: "open" });
     const style = document.createElement("style");
     const scene = document.createElement("div");
-    style.textContent = `:host { display: grid; place-items: center; width: 100%; height: 100%; }
+    style.textContent = `:host { display: grid; place-items: center; width: 100%; min-width: 0; min-height: 0; }
 :host > div { display: grid; place-items: center; width: 100%; }
-${output.css}`;
+${output.css}
+:host([data-compact="true"]) .motion-demo {
+  box-sizing: border-box;
+  height: 7rem;
+  min-height: 7rem;
+  padding: 0.75rem;
+}`;
     scene.innerHTML = output.html;
     shadow.replaceChildren(style, scene);
     const root = scene.querySelector<HTMLElement>(".motion-demo");
@@ -65,6 +73,7 @@ ${output.css}`;
     <div
       ref={runtimeHostRef}
       className="finder-candidate-stage motion-runtime-stage"
+      data-compact={compact ? "true" : undefined}
       aria-label={`${candidate.name} — ${candidate.description}`}
     />
   );
@@ -79,42 +88,93 @@ export function MotionCompare({
 }: MotionCompareProps) {
   const { t } = useTranslation();
   const [replayKey, setReplayKey] = useState(0);
+  const [isComparing, setIsComparing] = useState(false);
+
+  function replayTogether() {
+    setIsComparing(true);
+    setReplayKey((current) => current + 1);
+  }
+
+  function selectCandidate(candidate: MotionFinderCandidate) {
+    setIsComparing(false);
+    onSelect(candidate);
+  }
 
   return (
-    <div className="finder-compare">
+    <div
+      className={`finder-compare apple-motion-chooser ${
+        isComparing ? "is-comparing" : "is-focused"
+      }`}
+    >
       <div className="finder-compare-toolbar">
-        <span>{t("finder.resultCount", { count: candidates.length })}</span>
-        <Button
-          type="button"
-          variant="soft"
-          size="sm"
-          onClick={() => setReplayKey((current) => current + 1)}
-        >
-          <RotateCcw aria-hidden="true" size={15} strokeWidth={1.8} />
-          {t("finder.replayAll")}
-        </Button>
+        <div className="finder-compare-status">
+          <span>{t("finder.resultCount", { count: candidates.length })}</span>
+          <strong>{isComparing ? t("finder.resultTitle") : t("finder.selected")}</strong>
+        </div>
+        <div className="finder-compare-actions">
+          {isComparing ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              aria-controls="finder-candidate-deck"
+              onClick={() => setIsComparing(false)}
+            >
+              <Minimize2 aria-hidden="true" size={15} strokeWidth={1.8} />
+              {locale === "zh" ? "聚焦已选" : "Focus selection"}
+            </Button>
+          ) : null}
+          <Button
+            type="button"
+            variant="soft"
+            size="sm"
+            aria-controls="finder-candidate-deck"
+            aria-pressed={isComparing}
+            onClick={replayTogether}
+          >
+            <RotateCcw aria-hidden="true" size={15} strokeWidth={1.8} />
+            {t("finder.replayAll")}
+          </Button>
+        </div>
       </div>
 
-      <div className="finder-candidate-grid" aria-live="polite">
+      <div
+        id="finder-candidate-deck"
+        className="finder-candidate-grid finder-choice-deck"
+        data-layout={isComparing ? "compare" : "focus"}
+        aria-live="polite"
+      >
         {candidates.map((candidate) => {
           const selected = candidate.variantId === selectedId;
           const previewValues = selected && selectedValues ? selectedValues : candidate.values;
           return (
             <article
-              className={selected ? "finder-candidate is-selected" : "finder-candidate"}
+              className={`finder-candidate apple-motion-card ${
+                selected
+                  ? "finder-candidate--primary apple-motion-primary is-selected"
+                  : "finder-candidate--alternative apple-motion-alternative"
+              }`}
               key={candidate.variantId}
               data-variant-id={candidate.variantId}
+              data-rank={candidate.rank}
+              aria-labelledby={`finder-candidate-title-${candidate.variantId}`}
             >
               <header className="finder-candidate-header">
                 <div>
-                  <span>{t("finder.candidateLabel", { rank: candidate.rank })}</span>
-                  <h3>{candidate.name}</h3>
+                  <div className="finder-candidate-meta">
+                    <span>{t("finder.candidateLabel", { rank: candidate.rank })}</span>
+                    {selected ? <strong>{t("finder.selected")}</strong> : null}
+                  </div>
+                  <h3 id={`finder-candidate-title-${candidate.variantId}`}>
+                    {candidate.name}
+                  </h3>
                   <p>{candidate.description}</p>
                 </div>
               </header>
 
               <CandidatePreview
                 candidate={candidate}
+                compact={isComparing || !selected}
                 locale={locale}
                 replayKey={replayKey}
                 values={previewValues}
@@ -135,7 +195,7 @@ export function MotionCompare({
                   type="button"
                   className={selected ? "finder-select is-selected" : "finder-select"}
                   aria-pressed={selected}
-                  onClick={() => onSelect(candidate)}
+                  onClick={() => selectCandidate(candidate)}
                 >
                   {selected ? <Check aria-hidden="true" size={15} /> : null}
                   {selected

--- a/src/components/RecipeWorkspace.tsx
+++ b/src/components/RecipeWorkspace.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import {
   Accessibility,
   Check,
+  ChevronDown,
   ChevronLeft,
   ChevronRight,
   Monitor,
@@ -37,6 +38,8 @@ const deviceOptions = [
   { value: "mobile", icon: Smartphone }
 ] as const;
 
+const exportTabs = new Set(["css", "html", "js", "prompt"]);
+
 const guidanceLabels = {
   zh: {
     vocabulary: "动效词义",
@@ -57,7 +60,16 @@ const guidanceLabels = {
     enterExit: "进入 / 离开",
     interruptibility: "可打断性",
     gestureRules: "手势与键盘",
-    reducedMotionStrategy: "减弱动效策略"
+    reducedMotionStrategy: "减弱动效策略",
+    commonControls: "常用调节",
+    moreControls: "更多参数",
+    output: "复制实现",
+    outputCopy: "提示词和前端代码保持同步，可随时收起。",
+    references: "深入了解",
+    review: "发布检查",
+    accessibility: "可访问性",
+    parameters: "参数参考",
+    relatedSection: "相关动效"
   },
   en: {
     vocabulary: "Motion vocabulary",
@@ -78,7 +90,16 @@ const guidanceLabels = {
     enterExit: "Enter / exit",
     interruptibility: "Interruptibility",
     gestureRules: "Gesture and keyboard",
-    reducedMotionStrategy: "Reduced-motion strategy"
+    reducedMotionStrategy: "Reduced-motion strategy",
+    commonControls: "Essential controls",
+    moreControls: "More parameters",
+    output: "Copy implementation",
+    outputCopy: "Prompt and frontend code stay synchronized and can be tucked away at any time.",
+    references: "Learn more",
+    review: "Ship checklist",
+    accessibility: "Accessibility",
+    parameters: "Parameter reference",
+    relatedSection: "Related motion"
   }
 } as const;
 
@@ -112,6 +133,29 @@ function paramRange(param: MotionParam, locale: Locale) {
   return locale === "zh" ? "开启 / 关闭" : "On / Off";
 }
 
+function splitInspectorRecipe(recipe: MotionRecipe) {
+  if (recipe.params.length <= 3) {
+    return {
+      common: recipe,
+      advanced: undefined
+    };
+  }
+
+  const commonParams = recipe.params.slice(0, 2);
+  const expressiveParam = recipe.params.find(
+    (param) => !commonParams.includes(param) && param.id === "ease"
+  ) ?? recipe.params.find(
+    (param) => !commonParams.includes(param) && param.id === "distance"
+  ) ?? recipe.params[2];
+  const commonIds = new Set([...commonParams, expressiveParam].map((param) => param.id));
+  const advancedParams = recipe.params.filter((param) => !commonIds.has(param.id));
+
+  return {
+    common: { ...recipe, params: recipe.params.filter((param) => commonIds.has(param.id)) },
+    advanced: advancedParams.length > 0 ? { ...recipe, params: advancedParams } : undefined
+  };
+}
+
 export function RecipeWorkspace({ locale, recipe, mode = "embedded" }: RecipeWorkspaceProps) {
   const { t } = useTranslation();
   const location = useLocation();
@@ -120,8 +164,13 @@ export function RecipeWorkspace({ locale, recipe, mode = "embedded" }: RecipeWor
   const [device, setDevice] = useState<DeviceWidth>("desktop");
   const [reduced, setReduced] = useState(false);
   const [focusedTermId, setFocusedTermId] = useState(recipe.id);
+  const [outputOpen, setOutputOpen] = useState(false);
   const lastRequestedTermRef = useRef<string | null | undefined>(undefined);
+  const vocabularyDisclosureRef = useRef<HTMLDetailsElement>(null);
+  const advancedControlsRef = useRef<HTMLDetailsElement>(null);
   const SectionTitle = mode === "embedded" ? "h2" : "h1";
+  const SectionHeading = mode === "embedded" ? "h3" : "h2";
+  const DisclosureHeading = mode === "embedded" ? "h4" : "h3";
   const category = getCategory(recipe.categoryId);
   const isGuide = recipe.surfaceType === "guide";
   const labels = guidanceLabels[locale];
@@ -130,6 +179,7 @@ export function RecipeWorkspace({ locale, recipe, mode = "embedded" }: RecipeWor
     [recipe.canonicalId]
   );
   const guidance = getMotionGuidance(recipe.canonicalId);
+  const inspectorRecipe = useMemo(() => splitInspectorRecipe(recipe), [recipe]);
   const surfaceSearch = recipe.surfaceType === "component" ? "components" : recipe.surfaceType === "playground" ? "playgrounds" : "guides";
   const surfaceLabel = isGuide ? t("common.guide") : recipe.surfaceType === "playground" ? t("common.playground") : t("common.motionPattern");
   const relatedEntries = Array.from(
@@ -155,6 +205,9 @@ export function RecipeWorkspace({ locale, recipe, mode = "embedded" }: RecipeWor
       setFocusedTermId(validTerm ?? recipe.id);
 
       if (validTerm && lastRequestedTermRef.current !== validTerm) {
+        if (vocabularyDisclosureRef.current) {
+          vocabularyDisclosureRef.current.open = true;
+        }
         window.requestAnimationFrame(() => {
           const target = document.getElementById(`workspace-term-${validTerm}`);
           target?.focus({ preventScroll: true });
@@ -165,6 +218,17 @@ export function RecipeWorkspace({ locale, recipe, mode = "embedded" }: RecipeWor
     }, 0);
     return () => window.clearTimeout(timeout);
   }, [glossaryTerms, location.searchStr, recipe.id]);
+
+  useEffect(() => {
+    const tab = new URLSearchParams(window.location.search).get("tab");
+    setOutputOpen(Boolean(tab && exportTabs.has(tab)));
+  }, [recipe.id]);
+
+  useEffect(() => {
+    if (!inspectorRecipe.advanced || !advancedControlsRef.current) return;
+    const params = new URLSearchParams(window.location.search);
+    advancedControlsRef.current.open = inspectorRecipe.advanced.params.some((param) => params.has(param.id));
+  }, [inspectorRecipe.advanced, recipe.id]);
 
   function writeViewState(nextDevice: DeviceWidth, nextReduced: boolean) {
     setDevice(nextDevice);
@@ -184,9 +248,9 @@ export function RecipeWorkspace({ locale, recipe, mode = "embedded" }: RecipeWor
   }
 
   return (
-    <section className="library-entry" id="workspace" aria-labelledby="workspace-title">
-      <div className="library-entry-main">
-        <nav className="library-breadcrumbs" aria-label={t("workspace.breadcrumbLabel")}>
+    <section className="library-entry apple-recipe-workspace" id="workspace" aria-labelledby="workspace-title">
+      <div className="library-entry-main apple-recipe-main">
+        <nav className="library-breadcrumbs apple-recipe-breadcrumbs" aria-label={t("workspace.breadcrumbLabel")}>
           <Link to="/$locale/catalog/" params={{ locale }} search={{ surface: surfaceSearch }}>
             {t(`nav.${surfaceSearch}`)}
           </Link>
@@ -198,250 +262,329 @@ export function RecipeWorkspace({ locale, recipe, mode = "embedded" }: RecipeWor
           ) : null}
         </nav>
 
-        <header className="library-entry-header">
-          <div>
-            <div className="library-entry-meta">
+        <header className="library-entry-header apple-recipe-hero">
+          <div className="apple-recipe-identity">
+            <div className="library-entry-meta apple-recipe-meta">
               <span>{surfaceLabel}</span>
+              <code>{recipe.id}</code>
             </div>
             <SectionTitle id="workspace-title">{text(recipe.name, locale)}</SectionTitle>
             <p>{text(recipe.shortDescription, locale)}</p>
           </div>
           {!isGuide ? (
-            <CopyButton
-              label={t("common.copyCurrentPrompt")}
-              getText={() => buildRecipePrompt(recipe, values, locale)}
-              variant="accent"
-            />
+            <div className="apple-recipe-primary-action">
+              <CopyButton
+                label={t("common.copyCurrentPrompt")}
+                getText={() => buildRecipePrompt(recipe, values, locale)}
+                variant="accent"
+              />
+            </div>
           ) : null}
         </header>
 
-        <nav className="library-entry-tabs" aria-label={t("workspace.pageSectionsLabel")}>
-          <a href="#preview">{t("workspace.previewLabel")}</a>
-          <a href="#vocabulary">{labels.vocabulary}</a>
-          <a href="#decision">{labels.decision}</a>
-          {!isGuide ? <a href="#exports">CSS / HTML / JS / Prompt</a> : null}
-          {!isGuide ? <a href="#parameters">{t("common.parameter")}</a> : null}
-        </nav>
-
-        <section className="library-preview-section" id="preview" aria-labelledby="preview-title">
-          <div className="library-doc-section-heading is-compact">
+        <section className="library-preview-section apple-workbench-stage" id="preview" aria-labelledby="preview-title">
+          <div className="library-doc-section-heading is-compact apple-workbench-heading">
             <div>
               <span>{t("workspace.previewLabel")}</span>
-              <h2 id="preview-title">{t("workspace.previewTitle")}</h2>
+              <SectionHeading id="preview-title">{t("workspace.previewTitle")}</SectionHeading>
             </div>
             <p>{text(recipe.definition, locale)}</p>
           </div>
 
-          {!isGuide ? <div className="library-preview-toolbar">
-            <div className="library-device-switcher" aria-label={t("workspace.deviceLabel")}>
-              {deviceOptions.map(({ value, icon: Icon }) => (
-                <button
-                  type="button"
-                  key={value}
-                  className={device === value ? "is-active" : undefined}
-                  aria-pressed={device === value}
-                  aria-label={t(`workspace.devices.${value}`)}
-                  onClick={() => writeViewState(value, reduced)}
-                >
-                  <Icon aria-hidden="true" size={15} strokeWidth={1.8} />
-                </button>
-              ))}
+          {!isGuide ? (
+            <div className="library-preview-toolbar apple-preview-toolbar">
+              <div className="library-device-switcher" aria-label={t("workspace.deviceLabel")}>
+                {deviceOptions.map(({ value, icon: Icon }) => (
+                  <button
+                    type="button"
+                    key={value}
+                    className={device === value ? "is-active" : undefined}
+                    aria-pressed={device === value}
+                    aria-label={t(`workspace.devices.${value}`)}
+                    onClick={() => writeViewState(value, reduced)}
+                  >
+                    <Icon aria-hidden="true" size={15} strokeWidth={1.8} />
+                  </button>
+                ))}
+              </div>
+              <label className="library-reduced-toggle">
+                <input
+                  type="checkbox"
+                  checked={reduced}
+                  onChange={(event) => writeViewState(device, event.currentTarget.checked)}
+                />
+                <span aria-hidden="true"><Check size={12} /></span>
+                <Accessibility aria-hidden="true" size={15} strokeWidth={1.8} />
+                {t("common.reducedMotion")}
+              </label>
             </div>
-            <label className="library-reduced-toggle">
-              <input
-                type="checkbox"
-                checked={reduced}
-                onChange={(event) => writeViewState(device, event.currentTarget.checked)}
-              />
-              <span aria-hidden="true"><Check size={12} /></span>
-              <Accessibility aria-hidden="true" size={15} strokeWidth={1.8} />
-              {t("common.reducedMotion")}
-            </label>
-          </div> : null}
+          ) : null}
 
-          <div className={isGuide ? "library-workbench is-guide" : "library-workbench"}>
-            <div className={`library-preview-frame is-${device}${reduced ? " force-reduced-motion" : ""}`}>
+          <div className={isGuide ? "library-workbench apple-workbench is-guide" : "library-workbench apple-workbench"}>
+            <div className={`library-preview-frame apple-preview-stage is-${device}${reduced ? " force-reduced-motion" : ""}`}>
               <MotionPreview locale={locale} recipe={recipe} values={values} />
             </div>
-            {!isGuide ? <aside className="library-parameter-panel" aria-label={t("common.parameter")}>
-              <div className="library-sync-status">
-                <i aria-hidden="true" />
-                {t("common.ready")}
-              </div>
-              <ParameterControls
-                locale={locale}
-                recipe={recipe}
-                values={values}
-                onChange={updateValue}
-                onReset={resetValues}
-              />
-            </aside> : null}
-          </div>
-        </section>
-
-        <section className="library-content-section" id="vocabulary" aria-labelledby="vocabulary-title">
-          <div className="library-doc-section-heading">
-            <div>
-              <span>{labels.vocabulary}</span>
-              <h2 id="vocabulary-title">{labels.vocabularyTitle}</h2>
-            </div>
-            <p>{labels.vocabularyCopy}</p>
-          </div>
-          <div className="library-vocabulary-list">
-            {glossaryTerms.map((term) => (
-              <article
-                key={term.id}
-                id={`workspace-term-${term.id}`}
-                tabIndex={-1}
-                aria-labelledby={`workspace-term-title-${term.id}`}
-                className={`${term.canonical ? "is-canonical" : "is-related"}${focusedTermId === term.id ? " is-focused" : ""}`}
-              >
-                <header>
-                  <span>{term.canonical ? labels.canonical : labels.related}</span>
-                  <code>{term.id}</code>
-                </header>
-                <h3 id={`workspace-term-title-${term.id}`}>{text(term.name, locale)}</h3>
-                <small lang={locale === "zh" ? "en" : "zh-CN"}>
-                  {locale === "zh" ? term.name.en : term.name.zh}
-                </small>
-                <div>
-                  <span>{labels.definition}</span>
-                  <p lang="en">{term.definition.en}</p>
+            {!isGuide ? (
+              <aside className="library-parameter-panel apple-inspector" aria-label={labels.commonControls}>
+                <div className="library-sync-status apple-inspector-status">
+                  <i aria-hidden="true" />
+                  {t("common.ready")}
                 </div>
-                <div>
-                  <span>{labels.translation}</span>
-                  <p lang="zh-CN">{term.definition.zh}</p>
-                </div>
-                {term.distinction ? (
-                  <div className="library-vocabulary-distinction">
-                    <span>{labels.distinction}</span>
-                    <p>{text(term.distinction, locale)}</p>
-                  </div>
+                <ParameterControls
+                  locale={locale}
+                  recipe={inspectorRecipe.common}
+                  values={values}
+                  onChange={updateValue}
+                  onReset={resetValues}
+                />
+                {inspectorRecipe.advanced ? (
+                  <details className="apple-inspector-disclosure" ref={advancedControlsRef}>
+                    <summary>
+                      <span>{labels.moreControls}</span>
+                      <small>{inspectorRecipe.advanced.params.length}</small>
+                      <ChevronDown aria-hidden="true" size={16} strokeWidth={1.8} />
+                    </summary>
+                    <div className="apple-inspector-disclosure-body">
+                      <ParameterControls
+                        locale={locale}
+                        recipe={inspectorRecipe.advanced}
+                        values={values}
+                        onChange={updateValue}
+                        onReset={resetValues}
+                      />
+                    </div>
+                  </details>
                 ) : null}
-              </article>
-            ))}
+              </aside>
+            ) : null}
           </div>
-          <Link className="library-inline-link" to="/$locale/vocabulary/" params={{ locale }}>
-            {labels.openVocabulary}
-            <ChevronRight aria-hidden="true" size={15} />
-          </Link>
         </section>
 
-        {guidance ? (
-          <section className="library-content-section" id="decision" aria-labelledby="decision-title">
-            <div className="library-doc-section-heading">
-              <div>
-                <span>{labels.decision}</span>
-                <h2 id="decision-title">{labels.decisionTitle}</h2>
-              </div>
-              <p>{labels.decisionCopy}</p>
+        {!isGuide ? (
+          <details
+            className="apple-disclosure apple-output-disclosure"
+            open={outputOpen}
+            onToggle={(event) => setOutputOpen(event.currentTarget.open)}
+          >
+            <summary className="apple-disclosure-summary">
+              <span>
+                <small>{t("workspace.outputLabel")}</small>
+                <strong>{labels.output}</strong>
+                <span className="apple-disclosure-copy">{labels.outputCopy}</span>
+              </span>
+              <ChevronDown aria-hidden="true" size={18} strokeWidth={1.7} />
+            </summary>
+            <div className="apple-disclosure-body apple-output-body">
+              <ExportPanel locale={locale} recipe={recipe} values={values} />
             </div>
-            <div className="library-guidance-grid">
-              {([
-                [labels.purpose, guidance.purpose],
-                [labels.frequency, guidance.frequency],
-                [labels.trigger, guidance.trigger],
-                [labels.enterExit, guidance.enterExit],
-                [labels.interruptibility, guidance.interruptibility],
-                [labels.gestureRules, guidance.gestureRules],
-                [labels.reducedMotionStrategy, guidance.reducedMotionStrategy]
-              ] as const).map(([label, value]) => (
-                <article key={label}>
-                  <span>{label}</span>
-                  <p>{text(value, locale)}</p>
-                </article>
-              ))}
-            </div>
-          </section>
+          </details>
         ) : null}
 
-        {!isGuide ? <ExportPanel locale={locale} recipe={recipe} values={values} /> : null}
+        <section className="apple-reference-library" aria-labelledby="reference-library-title">
+          <header className="apple-reference-library-heading">
+            <SectionHeading id="reference-library-title">{labels.references}</SectionHeading>
+          </header>
 
-        <section className="library-content-section" id="review" aria-labelledby="review-title">
-          <div className="library-doc-section-heading">
-            <div>
-              <span>{t("common.reviewNotes")}</span>
-              <h2 id="review-title">{t("workspace.reviewTitle")}</h2>
-            </div>
-          </div>
-          <ul className="library-check-list">
-            {recipe.reviewNotes.map((item) => (
-              <li key={text(item, locale)}><Check aria-hidden="true" size={15} />{text(item, locale)}</li>
-            ))}
-          </ul>
-        </section>
-
-        <section className="library-content-section" id="accessibility" aria-labelledby="accessibility-title">
-          <div className="library-doc-section-heading">
-            <div>
-              <span>{t("common.accessibility")}</span>
-              <h2 id="accessibility-title">{t("workspace.accessibilityTitle")}</h2>
-            </div>
-          </div>
-          <div className="library-accessibility-note">
-            <Accessibility aria-hidden="true" size={20} strokeWidth={1.7} />
-            <div>
-              <strong>{t("common.reducedMotion")}</strong>
-              <p>{text(recipe.reducedMotion, locale)}</p>
-            </div>
-          </div>
-        </section>
-
-        {!isGuide ? <section className="library-content-section" id="parameters" aria-labelledby="parameters-title">
-          <div className="library-doc-section-heading">
-            <div>
-              <span>{t("common.parameter")}</span>
-              <h2 id="parameters-title">{t("workspace.parameterReference")}</h2>
-            </div>
-          </div>
-          <div className="library-table-scroll">
-            <table className="library-parameter-table">
-              <thead>
-                <tr>
-                  <th>{t("workspace.parameterName")}</th>
-                  <th>{t("workspace.parameterRange")}</th>
-                  <th>{t("workspace.parameterDefault")}</th>
-                  <th>{t("workspace.parameterPurpose")}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {recipe.params.map((param) => (
-                  <tr key={param.id}>
-                    <td><code>{param.id}</code></td>
-                    <td>{paramRange(param, locale)}</td>
-                    <td>{paramDefault(param, locale)}</td>
-                    <td>{text(param.description, locale)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        </section> : null}
-
-        {relatedEntries.length > 0 ? (
-          <section className="library-content-section" id="related" aria-labelledby="related-title">
-            <div className="library-doc-section-heading">
-              <div>
-                <span>{t("common.related")}</span>
-                <h2 id="related-title">{t("workspace.relatedTitle")}</h2>
-              </div>
-            </div>
-            <div className="library-related-links">
-              {relatedEntries.map((entry) => (
-                <Link
-                  key={entry.id}
-                  to="/$locale/$categoryId/$recipeId/"
-                  params={{ locale, categoryId: entry.categoryId, recipeId: entry.id }}
-                >
-                  <span>{text(entry.name, locale)}</span>
+          <section className="library-content-section apple-reference-section" id="vocabulary" aria-labelledby="vocabulary-summary-title">
+            <details className="apple-disclosure" ref={vocabularyDisclosureRef}>
+              <summary className="apple-disclosure-summary">
+                <span>
+                  <small>{labels.vocabulary}</small>
+                  <strong id="vocabulary-summary-title">{labels.vocabularyTitle}</strong>
+                  <span className="apple-disclosure-copy">{labels.vocabularyCopy}</span>
+                </span>
+                <ChevronDown aria-hidden="true" size={18} strokeWidth={1.7} />
+              </summary>
+              <div className="apple-disclosure-body">
+                <DisclosureHeading className="sr-only" id="vocabulary-title">{labels.vocabularyTitle}</DisclosureHeading>
+                <div className="library-vocabulary-list">
+                  {glossaryTerms.map((term) => (
+                    <article
+                      key={term.id}
+                      id={`workspace-term-${term.id}`}
+                      tabIndex={-1}
+                      aria-labelledby={`workspace-term-title-${term.id}`}
+                      className={`${term.canonical ? "is-canonical" : "is-related"}${focusedTermId === term.id ? " is-focused" : ""}`}
+                    >
+                      <header>
+                        <span>{term.canonical ? labels.canonical : labels.related}</span>
+                        <code>{term.id}</code>
+                      </header>
+                      <h4 id={`workspace-term-title-${term.id}`}>{text(term.name, locale)}</h4>
+                      <small lang={locale === "zh" ? "en" : "zh-CN"}>
+                        {locale === "zh" ? term.name.en : term.name.zh}
+                      </small>
+                      <div>
+                        <span>{labels.definition}</span>
+                        <p lang="en">{term.definition.en}</p>
+                      </div>
+                      <div>
+                        <span>{labels.translation}</span>
+                        <p lang="zh-CN">{term.definition.zh}</p>
+                      </div>
+                      {term.distinction ? (
+                        <div className="library-vocabulary-distinction">
+                          <span>{labels.distinction}</span>
+                          <p>{text(term.distinction, locale)}</p>
+                        </div>
+                      ) : null}
+                    </article>
+                  ))}
+                </div>
+                <Link className="library-inline-link" to="/$locale/vocabulary/" params={{ locale }}>
+                  {labels.openVocabulary}
                   <ChevronRight aria-hidden="true" size={15} />
                 </Link>
-              ))}
-            </div>
+              </div>
+            </details>
           </section>
-        ) : null}
 
-        <nav className="library-entry-pagination" aria-label={t("workspace.paginationLabel")}>
+          {guidance ? (
+            <section className="library-content-section apple-reference-section" id="decision" aria-labelledby="decision-summary-title">
+              <details className="apple-disclosure">
+                <summary className="apple-disclosure-summary">
+                  <span>
+                    <small>{labels.decision}</small>
+                    <strong id="decision-summary-title">{labels.decisionTitle}</strong>
+                    <span className="apple-disclosure-copy">{labels.decisionCopy}</span>
+                  </span>
+                  <ChevronDown aria-hidden="true" size={18} strokeWidth={1.7} />
+                </summary>
+                <div className="apple-disclosure-body">
+                  <DisclosureHeading className="sr-only" id="decision-title">{labels.decisionTitle}</DisclosureHeading>
+                  <div className="library-guidance-grid">
+                    {([
+                      [labels.purpose, guidance.purpose],
+                      [labels.frequency, guidance.frequency],
+                      [labels.trigger, guidance.trigger],
+                      [labels.enterExit, guidance.enterExit],
+                      [labels.interruptibility, guidance.interruptibility],
+                      [labels.gestureRules, guidance.gestureRules],
+                      [labels.reducedMotionStrategy, guidance.reducedMotionStrategy]
+                    ] as const).map(([label, value]) => (
+                      <article key={label}>
+                        <span>{label}</span>
+                        <p>{text(value, locale)}</p>
+                      </article>
+                    ))}
+                  </div>
+                </div>
+              </details>
+            </section>
+          ) : null}
+
+          <section className="library-content-section apple-reference-section" id="review" aria-labelledby="review-summary-title">
+            <details className="apple-disclosure">
+              <summary className="apple-disclosure-summary">
+                <span>
+                  <small>{t("common.reviewNotes")}</small>
+                  <strong id="review-summary-title">{labels.review}</strong>
+                </span>
+                <ChevronDown aria-hidden="true" size={18} strokeWidth={1.7} />
+              </summary>
+              <div className="apple-disclosure-body">
+                <DisclosureHeading className="sr-only" id="review-title">{t("workspace.reviewTitle")}</DisclosureHeading>
+                <ul className="library-check-list">
+                  {recipe.reviewNotes.map((item) => (
+                    <li key={text(item, locale)}><Check aria-hidden="true" size={15} />{text(item, locale)}</li>
+                  ))}
+                </ul>
+              </div>
+            </details>
+          </section>
+
+          <section className="library-content-section apple-reference-section" id="accessibility" aria-labelledby="accessibility-summary-title">
+            <details className="apple-disclosure">
+              <summary className="apple-disclosure-summary">
+                <span>
+                  <small>{t("common.accessibility")}</small>
+                  <strong id="accessibility-summary-title">{labels.accessibility}</strong>
+                </span>
+                <ChevronDown aria-hidden="true" size={18} strokeWidth={1.7} />
+              </summary>
+              <div className="apple-disclosure-body">
+                <DisclosureHeading className="sr-only" id="accessibility-title">{t("workspace.accessibilityTitle")}</DisclosureHeading>
+                <div className="library-accessibility-note">
+                  <Accessibility aria-hidden="true" size={20} strokeWidth={1.7} />
+                  <div>
+                    <strong>{t("common.reducedMotion")}</strong>
+                    <p>{text(recipe.reducedMotion, locale)}</p>
+                  </div>
+                </div>
+              </div>
+            </details>
+          </section>
+
+          {!isGuide ? (
+            <section className="library-content-section apple-reference-section" id="parameters" aria-labelledby="parameters-summary-title">
+              <details className="apple-disclosure">
+                <summary className="apple-disclosure-summary">
+                  <span>
+                    <small>{t("common.parameter")}</small>
+                    <strong id="parameters-summary-title">{labels.parameters}</strong>
+                  </span>
+                  <ChevronDown aria-hidden="true" size={18} strokeWidth={1.7} />
+                </summary>
+                <div className="apple-disclosure-body">
+                  <DisclosureHeading className="sr-only" id="parameters-title">{t("workspace.parameterReference")}</DisclosureHeading>
+                  <div className="library-table-scroll">
+                    <table className="library-parameter-table">
+                      <thead>
+                        <tr>
+                          <th>{t("workspace.parameterName")}</th>
+                          <th>{t("workspace.parameterRange")}</th>
+                          <th>{t("workspace.parameterDefault")}</th>
+                          <th>{t("workspace.parameterPurpose")}</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {recipe.params.map((param) => (
+                          <tr key={param.id}>
+                            <td><code>{param.id}</code></td>
+                            <td>{paramRange(param, locale)}</td>
+                            <td>{paramDefault(param, locale)}</td>
+                            <td>{text(param.description, locale)}</td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </details>
+            </section>
+          ) : null}
+
+          {relatedEntries.length > 0 ? (
+            <section className="library-content-section apple-reference-section" id="related" aria-labelledby="related-summary-title">
+              <details className="apple-disclosure">
+                <summary className="apple-disclosure-summary">
+                  <span>
+                    <small>{t("common.related")}</small>
+                    <strong id="related-summary-title">{labels.relatedSection}</strong>
+                  </span>
+                  <ChevronDown aria-hidden="true" size={18} strokeWidth={1.7} />
+                </summary>
+                <div className="apple-disclosure-body">
+                  <DisclosureHeading className="sr-only" id="related-title">{t("workspace.relatedTitle")}</DisclosureHeading>
+                  <div className="library-related-links">
+                    {relatedEntries.map((entry) => (
+                      <Link
+                        key={entry.id}
+                        to="/$locale/$categoryId/$recipeId/"
+                        params={{ locale, categoryId: entry.categoryId, recipeId: entry.id }}
+                      >
+                        <span>{text(entry.name, locale)}</span>
+                        <ChevronRight aria-hidden="true" size={15} />
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              </details>
+            </section>
+          ) : null}
+        </section>
+
+        <nav className="library-entry-pagination apple-recipe-pagination" aria-label={t("workspace.paginationLabel")}>
           {previousRecipe ? (
             <Link
               to="/$locale/$categoryId/$recipeId/"
@@ -462,18 +605,6 @@ export function RecipeWorkspace({ locale, recipe, mode = "embedded" }: RecipeWor
           ) : null}
         </nav>
       </div>
-
-      <aside className="library-entry-toc" aria-label={t("common.onThisPage")}>
-        <strong>{t("common.onThisPage")}</strong>
-        <a href="#preview">{t("workspace.previewLabel")}</a>
-        <a href="#vocabulary">{labels.vocabulary}</a>
-        <a href="#decision">{labels.decision}</a>
-        {!isGuide ? <a href="#exports">CSS / HTML / JS / Prompt</a> : null}
-        <a href="#review">{t("common.reviewNotes")}</a>
-        <a href="#accessibility">{t("common.accessibility")}</a>
-        {!isGuide ? <a href="#parameters">{t("workspace.parameterReference")}</a> : null}
-        {relatedEntries.length > 0 ? <a href="#related">{t("common.related")}</a> : null}
-      </aside>
     </section>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { AppRouterProvider, router } from "./router";
 import "./styles.css";
 import "./library.css";
 import "./vocabulary.css";
+import "./apple-redesign.css";
 
 const helmetModule = helmetAsync as typeof helmetAsync & Record<string, typeof helmetAsync | undefined>;
 const { HelmetProvider } = (helmetModule["default"] ?? helmetAsync) as typeof helmetAsync;

--- a/src/pages/CatalogPage.tsx
+++ b/src/pages/CatalogPage.tsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from "@tanstack/react-router";
+import { Link, useLocation, useNavigate } from "@tanstack/react-router";
 import { ArrowRight, BookOpen, Search, SlidersHorizontal, Sparkles } from "lucide-react";
 import { useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -33,12 +33,18 @@ function isSurfaceFilter(value: string | null): value is SurfaceFilter {
   return value === "components" || value === "playgrounds" || value === "guides";
 }
 
-function readCatalogState(fallback: SurfaceFilter) {
-  const params = new URLSearchParams(window.location.search);
+function isCategoryId(value: string | null): value is string {
+  return value !== null && categories.some((category) => category.id === value);
+}
+
+function readCatalogState(search: string, fallback: SurfaceFilter) {
+  const params = new URLSearchParams(search);
   const surface = params.get("surface");
+  const category = params.get("category");
   return {
     surface: isSurfaceFilter(surface) ? surface : fallback,
-    query: params.get("q") ?? ""
+    query: params.get("q") ?? "",
+    categoryId: isCategoryId(category) ? category : undefined
   };
 }
 
@@ -50,21 +56,27 @@ export function CatalogPage({
   initialSurface?: SurfaceFilter;
 }) {
   const { t } = useTranslation();
+  const location = useLocation();
   const navigate = useNavigate();
   const [surface, setSurface] = useState<SurfaceFilter>(initialSurface);
   const [query, setQuery] = useState("");
+  const [categoryId, setCategoryId] = useState<string>();
   const deferredQuery = useDeferredValue(query);
   const searchRef = useRef<HTMLInputElement>(null);
   const activeFilter = surfaceFilterById.get(surface) ?? surfaceFilters[0];
+  const clearFiltersLabel = query
+    ? t("catalog.clearSearch")
+    : locale === "zh" ? "清除筛选" : "Clear filters";
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {
-      const state = readCatalogState(initialSurface);
+      const state = readCatalogState(location.searchStr, initialSurface);
       setSurface(state.surface);
       setQuery(state.query);
+      setCategoryId(state.categoryId);
     }, 0);
     return () => window.clearTimeout(timeout);
-  }, [initialSurface, locale]);
+  }, [initialSurface, locale, location.searchStr]);
 
   useEffect(() => {
     function focusSearch(event: KeyboardEvent) {
@@ -83,20 +95,25 @@ export function CatalogPage({
     const normalized = deferredQuery.trim().toLowerCase();
     return catalogRecipes.filter((recipe) => {
       const meta = getMotionCatalogMeta(recipe);
-      return meta.surfaceType === activeFilter.surfaceType && (!normalized || createRecipeSearchIndex(recipe, locale).includes(normalized));
+      const matchesCategory = !categoryId || recipe.categoryId === categoryId;
+      return meta.surfaceType === activeFilter.surfaceType
+        && matchesCategory
+        && (!normalized || createRecipeSearchIndex(recipe, locale).includes(normalized));
     });
-  }, [activeFilter.surfaceType, deferredQuery, locale]);
+  }, [activeFilter.surfaceType, categoryId, deferredQuery, locale]);
 
   const grouped = categories
     .map((category) => ({ category, entries: filteredRecipes.filter((recipe) => recipe.categoryId === category.id) }))
     .filter((group) => group.entries.length > 0);
 
-  function updateUrl(nextSurface: SurfaceFilter, nextQuery: string) {
+  function updateUrl(nextSurface: SurfaceFilter, nextQuery: string, nextCategoryId?: string) {
     setSurface(nextSurface);
     setQuery(nextQuery);
+    setCategoryId(nextCategoryId);
     const params = new URLSearchParams();
     params.set("surface", nextSurface);
     if (nextQuery.trim()) params.set("q", nextQuery.trim());
+    if (nextCategoryId) params.set("category", nextCategoryId);
     void navigate({
       href: `${pathFor(locale, ["catalog"])}?${params.toString()}`,
       replace: true,
@@ -121,31 +138,14 @@ export function CatalogPage({
         ]}
       />
 
-      <section className="library-catalog-hero">
+      <section className="library-catalog-hero library-catalog-hero-unified">
         <span>{t("catalog.libraryLabel")}</span>
-        <h1>{t(`catalog.surfaces.${activeFilter.surfaceType}.title`)}</h1>
-        <p>{t(`catalog.surfaces.${activeFilter.surfaceType}.copy`)}</p>
+        <h1>{t("catalog.title")}</h1>
+        <p>{t("catalog.copy")}</p>
       </section>
 
-      <div className="library-surface-tabs" aria-label={t("catalog.surfaceLabel")}>
-        {surfaceFilters.map(({ id, icon: Icon }) => (
-          <button
-            type="button"
-            aria-pressed={surface === id}
-            className={surface === id ? "is-active" : undefined}
-            key={id}
-            onClick={() => updateUrl(id, query)}
-          >
-            <Icon aria-hidden="true" size={16} strokeWidth={1.7} />
-            <span>{t(`nav.${id}`)}</span>
-            <small>{surfaceCounts.get(id) ?? 0}</small>
-          </button>
-        ))}
-      </div>
-
-      <div className="library-catalog-layout" id="catalog-content">
-        <CatalogSidebar locale={locale} compact surfaceType={activeFilter.surfaceType} />
-        <div className="library-catalog-results">
+      <section className="library-catalog-toolbar" aria-label={t("catalog.surfaceLabel")}>
+        <div className="library-catalog-toolbar-primary">
           <label className="library-catalog-search" id="catalog-search">
             <Search aria-hidden="true" size={18} strokeWidth={1.8} />
             <input
@@ -154,17 +154,55 @@ export function CatalogPage({
               autoComplete="off"
               spellCheck={false}
               value={query}
-              onChange={(event) => updateUrl(surface, event.currentTarget.value)}
+              onChange={(event) => updateUrl(surface, event.currentTarget.value, categoryId)}
               placeholder={t("catalog.searchPlaceholder")}
               aria-label={t("common.search")}
             />
             <kbd>/</kbd>
           </label>
 
-          <div className="library-results-meta">
-            <span>{t("catalog.results", { count: filteredRecipes.length })}</span>
-            {query ? <button type="button" onClick={() => updateUrl(surface, "")}>{t("catalog.clearSearch")}</button> : null}
+          <div className="library-surface-tabs library-surface-control" aria-label={t("catalog.surfaceLabel")}>
+            {surfaceFilters.map(({ id, icon: Icon }) => (
+              <button
+                type="button"
+                aria-pressed={surface === id}
+                className={surface === id ? "is-active" : undefined}
+                key={id}
+                onClick={() => updateUrl(id, query)}
+              >
+                <Icon aria-hidden="true" size={16} strokeWidth={1.7} />
+                <span>{t(`nav.${id}`)}</span>
+                <small>{surfaceCounts.get(id) ?? 0}</small>
+              </button>
+            ))}
           </div>
+        </div>
+
+        <div className="library-catalog-toolbar-secondary">
+          <CatalogSidebar
+            locale={locale}
+            compact
+            filterMode
+            surfaceType={activeFilter.surfaceType}
+            selectedCategoryId={categoryId}
+            onCategoryChange={(nextCategoryId) => updateUrl(surface, query, nextCategoryId)}
+          />
+        </div>
+
+        <div className="library-results-meta">
+          <div>
+            <strong>{t(`catalog.surfaces.${activeFilter.surfaceType}.title`)}</strong>
+            <span>{t("catalog.results", { count: filteredRecipes.length })}</span>
+          </div>
+          <p>{t(`catalog.surfaces.${activeFilter.surfaceType}.copy`)}</p>
+          {query || categoryId ? (
+            <button type="button" onClick={() => updateUrl(surface, "")}>{clearFiltersLabel}</button>
+          ) : null}
+        </div>
+      </section>
+
+      <div className="library-catalog-layout is-unified" id="catalog-content">
+        <div className="library-catalog-results">
 
           {grouped.length > 0 ? grouped.map(({ category, entries }) => (
             <section className="library-catalog-group" key={category.id} aria-labelledby={`${category.id}-catalog-title`}>
@@ -230,7 +268,7 @@ export function CatalogPage({
             <section className="library-empty-state">
               <h2>{t("common.noRecipesTitle")}</h2>
               <p>{t("catalog.noResultsCopy")}</p>
-              <button className="library-button" type="button" onClick={() => updateUrl(surface, "")}>{t("catalog.clearSearch")}</button>
+              <button className="library-button" type="button" onClick={() => updateUrl(surface, "")}>{clearFiltersLabel}</button>
             </section>
           )}
         </div>

--- a/src/pages/CategoryPage.tsx
+++ b/src/pages/CategoryPage.tsx
@@ -1,7 +1,6 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowLeft, ArrowRight, BookOpen } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { CatalogSidebar } from "../components/CatalogSidebar";
 import { MotionThumbnail } from "../components/MotionThumbnail";
 import { Seo } from "../components/Seo";
 import { getCategory } from "../data/categories";
@@ -49,8 +48,7 @@ export function CategoryPage({ locale, categoryId }: CategoryPageProps) {
         ]}
       />
 
-      <div className="library-category-layout">
-        <CatalogSidebar locale={locale} activeCategoryId={category.id} compact />
+      <div className="library-category-layout apple-category-page">
         <div className="library-category-main">
           <nav className="library-breadcrumbs" aria-label={t("workspace.breadcrumbLabel")}>
             <Link to="/$locale/catalog/" params={{ locale }} search={{ surface: "components" }}>

--- a/src/pages/FinderPage.tsx
+++ b/src/pages/FinderPage.tsx
@@ -1,16 +1,17 @@
-import { ArrowRight, Search, Sparkles } from "lucide-react";
+import { ArrowRight, Search, SlidersHorizontal, Sparkles } from "lucide-react";
 import { useLocation, useNavigate } from "@tanstack/react-router";
 import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ExportPanel } from "../components/ExportPanel";
+import { FinderExportDisclosure } from "../components/FinderExportDisclosure";
 import { MotionCompare } from "../components/MotionCompare";
-import { MotionPreview } from "../components/MotionPreview";
 import { ParameterControls } from "../components/ParameterControls";
+import { CopyButton } from "../components/CopyButton";
 import { Seo } from "../components/Seo";
 import { pathFor, siteUrl } from "../data/site";
 import type { Locale, ParamValue, ParamValues } from "../data/types";
 import {
   buildRecipeJs,
+  buildRecipePrompt,
   parseParamValues,
   valuesToSearchParams
 } from "../lib/motion-engine";
@@ -241,14 +242,17 @@ export function FinderPage({ locale }: { locale: Locale }) {
         ]}
       />
 
-      <section className="finder-hero" aria-labelledby="finder-title">
+      <section
+        className={`finder-hero apple-finder-intake ${result ? "has-result" : "is-empty"}`}
+        aria-labelledby="finder-title"
+      >
         <div className="finder-hero-copy">
           <span>{t("finder.eyebrow")}</span>
           <h1 id="finder-title">{t("finder.title")}</h1>
           <p>{t("finder.copy")}</p>
         </div>
 
-        <form className="finder-search" role="search" onSubmit={handleSubmit}>
+        <form className="finder-search apple-search-pill" role="search" onSubmit={handleSubmit}>
           <label htmlFor="finder-query">{t("finder.formLabel")}</label>
           <div className="finder-search-field">
             <Search aria-hidden="true" size={20} strokeWidth={1.7} />
@@ -286,8 +290,11 @@ export function FinderPage({ locale }: { locale: Locale }) {
       </section>
 
       {result && candidates.length > 0 ? (
-        <section className="finder-results" aria-labelledby="finder-results-title">
-          <div className="library-doc-section-heading finder-results-heading">
+        <section
+          className="finder-results finder-workspace apple-finder-workspace"
+          aria-labelledby="finder-results-title"
+        >
+          <div className="library-doc-section-heading finder-results-heading finder-workspace-heading">
             <div>
               <span>{t("finder.resultEyebrow")}</span>
               <h2 id="finder-results-title">{t("finder.resultTitle")}</h2>
@@ -311,13 +318,68 @@ export function FinderPage({ locale }: { locale: Locale }) {
             <p className="finder-low-confidence" role="note">{t("finder.lowConfidence")}</p>
           ) : null}
 
-          <MotionCompare
-            locale={locale}
-            candidates={candidates}
-            selectedId={selectedId}
-            selectedValues={values}
-            onSelect={selectCandidate}
-          />
+          <div className="finder-workspace-shell apple-workspace-shell">
+            <div className="finder-workspace-stage">
+              <MotionCompare
+                locale={locale}
+                candidates={candidates}
+                selectedId={selectedId}
+                selectedValues={values}
+                onSelect={selectCandidate}
+              />
+            </div>
+
+            {selectedCandidate && values ? (
+              <aside
+                className="finder-tune finder-inspector apple-inspector"
+                aria-labelledby="finder-tune-title"
+                aria-label={t("finder.paramsLabel")}
+              >
+                <header className="finder-inspector-heading">
+                  <div>
+                    <span>{t("finder.tuneEyebrow")}</span>
+                    <h2 id="finder-tune-title">
+                      {t("finder.tuneTitle", { name: selectedCandidate.name })}
+                    </h2>
+                  </div>
+                  <SlidersHorizontal aria-hidden="true" size={18} strokeWidth={1.7} />
+                </header>
+
+                <p className="finder-inspector-copy">{t("finder.tuneCopy")}</p>
+                <div className="library-sync-status finder-inspector-status">
+                  <i aria-hidden="true" />
+                  {t("finder.readyStatus")}
+                </div>
+                <div className="finder-inspector-controls">
+                  <ParameterControls
+                    locale={locale}
+                    recipe={selectedCandidate.recipe}
+                    values={values}
+                    onChange={updateValue}
+                    onReset={resetValues}
+                  />
+                </div>
+                <CopyButton
+                  className="finder-primary-copy apple-primary-action"
+                  label={t("common.copyCurrentPrompt")}
+                  getText={() =>
+                    buildRecipePrompt(selectedCandidate.recipe, values, locale)
+                  }
+                />
+              </aside>
+            ) : null}
+          </div>
+
+          {selectedCandidate && values ? (
+            <div className="finder-workspace-output">
+              <p className="finder-change-hint">{t("finder.changeHint")}</p>
+              <FinderExportDisclosure
+                locale={locale}
+                recipe={selectedCandidate.recipe}
+                values={values}
+              />
+            </div>
+          ) : null}
         </section>
       ) : (
         <section className="finder-empty" aria-labelledby="finder-empty-title">
@@ -327,49 +389,6 @@ export function FinderPage({ locale }: { locale: Locale }) {
         </section>
       )}
 
-      {selectedCandidate && values ? (
-        <section className="finder-tune" aria-labelledby="finder-tune-title">
-          <div className="library-doc-section-heading">
-            <div>
-              <span>{t("finder.tuneEyebrow")}</span>
-              <h2 id="finder-tune-title">
-                {t("finder.tuneTitle", { name: selectedCandidate.name })}
-              </h2>
-            </div>
-            <p>{t("finder.tuneCopy")}</p>
-          </div>
-
-          <div className="library-workbench finder-workbench">
-            <div className="library-preview-frame">
-              <MotionPreview
-                locale={locale}
-                recipe={selectedCandidate.recipe}
-                values={values}
-              />
-            </div>
-            <aside className="library-parameter-panel" aria-label={t("finder.paramsLabel")}>
-              <div className="library-sync-status">
-                <i aria-hidden="true" />
-                {t("finder.readyStatus")}
-              </div>
-              <ParameterControls
-                locale={locale}
-                recipe={selectedCandidate.recipe}
-                values={values}
-                onChange={updateValue}
-                onReset={resetValues}
-              />
-            </aside>
-          </div>
-
-          <p className="finder-change-hint">{t("finder.changeHint")}</p>
-          <ExportPanel
-            locale={locale}
-            recipe={selectedCandidate.recipe}
-            values={values}
-          />
-        </section>
-      ) : null}
     </>
   );
 }

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -1,34 +1,14 @@
 import { Link } from "@tanstack/react-router";
-import { ArrowRight, BookOpen, SlidersHorizontal, Sparkles } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import { useTranslation } from "react-i18next";
-import { FeatureGrid } from "../components/FeatureGrid";
 import { Hero } from "../components/Hero";
 import { MotionThumbnail } from "../components/MotionThumbnail";
 import { Seo } from "../components/Seo";
 import { compactCatalogEntries, getCompactCatalogEntry } from "../data/compact-catalog";
-import type { Locale, MotionSurfaceType } from "../data/types";
+import type { Locale } from "../data/types";
 import { pathFor, siteUrl, text } from "../data/site";
 
-type Surface = "components" | "playgrounds" | "guides";
-
-const featuredIds = [
-  "slide-in",
-  "stagger",
-  "press-tap-feedback",
-  "text-morph",
-  "spring",
-  "page-transition"
-];
-
-const surfaces: Array<{
-  id: Surface;
-  surfaceType: MotionSurfaceType;
-  icon: typeof Sparkles;
-}> = [
-  { id: "components", surfaceType: "component", icon: Sparkles },
-  { id: "playgrounds", surfaceType: "playground", icon: SlidersHorizontal },
-  { id: "guides", surfaceType: "guide", icon: BookOpen }
-];
+const featuredIds = ["spring", "morph", "stagger"];
 
 export function LandingPage({ locale }: { locale: Locale }) {
   const { t } = useTranslation();
@@ -64,21 +44,38 @@ export function LandingPage({ locale }: { locale: Locale }) {
           }
         ]}
       />
+
       <Hero locale={locale} />
 
-      <section className="library-featured" aria-labelledby="featured-title">
-        <div className="library-section-heading">
+      <section className="apple-home-library" aria-labelledby="home-library-title">
+        <div className="apple-home-library-heading">
           <div>
-            <span>{t("landing.featuredLabel")}</span>
-            <h2 id="featured-title">{t("landing.featuredTitle")}</h2>
+            <span>{locale === "zh" ? "动效库" : "MOTION LIBRARY"}</span>
+            <h2 id="home-library-title">
+              {locale === "zh" ? "从相近的感觉开始探索。" : "Explore motions that feel close."}
+            </h2>
           </div>
-          <p>{t("landing.featuredCopy")}</p>
+          <div>
+            <p>
+              {locale === "zh"
+                ? "每个配方都有真实预览、可调参数、准确提示词与可复制实现。"
+                : "Every recipe includes a live preview, tunable parameters, precise prompts, and portable code."}
+            </p>
+            <Link
+              to="/$locale/catalog/"
+              params={{ locale }}
+              search={{ surface: "components" }}
+            >
+              {locale === "zh" ? "浏览完整动效库" : "Browse the full library"}
+              <ArrowRight aria-hidden="true" size={16} />
+            </Link>
+          </div>
         </div>
 
-        <div className="library-card-grid library-home-feature-grid is-component">
+        <div className="library-card-grid apple-home-card-grid is-component">
           {featured.map((recipe) => (
             <Link
-              className="library-card"
+              className="library-card apple-motion-card"
               key={recipe.id}
               to="/$locale/$categoryId/$recipeId/"
               params={{ locale, categoryId: recipe.categoryId, recipeId: recipe.id }}
@@ -93,56 +90,6 @@ export function LandingPage({ locale }: { locale: Locale }) {
               </div>
             </Link>
           ))}
-        </div>
-
-        <Link
-          className="library-featured-more"
-          to="/$locale/catalog/"
-          params={{ locale }}
-          search={{ surface: "components" }}
-        >
-          {t("landing.openFullCatalog")}
-          <ArrowRight aria-hidden="true" size={15} strokeWidth={1.8} />
-        </Link>
-      </section>
-
-      <FeatureGrid />
-
-      <section className="library-home-surfaces" aria-labelledby="library-title">
-        <div className="library-section-heading">
-          <div>
-            <span>{t("landing.directoryLabel")}</span>
-            <h2 id="library-title">{t("landing.directoryTitle")}</h2>
-          </div>
-          <p>{t("landing.directoryCopy")}</p>
-        </div>
-
-        <div className="library-home-surface-grid">
-          {surfaces.map(({ id, surfaceType, icon: Icon }) => {
-            const count = compactCatalogEntries.filter(
-              (recipe) => recipe.surfaceType === surfaceType
-            ).length;
-            return (
-              <Link
-                className={`library-home-surface is-${surfaceType}`}
-                key={id}
-                to="/$locale/catalog/"
-                params={{ locale }}
-                search={{ surface: id }}
-              >
-                <div className="library-home-surface-head">
-                  <span><Icon aria-hidden="true" size={17} strokeWidth={1.7} /></span>
-                  <small>{count}</small>
-                </div>
-                <h3>{t(`catalog.surfaces.${surfaceType}.title`)}</h3>
-                <p>{t(`catalog.surfaces.${surfaceType}.copy`)}</p>
-                <strong>
-                  {t(`nav.${id}`)}
-                  <ArrowRight aria-hidden="true" size={15} strokeWidth={1.8} />
-                </strong>
-              </Link>
-            );
-          })}
         </div>
       </section>
     </>

--- a/src/pages/RecipePage.tsx
+++ b/src/pages/RecipePage.tsx
@@ -1,8 +1,7 @@
-import { CatalogSidebar } from "../components/CatalogSidebar";
 import { RecipeWorkspace } from "../components/RecipeWorkspace";
 import { Seo } from "../components/Seo";
 import { getCategory } from "../data/categories";
-import { getMotionCatalogMeta, getRecipe } from "../data/recipes";
+import { getRecipe } from "../data/recipes";
 import type { Locale } from "../data/types";
 import { pathFor, text } from "../data/site";
 import { breadcrumbStructuredData, entryStructuredData } from "../lib/structured-data";
@@ -22,7 +21,6 @@ export function RecipePage({ locale, categoryId, recipeId }: RecipePageProps) {
   }
 
   const category = getCategory(recipe.categoryId);
-  const meta = getMotionCatalogMeta(recipe);
 
   return (
     <>
@@ -44,13 +42,7 @@ export function RecipePage({ locale, categoryId, recipeId }: RecipePageProps) {
             : []
         }
       />
-      <div className="library-doc-layout">
-        <CatalogSidebar
-          locale={locale}
-          activeCategoryId={recipe.categoryId}
-          activeRecipeId={recipe.id}
-          surfaceType={meta.surfaceType}
-        />
+      <div className="apple-recipe-page">
         <RecipeWorkspace key={recipe.id} locale={locale} recipe={recipe} mode="recipe" />
       </div>
     </>

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -4,11 +4,8 @@ test("desktop landing page renders without horizontal overflow", async ({ page }
   await page.goto("/zh/");
   await expect(page).toHaveTitle(/Motion Lexicon/);
   await expect(page.getByRole("heading", { name: /说出你要的感觉/ })).toBeVisible();
-  await expect(page.getByRole("link", { name: /开始描述动效/ })).toHaveAttribute(
-    "href",
-    "/zh/finder/"
-  );
-  await expect(page.locator(".library-card")).toHaveCount(6);
+  await expect(page.getByRole("button", { name: /开始描述动效/ })).toBeVisible();
+  await expect(page.locator(".library-card")).toHaveCount(3);
 
   const hasHorizontalOverflow = await page.evaluate(() => {
     return document.documentElement.scrollWidth > window.innerWidth;
@@ -25,6 +22,7 @@ test("english landing page renders english copy", async ({ page }) => {
 test("recipe controls update generated CSS, prompt, and URL query", async ({ page }) => {
   await page.goto("/zh/entrances/slide-in/");
   await expect(page.getByRole("heading", { level: 1, name: "滑入" })).toBeVisible();
+  await page.locator(".apple-output-disclosure summary").click();
 
   await page.getByRole("slider").first().press("ArrowRight");
 

--- a/tests/e2e/finder.spec.ts
+++ b/tests/e2e/finder.spec.ts
@@ -71,6 +71,7 @@ test("Finder creates a shareable selection and parameter state", async ({ page }
   await firstSlider.press("ArrowRight");
   await expect(page).toHaveURL(/duration=/);
 
+  await page.locator(".apple-export-disclosure summary").click();
   await page.getByRole("tab", { name: "Prompt" }).click();
   await expect(page).toHaveURL(/tab=prompt/);
   await firstSlider.press("ArrowRight");

--- a/tests/e2e/open-source-entry.spec.ts
+++ b/tests/e2e/open-source-entry.spec.ts
@@ -5,16 +5,24 @@ const repositoryUrl = "https://github.com/Ryan-yang125/motion-lexicon";
 test("landing page exposes GitHub, CLI, Skill, and versioned public data", async ({ page, request }) => {
   await page.goto("/zh/");
 
-  await expect(page.getByRole("link", { name: "Motion Lexicon on GitHub" })).toHaveAttribute(
+  await expect(page.getByRole("contentinfo").getByRole("link", { name: "GitHub" })).toHaveAttribute(
     "href",
     repositoryUrl
   );
-  await expect(page.getByText("npx github:Ryan-yang125/motion-lexicon", { exact: true })).toBeVisible();
-  await expect(
-    page.getByText("npx skills add Ryan-yang125/motion-lexicon --skill motion-lexicon", {
-      exact: true
-    })
-  ).toBeVisible();
+  await page.locator(".library-utility-menu summary").click();
+  const resources = page.locator(".library-utility-popover");
+  await expect(resources.getByRole("link", { name: "CLI", exact: true })).toHaveAttribute(
+    "href",
+    `${repositoryUrl}#free-cli-and-agent-skill`
+  );
+  await expect(resources.getByRole("link", { name: "Agent Skill", exact: true })).toHaveAttribute(
+    "href",
+    `${repositoryUrl}/tree/main/skills/motion-lexicon`
+  );
+  await expect(resources.getByRole("link", { name: "Catalog JSON", exact: true })).toHaveAttribute(
+    "href",
+    "/data/v1/catalog.json"
+  );
 
   const catalogResponse = await request.get("/data/v1/catalog.json");
   expect(catalogResponse.ok()).toBe(true);

--- a/tests/e2e/release.spec.ts
+++ b/tests/e2e/release.spec.ts
@@ -142,6 +142,7 @@ test("all canonical catalog entries expose a working surface contract", async ({
       await expect(page.locator("#exports")).toHaveCount(0);
       await expect(page.locator(".library-parameter-panel")).toHaveCount(0);
     } else {
+      await page.locator(".apple-output-disclosure summary").click();
       await expect(page.getByRole("tab", { name: "CSS" })).toBeVisible();
       await expect(page.getByRole("tab", { name: "HTML" })).toBeVisible();
       await expect(page.getByRole("tab", { name: "Prompt" })).toBeVisible();

--- a/tests/e2e/vocabulary.spec.ts
+++ b/tests/e2e/vocabulary.spec.ts
@@ -19,6 +19,7 @@ test("vocabulary publishes all 91 independently maintained terms", async ({ page
 
 test("vocabulary search finds aliases and links to their working component", async ({ page }) => {
   await page.goto("/zh/vocabulary/");
+  await page.locator(".library-utility-menu summary").click();
   await expect(page.getByRole("combobox", { name: "主题" })).toBeEnabled();
   const search = page.getByRole("searchbox", { name: "搜索动画词汇" });
   await search.fill("共享元素");


### PR DESCRIPTION
## Outcome

Rebuilds the web experience around Describe → Choose → Tune → Use with an Apple-inspired product hierarchy.

- Focused landing intake and representative preview
- One primary Finder candidate, two alternatives, synchronized comparison, and Inspector
- Unified Library toolbar and calmer browsing surface
- Recipe workbench with progressive output and reference disclosures
- Responsive light/dark materials plus reduced-motion, transparency, and contrast adaptations
- Updated product, design, and browser acceptance documentation

## Verification

- npm run lint
- npm run typecheck
- npm run test
- npm run i18n:check
- npm run vocabulary:check
- npm run seo:check
- npm run motion:check
- npm run a11y:check
- npm run build
- npm run bundle:check
- npm run crawl:dist
- npm run test:visual