### PR TITLE
Add bilingual product docs and address Finder reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 
 <h1 align="center">Motion Lexicon</h1>
 
+<p align="center">
+  <a href="./README.md"><strong>English</strong></a> ·
+  <a href="./README.zh-CN.md">简体中文</a>
+</p>
+
 <p align="center"><strong>Describe how motion should feel. Leave with an exact, copy-ready recipe.</strong></p>
 
 <p align="center">
@@ -16,8 +21,7 @@
 <p align="center">
   <a href="https://motion-lexicon.pages.dev/en/finder/"><strong>Try Motion Finder</strong></a> ·
   <a href="https://motion-lexicon.pages.dev/en/catalog/"><strong>Explore the Library</strong></a> ·
-  <a href="https://motion-lexicon.pages.dev/zh/">中文</a> ·
-  <a href="https://motion-lexicon.pages.dev/en/">English</a>
+  <a href="https://motion-lexicon.pages.dev/en/"><strong>Visit the Website</strong></a>
 </p>
 
 <p align="center">
@@ -32,7 +36,7 @@
 
 ## From a vague feeling to a usable motion
 
-You can start with the words already in your head:
+Start with the words already in your head:
 
 > “The card should pop in with weight, then settle cleanly.”
 
@@ -85,9 +89,10 @@ curated surface, keeping discovery broad and implementation focused.
 - **AI agents** that work better with precise prompts, structured data, and
   explicit constraints
 
-## Free CLI
+## Use it from the browser, CLI, or an agent
 
-Use the same recommendation model from your terminal:
+The website is the fastest visual path. The free CLI carries the same
+recommendation model into a terminal:
 
 ```bash
 npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 recommend \
@@ -109,9 +114,7 @@ npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 export spring \
 `recommend` returns up to three ranked variants with match reasons,
 distinctions, resolved presets, preview URLs, and a shareable comparison URL.
 
-## Free Agent Skill
-
-Install Motion Lexicon as an Agent Skill:
+Install the free Motion Lexicon Agent Skill:
 
 ```bash
 npx skills add Ryan-yang125/motion-lexicon --skill motion-lexicon
@@ -119,7 +122,6 @@ npx skills add Ryan-yang125/motion-lexicon --skill motion-lexicon
 
 The Skill guides an agent from a vague request through recommendation, visual
 comparison, parameter choices, accessibility checks, and implementation output.
-
 Agent integrations can also read:
 
 - [llms.txt](https://motion-lexicon.pages.dev/llms.txt)
@@ -130,38 +132,91 @@ Agent integrations can also read:
 
 ## Free, open, and portable
 
-Motion Lexicon runs as a static website and keeps the public product available
+Motion Lexicon runs as a static website and keeps the complete public product
 free of charge. The browser experience, CLI, Agent Skill, catalog data, and
-generated output are designed to travel easily between people and tools.
+generated output travel easily between people and tools.
 
 - Source code: [MIT](./LICENSE)
 - Project-authored content and data: [CC BY 4.0](./CONTENT-LICENSE)
 - Generated code fragments: [0BSD](./CONTENT-LICENSE)
 
-## For contributors
+## Project snapshot
 
-Motion Lexicon is built with React, TypeScript, Vite, TanStack Router, i18next,
-and a build-time static rendering pipeline. The production site ships as static
-HTML, CSS, and JavaScript with localized metadata for 120 canonical routes.
+**v0.2.0 is live.** The current release includes the bilingual Finder, 44
+canonical workspaces, all 91 source terms, the CLI, the Agent Skill, versioned
+machine-readable data, localized SEO, and 120 prerendered canonical routes.
+
+- Finder comparison state and non-default recipe parameters stay shareable in
+  the URL.
+- Preview, parameters, prompt, portable code, and reduced-motion output come
+  from one semantic motion specification.
+- Light and dark themes, keyboard and pointer interaction, reduced-motion
+  behavior, and responsive workspaces ship across the public experience.
+
+<!-- markdownlint-disable MD013 MD033 -->
+
+<details>
+<summary><strong>Engineering reference for contributors</strong></summary>
+
+### Core routes
+
+Every public product route is available in English (`/en/`) and Chinese
+(`/zh/`).
+
+| Route shape | Purpose |
+| --- | --- |
+| `/:locale/` | Product home |
+| `/:locale/finder/` | Natural-language motion recommendation and comparison |
+| `/:locale/catalog/` | Full 44-workspace library |
+| `/:locale/vocabulary/` | Complete 91-term vocabulary |
+| `/:locale/:category/` | Motion-family discovery page |
+| `/:locale/:category/:recipe/` | Canonical recipe workspace |
+| `/data/v1/*.json` | Versioned catalog, vocabulary, and schema |
+
+### Build and static delivery
+
+Motion Lexicon uses React, TypeScript, Vite, TanStack Router, and i18next. A
+production build runs this sequence:
+
+```text
+tsc -b
+→ vite build
+→ tsx --tsconfig tsconfig.app.json scripts/prerender.ts
+```
+
+The prerender step enumerates canonical routes from `src/data/site.ts`, renders
+them through `src/entry-server.tsx`, injects localized metadata, and writes
+`dist/<route>/index.html`. It also generates `dist/sitemap.xml`,
+`dist/robots.txt`, and static redirect rules. The build also carries favicon
+assets, bilingual social images, the web manifest, `404.html`, and static
+headers into `dist/`.
+
+The finished `dist/` directory contains static HTML, CSS, JavaScript, images,
+and data. It can be served from Cloudflare Pages, Vercel static hosting,
+Netlify, or any CDN-backed file server. React server rendering runs during the
+build only; production requires no Node server.
 
 ```bash
 npm install
 npm run dev
-```
-
-Create and inspect the production build:
-
-```bash
 npm run build
 npm run preview -- --host 127.0.0.1 --port 4173
 ```
 
-The main verification commands are:
+### Quality gates
 
 ```bash
 npm run lint
 npm run typecheck
 npm run test
+npm run i18n:check
+npm run vocabulary:check
+npm run seo:check
+npm run motion:check
+npm run a11y:check
+npm run build
+npm run bundle:check
+npm run crawl:dist
 npm run test:visual
 ```
 
@@ -171,8 +226,12 @@ and [DESIGN.md](./DESIGN.md). Contribution guidelines are in
 [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md), and security reports follow
 [SECURITY.md](./SECURITY.md).
 
+</details>
+
+<!-- markdownlint-enable MD013 MD033 -->
+
 ---
 
 **[Describe a motion](https://motion-lexicon.pages.dev/en/finder/)** ·
 **[Browse all recipes](https://motion-lexicon.pages.dev/en/catalog/)** ·
-**[Open the Chinese site](https://motion-lexicon.pages.dev/zh/)**
+**[阅读中文 README](./README.zh-CN.md)**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,209 @@
+<!-- markdownlint-disable MD013 MD033 MD041 -->
+
+<p align="center">
+  <img src="public/brand/motion-lexicon-mark.svg" width="88" height="88" alt="Motion Lexicon 标志" />
+</p>
+
+<h1 align="center">Motion Lexicon</h1>
+
+<p align="center">
+  <a href="./README.md">English</a> ·
+  <a href="./README.zh-CN.md"><strong>简体中文</strong></a>
+</p>
+
+<p align="center"><strong>描述你想要的感觉，获得精确、可复制的动效方案。</strong></p>
+
+<p align="center">
+  为产品创作者、设计师、开发者和 AI Agent 打造的免费可视化动效选择器。<br />
+  <strong>描述 → 选择 → 调整 → 使用</strong>
+</p>
+
+<p align="center">
+  <a href="https://motion-lexicon.pages.dev/zh/finder/"><strong>体验 Motion Finder</strong></a> ·
+  <a href="https://motion-lexicon.pages.dev/zh/catalog/"><strong>浏览动效库</strong></a> ·
+  <a href="https://motion-lexicon.pages.dev/zh/"><strong>访问网站</strong></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/Ryan-yang125/motion-lexicon/actions/workflows/ci.yml"><img src="https://github.com/Ryan-yang125/motion-lexicon/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/badge/code-MIT-black.svg" alt="代码许可证：MIT" /></a>
+  <a href="./CONTENT-LICENSE"><img src="https://img.shields.io/badge/content-CC_BY_4.0-0A84FF.svg" alt="内容许可证：CC BY 4.0" /></a>
+</p>
+
+<!-- markdownlint-enable MD013 MD033 MD041 -->
+
+![Motion Lexicon 首页——描述你想要的动效](docs/assets/readme-home.webp)
+
+## 从模糊感觉走向可用动效
+
+直接说出脑海里的那句话：
+
+> “卡片弹出来要有重量，最后收得住。”
+
+Motion Finder 会把这句话转化成一条清晰的工作流：
+
+1. **描述**感觉、目的或行为，支持中文和英文。
+2. **选择**三个排序后的候选，查看匹配原因和关键区别。
+3. **调整**选中的动效，在实时预览中确认参数变化。
+4. **使用**适合 Agent 的 Prompt，或可移植的 HTML、CSS 和 JavaScript。
+
+完整状态保存在 URL 中，方便分享给团队成员，也能随时回到同一个动效决策。
+
+![Motion Finder——候选推荐与同步比较](docs/assets/readme-finder.webp)
+
+## 每个动效都有一张可视化工作台
+
+每张动效方案都把预览、控制、实现和设计指导放在同一个页面中。
+
+- 大尺寸实时预览，支持重播、设备切换和减少动态效果模式
+- 聚焦关键参数的 Inspector 调节面板
+- 从同一份动效规范生成 Prompt、HTML、CSS 和框架无关的 JavaScript
+- 包含用途、使用频率、交互规则、评审标准和无障碍指导
+- 每个方案和参数状态都有稳定、可分享的 URL
+
+![动效方案工作台——预览、Inspector 与可复制实现](docs/assets/readme-workspace.webp)
+
+## 可以探索什么
+
+| 产品界面 | 可以获得什么 |
+| --- | --- |
+| [Motion Finder](https://motion-lexicon.pages.dev/zh/finder/) | 根据自然语言需求给出三个可解释的推荐 |
+| [动效库](https://motion-lexicon.pages.dev/zh/catalog/) | 12 个动效类别中的 44 张精选可视化工作台 |
+| [动效词汇](https://motion-lexicon.pages.dev/zh/vocabulary/) | 91 个中英双语术语、精确定义和近义词区别 |
+| [方案工作台](https://motion-lexicon.pages.dev/zh/entrances/slide-in/) | 实时预览、参数、Prompt、可移植代码和评审指导 |
+| [版本化数据](https://motion-lexicon.pages.dev/data/v1/catalog.json) | 供工具和 Agent 使用的结构化词典、目录与 Schema |
+
+44 张标准工作台由 31 个可复制组件、9 个专项 Playground 和 4 份实用指南组成。全部 91 个源术语都会进入这套精选体系，让探索范围足够广，也让实现路径保持聚焦。
+
+## 适合谁使用
+
+- **产品创作者**：已经知道想要什么感觉，希望找到准确的动效语言
+- **设计师**：需要通过可视化方式比较相近的动画模式
+- **开发者**：希望获得具体参数和可移植的实现代码
+- **AI Agent**：通过精确 Prompt、结构化数据和明确约束提高实现质量
+
+## 在浏览器、CLI 和 Agent 中使用
+
+网站提供最快的可视化路径。免费 CLI 可以在终端里调用同一套推荐模型：
+
+```bash
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 recommend \
+  "卡片弹出来要有重量，最后收得住" \
+  --locale zh \
+  --format json
+```
+
+继续完成搜索、查看和实现导出：
+
+```bash
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 search \
+  "共享元素" --locale zh
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 show spring --locale zh
+npx -y github:Ryan-yang125/motion-lexicon#v0.2.0 export spring \
+  --locale zh --format bundle
+```
+
+`recommend` 最多返回三个排序后的候选，包含匹配原因、差异说明、完整预设、预览链接和可分享的比较链接。
+
+安装免费的 Motion Lexicon Agent Skill：
+
+```bash
+npx skills add Ryan-yang125/motion-lexicon --skill motion-lexicon
+```
+
+Skill 会引导 Agent 从模糊需求进入候选推荐、视觉比较、参数选择、无障碍检查和实现输出。Agent 也可以直接读取：
+
+- [llms.txt](https://motion-lexicon.pages.dev/llms.txt)
+- [llms-full.txt](https://motion-lexicon.pages.dev/llms-full.txt)
+- [Catalog JSON](https://motion-lexicon.pages.dev/data/v1/catalog.json)
+- [Vocabulary JSON](https://motion-lexicon.pages.dev/data/v1/vocabulary.json)
+- [JSON Schema](https://motion-lexicon.pages.dev/data/v1/schema.json)
+
+## 免费、开源、方便迁移
+
+Motion Lexicon 以静态网站运行，完整公共产品永久免费。浏览器体验、CLI、Agent Skill、目录数据和生成结果都可以轻松进入不同团队与工具。
+
+- 源代码：[MIT](./LICENSE)
+- 项目原创内容与数据：[CC BY 4.0](./CONTENT-LICENSE)
+- 生成的代码片段：[0BSD](./CONTENT-LICENSE)
+
+## 当前版本
+
+**v0.2.0 已上线。** 当前版本包含双语 Finder、44 张标准工作台、全部 91
+个源术语、CLI、Agent Skill、版本化机器可读数据、本地化 SEO，以及 120
+条预渲染标准路由。
+
+- Finder 比较状态和动效方案的非默认参数保存在 URL 中，随时可以分享。
+- 预览、参数、Prompt、可移植代码和减少动态效果输出来自同一份语义化动效规范。
+- 浅色与深色主题、键盘与指针交互、减少动态效果和响应式工作台已经覆盖公共体验。
+
+<!-- markdownlint-disable MD013 MD033 -->
+
+<details>
+<summary><strong>面向贡献者的工程参考</strong></summary>
+
+### 核心路由
+
+所有公共产品路由都提供英文版（`/en/`）和中文版（`/zh/`）。
+
+| 路由形式 | 用途 |
+| --- | --- |
+| `/:locale/` | 产品首页 |
+| `/:locale/finder/` | 自然语言动效推荐与比较 |
+| `/:locale/catalog/` | 包含 44 张工作台的完整动效库 |
+| `/:locale/vocabulary/` | 包含 91 个术语的完整词汇表 |
+| `/:locale/:category/` | 动效类别发现页 |
+| `/:locale/:category/:recipe/` | 标准动效方案工作台 |
+| `/data/v1/*.json` | 版本化目录、词汇与 Schema |
+
+### 构建与静态交付
+
+Motion Lexicon 使用 React、TypeScript、Vite、TanStack Router 和 i18next。生产构建依次执行：
+
+```text
+tsc -b
+→ vite build
+→ tsx --tsconfig tsconfig.app.json scripts/prerender.ts
+```
+
+预渲染步骤从 `src/data/site.ts` 枚举标准路由，通过 `src/entry-server.tsx` 完成渲染并注入本地化元数据，最终写入 `dist/<route>/index.html`。同一流程也会生成 `dist/sitemap.xml`、`dist/robots.txt` 和静态重定向规则。
+
+构建流程还会把 favicon、双语社交分享图、Web App Manifest、`404.html` 和静态响应头写入 `dist/`。
+
+最终的 `dist/` 目录包含静态 HTML、CSS、JavaScript、图片和数据，可以部署到 Cloudflare Pages、Vercel 静态托管、Netlify 或任意使用 CDN 的文件服务器。React 服务端渲染只在构建阶段运行，生产环境无需 Node 服务器。
+
+```bash
+npm install
+npm run dev
+npm run build
+npm run preview -- --host 127.0.0.1 --port 4173
+```
+
+### 质量门禁
+
+```bash
+npm run lint
+npm run typecheck
+npm run test
+npm run i18n:check
+npm run vocabulary:check
+npm run seo:check
+npm run motion:check
+npm run a11y:check
+npm run build
+npm run bundle:check
+npm run crawl:dist
+npm run test:visual
+```
+
+产品目标与实现决策记录在 [PRODUCT.md](./PRODUCT.md) 和 [DESIGN.md](./DESIGN.md) 中。参与贡献请阅读 [CONTRIBUTING.md](./CONTRIBUTING.md)，社区行为规范见 [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)，安全问题报告方式见 [SECURITY.md](./SECURITY.md)。
+
+</details>
+
+<!-- markdownlint-enable MD013 MD033 -->
+
+---
+
+**[描述一个动效](https://motion-lexicon.pages.dev/zh/finder/)** ·
+**[浏览全部方案](https://motion-lexicon.pages.dev/zh/catalog/)** ·
+**[Read the English README](./README.md)**

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "packages/cli/dist",
     "skills/motion-lexicon",
     "README.md",
+    "README.zh-CN.md",
     "LICENSE",
     "CONTENT-LICENSE",
     "NOTICE"

--- a/src/apple-redesign.css
+++ b/src/apple-redesign.css
@@ -1527,7 +1527,7 @@ summary {
 .library-category-filter-options::-webkit-scrollbar { display: none; }
 
 .library-category-filter-options button {
-  min-height: 38px;
+  min-height: 44px;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -1905,8 +1905,7 @@ summary {
     min-height: 118px;
   }
 
-  .finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-meta span,
-  .finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-actions {
+  .finder-choice-deck[data-layout="focus"] .apple-motion-alternative .finder-candidate-meta span {
     display: none;
   }
 

--- a/src/components/MotionCompare.tsx
+++ b/src/components/MotionCompare.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from "react-i18next";
 import type { Locale, ParamValues } from "../data/types";
 import {
   buildRecipeCss,
-  buildRecipeHtml,
   getMotionRuntimeConfig
 } from "../lib/motion-engine";
 import type { MotionFinderCandidate } from "../lib/motion-finder";
@@ -19,15 +18,74 @@ type MotionCompareProps = {
   onSelect: (candidate: MotionFinderCandidate) => void;
 };
 
+type ComparisonSceneKind = "entrance" | "continuity" | "sequence";
+
+function comparisonSceneKind(candidates: MotionFinderCandidate[]): ComparisonSceneKind {
+  const categoryId = candidates[0]?.recipe.categoryId;
+  if (categoryId === "state-transitions") return "continuity";
+  if (categoryId === "sequencing") return "sequence";
+  return "entrance";
+}
+
+function comparisonCardContent(locale: Locale, kind: ComparisonSceneKind) {
+  const title = locale === "zh" ? "产品更新" : "Product update";
+  return `<strong>${title}</strong>
+    <span class="motion-line"></span>
+    <span class="motion-line"></span>${kind === "sequence"
+      ? `<ol class="motion-list" aria-label="${title}"><li class="motion-list-item">01</li><li class="motion-list-item">02</li><li class="motion-list-item">03</li></ol>`
+      : ""}`;
+}
+
+function buildComparisonSceneHtml(
+  candidate: MotionFinderCandidate,
+  locale: Locale,
+  kind: ComparisonSceneKind
+) {
+  const id = candidate.recipe.canonicalId;
+  const content = comparisonCardContent(locale, kind);
+  const scene = kind === "continuity"
+    ? `<div class="motion-state-stack" data-comparison-scene data-comparison-kind="${kind}">
+    <article class="motion-state motion-state--from">${content}</article>
+    <article class="motion-state motion-state--to motion-surface">${content}</article>
+  </div>`
+    : `<article class="motion-surface" data-comparison-scene data-comparison-kind="${kind}" data-spring-target>
+    ${content}
+  </article>`;
+
+  return `<div class="motion-demo motion-demo--${id}" data-motion="${id}">
+  ${scene}
+  <button hidden data-motion-replay></button>
+</div>`;
+}
+
+function buildComparisonSceneCss(
+  candidate: MotionFinderCandidate,
+  kind: ComparisonSceneKind
+) {
+  const root = `.motion-demo.motion-demo--${candidate.recipe.canonicalId}`;
+  const common = `${root} .motion-list{display:grid;gap:.38rem;width:100%;margin:.2rem 0 0;padding:0;list-style:none}
+${root} .motion-list-item{padding:.35rem .5rem;background:#f4f4f5;border:1px solid #e4e4e7;border-radius:6px}`;
+
+  if (kind === "continuity") {
+    return `${common}
+${root} .motion-state{color:#18181b;background:#fff}
+${root} .motion-state--from{transform:translate3d(-12px,7px,0) scale(.94);background:#f4f4f5}`;
+  }
+
+  return common;
+}
+
 function CandidatePreview({
   candidate,
   compact,
+  kind,
   locale,
   replayKey,
   values
 }: {
   candidate: MotionFinderCandidate;
   compact: boolean;
+  kind: ComparisonSceneKind;
   locale: Locale;
   replayKey: number;
   values: ParamValues;
@@ -36,10 +94,10 @@ function CandidatePreview({
   const previousReplayRef = useRef(replayKey);
   const output = useMemo(
     () => ({
-      css: buildRecipeCss(candidate.recipe, values),
-      html: buildRecipeHtml(candidate.recipe, values, locale, candidate.name)
+      css: `${buildRecipeCss(candidate.recipe, values)}\n\n${buildComparisonSceneCss(candidate, kind)}`,
+      html: buildComparisonSceneHtml(candidate, locale, kind)
     }),
-    [candidate.name, candidate.recipe, locale, values]
+    [candidate, kind, locale, values]
   );
 
   useEffect(() => {
@@ -89,6 +147,7 @@ export function MotionCompare({
   const { t } = useTranslation();
   const [replayKey, setReplayKey] = useState(0);
   const [isComparing, setIsComparing] = useState(false);
+  const sceneKind = comparisonSceneKind(candidates);
 
   function replayTogether() {
     setIsComparing(true);
@@ -175,6 +234,7 @@ export function MotionCompare({
               <CandidatePreview
                 candidate={candidate}
                 compact={isComparing || !selected}
+                kind={sceneKind}
                 locale={locale}
                 replayKey={replayKey}
                 values={previewValues}

--- a/src/components/MotionCompare.tsx
+++ b/src/components/MotionCompare.tsx
@@ -63,8 +63,9 @@ function buildComparisonSceneCss(
   kind: ComparisonSceneKind
 ) {
   const root = `.motion-demo.motion-demo--${candidate.recipe.canonicalId}`;
-  const common = `${root} .motion-list{display:grid;gap:.38rem;width:100%;margin:.2rem 0 0;padding:0;list-style:none}
-${root} .motion-list-item{padding:.35rem .5rem;background:#f4f4f5;border:1px solid #e4e4e7;border-radius:6px}`;
+  const common = `${root} .motion-list{display:grid;gap:.4rem;margin:0;padding:0;list-style:none}
+${root} .motion-list-item{padding:.35rem .5rem;background:#f4f4f5;border:1px solid #e4e4e7;border-radius:6px}
+${root} [data-spring-target]{pointer-events:none;cursor:default!important}`;
 
   if (kind === "continuity") {
     return `${common}

--- a/src/lib/motion-finder.ts
+++ b/src/lib/motion-finder.ts
@@ -169,7 +169,7 @@ export function recommendMotions(
       ? "medium"
       : "low";
 
-  const candidates = selected.group.variants
+  const rankedCandidates = selected.group.variants
     .map((variant, index) => {
       const matched = selected.variants[index];
       const resolved = resolveVariant(variant.variantId);
@@ -202,10 +202,10 @@ export function recommendMotions(
       };
     })
     .sort((a, b) => b.evidence - a.evidence || a.sourceIndex - b.sourceIndex)
-    .slice(0, limit)
     .map(({ candidate }, index) => ({ ...candidate, rank: index + 1 }));
 
-  const variants = candidates.map((candidate) => candidate.variantId);
+  const candidates = rankedCandidates.slice(0, limit);
+  const variants = rankedCandidates.map((candidate) => candidate.variantId);
   return {
     query: cleanQuery,
     locale,

--- a/tests/cli/core.spec.ts
+++ b/tests/cli/core.spec.ts
@@ -60,6 +60,20 @@ describe("Motion Lexicon CLI API", () => {
     });
   });
 
+  it("keeps the full comparison trio in Finder links when --limit trims CLI items", () => {
+    for (const limit of [1, 2] as const) {
+      const result = recommend("卡片弹出来要有重量、最后收得住", {
+        locale: "zh",
+        limit
+      });
+      const compare = new URL(result.compareUrl).searchParams.get("compare");
+
+      expect(result.count).toBe(limit);
+      expect(result.items).toHaveLength(limit);
+      expect(compare).toBe("spring,pop-in,scale-in");
+    }
+  });
+
   it("resolves aliases and preserves their preset values", () => {
     const resolved = resolveRecipe("pop-in");
     expect(resolved).toMatchObject({
@@ -151,6 +165,23 @@ describe("runCli", () => {
       variantId: "shared-element-transition",
       canonicalId: "morph"
     });
+    expect(output.stderr()).toBe("");
+  });
+
+  it("keeps a Top 3 web comparison when --limit reduces JSON items", async () => {
+    const output = capture();
+    expect(
+      await runCli(
+        ["recommend", "card enters with weight", "--limit", "1", "--format", "json"],
+        output.io
+      )
+    ).toBe(0);
+    const result = JSON.parse(output.stdout());
+    const compare = new URL(result.compareUrl).searchParams.get("compare");
+
+    expect(result.count).toBe(1);
+    expect(result.items).toHaveLength(1);
+    expect(compare?.split(",")).toHaveLength(3);
     expect(output.stderr()).toBe("");
   });
 

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -78,3 +78,19 @@ test("mobile route is readable without horizontal overflow", async ({ page }) =>
   });
   expect(hasHorizontalOverflow).toBe(false);
 });
+
+test("catalog category filters keep 44px touch targets", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 900 });
+  await page.goto("/zh/catalog/?surface=components");
+
+  const filters = page.locator(".library-category-filter-options button");
+  await expect(filters.first()).toBeVisible();
+  const heights = await filters.evaluateAll((buttons) =>
+    buttons.map((button) => button.getBoundingClientRect().height)
+  );
+  expect(heights.length).toBeGreaterThan(1);
+  expect(Math.min(...heights)).toBeGreaterThanOrEqual(44);
+
+  await filters.nth(1).click();
+  await expect(page).toHaveURL(/category=/);
+});

--- a/tests/e2e/finder.spec.ts
+++ b/tests/e2e/finder.spec.ts
@@ -44,6 +44,24 @@ test("Finder restores a shared comparison and keeps variant CSS isolated", async
   expect(new Set(comparisonScenes.map((scene) => scene.content)).size).toBe(1);
   expect(comparisonScenes.map((scene) => scene.label)).toEqual(["产品更新", "产品更新", "产品更新"]);
 
+  const springComparisonTarget = await page
+    .locator("[data-variant-id='spring'] .finder-candidate-stage")
+    .evaluate((stage) => {
+      const target = stage.shadowRoot?.querySelector<HTMLElement>("[data-spring-target]");
+      return target
+        ? {
+            cursor: getComputedStyle(target).cursor,
+            pointerEvents: getComputedStyle(target).pointerEvents,
+            tabIndex: target.tabIndex
+          }
+        : null;
+    });
+  expect(springComparisonTarget).toEqual({
+    cursor: "default",
+    pointerEvents: "none",
+    tabIndex: -1
+  });
+
   await page.getByRole("button", { name: "同步重播" }).click();
   const comparisonGeometry = await page.locator(".finder-candidate-stage").evaluateAll((stages) =>
     stages.map((stage) => {
@@ -166,7 +184,8 @@ test("Finder remains readable on a mobile viewport", async ({ page }, testInfo) 
   test.skip(!testInfo.project.name.includes("mobile"), "Mobile layout runs once in the mobile project.");
 
   await page.goto(`/en/finder/?q=${encodeURIComponent("bring in a list one by one")}`);
-  await expect(page.getByRole("heading", { level: 1, name: /Describe the feel/ })).toBeVisible();
+  await expect(page.locator("h1#finder-title")).toHaveText(/Describe the feel/);
+  await expect(page.getByRole("region", { name: /Describe the feel/ })).toBeVisible();
   await expect(page.locator(".finder-candidate")).toHaveCount(3);
 
   const alternative = page.locator(".apple-motion-alternative").first();

--- a/tests/e2e/finder.spec.ts
+++ b/tests/e2e/finder.spec.ts
@@ -62,7 +62,10 @@ test("Finder restores a shared comparison and keeps variant CSS isolated", async
     tabIndex: -1
   });
 
-  await page.getByRole("button", { name: "同步重播" }).click();
+  const replayTogether = page.getByRole("button", { name: "同步重播" });
+  await replayTogether.focus();
+  await expect(replayTogether).toBeFocused();
+  await replayTogether.click();
   const comparisonGeometry = await page.locator(".finder-candidate-stage").evaluateAll((stages) =>
     stages.map((stage) => {
       const scene = stage.shadowRoot?.querySelector<HTMLElement>("[data-comparison-scene]");

--- a/tests/e2e/finder.spec.ts
+++ b/tests/e2e/finder.spec.ts
@@ -30,12 +30,34 @@ test("Finder restores a shared comparison and keeps variant CSS isolated", async
   expect(isolatedStyles.every((stage) => stage.hasShadowRoot)).toBe(true);
   expect(isolatedStyles[0].css).toContain("scale(0.92)");
   expect(isolatedStyles[1].css).toContain("scale(0.86)");
-  const previewLabels = await page.locator(".finder-candidate-stage").evaluateAll((stages) =>
-    stages.map((stage) => stage.shadowRoot?.querySelector("strong")?.textContent ?? "")
+  const comparisonScenes = await page.locator(".finder-candidate-stage").evaluateAll((stages) =>
+    stages.map((stage) => {
+      const scene = stage.shadowRoot?.querySelector<HTMLElement>("[data-comparison-scene]");
+      return {
+        content: scene?.innerHTML ?? "",
+        kind: scene?.dataset.comparisonKind,
+        label: scene?.querySelector("strong")?.textContent ?? ""
+      };
+    })
   );
-  expect(previewLabels).toEqual(["缩放入场", "弹入", "弹簧"]);
+  expect(comparisonScenes.map((scene) => scene.kind)).toEqual(["entrance", "entrance", "entrance"]);
+  expect(new Set(comparisonScenes.map((scene) => scene.content)).size).toBe(1);
+  expect(comparisonScenes.map((scene) => scene.label)).toEqual(["产品更新", "产品更新", "产品更新"]);
 
   await page.getByRole("button", { name: "同步重播" }).click();
+  const comparisonGeometry = await page.locator(".finder-candidate-stage").evaluateAll((stages) =>
+    stages.map((stage) => {
+      const scene = stage.shadowRoot?.querySelector<HTMLElement>("[data-comparison-scene]");
+      return {
+        stageWidth: (stage as HTMLElement).offsetWidth,
+        stageHeight: (stage as HTMLElement).offsetHeight,
+        sceneWidth: scene?.offsetWidth ?? 0,
+        sceneHeight: scene?.offsetHeight ?? 0
+      };
+    })
+  );
+  expect(new Set(comparisonGeometry.map((item) => `${item.stageWidth}x${item.stageHeight}`)).size).toBe(1);
+  expect(new Set(comparisonGeometry.map((item) => `${item.sceneWidth}x${item.sceneHeight}`)).size).toBe(1);
   await expect(page.getByRole("heading", { level: 2, name: /调节.*弹入/ })).toBeVisible();
 
   await page.goto(
@@ -89,12 +111,72 @@ test("Finder creates a shareable selection and parameter state", async ({ page }
   expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
 });
 
+test("Finder keeps every intent group on one neutral comparison scene", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Shared scene geometry runs once on desktop.");
+
+  const scenarios = [
+    { query: "卡片弹出来要有重量，最后收得住", kind: "entrance" },
+    { query: "同一个缩略图展开成详情页", kind: "continuity" },
+    { query: "列表一个接一个出现", kind: "sequence" }
+  ];
+
+  for (const scenario of scenarios) {
+    await page.goto(`/zh/finder/?q=${encodeURIComponent(scenario.query)}`);
+    await expect(page.locator(".finder-candidate")).toHaveCount(3);
+    await page.getByRole("button", { name: "同步重播" }).click();
+
+    const scenes = await page.locator(".finder-candidate-stage").evaluateAll((stages) =>
+      stages.map((stage) => {
+        const scene = stage.shadowRoot?.querySelector<HTMLElement>("[data-comparison-scene]");
+        return {
+          content: scene?.innerHTML ?? "",
+          kind: scene?.dataset.comparisonKind,
+          width: scene?.offsetWidth ?? 0,
+          height: scene?.offsetHeight ?? 0,
+          layers: scene
+            ? Array.from(scene.querySelectorAll<HTMLElement>(".motion-state")).map((layer) => ({
+                className: layer.className,
+                position: getComputedStyle(layer).position,
+                left: layer.offsetLeft,
+                top: layer.offsetTop,
+                width: layer.offsetWidth,
+                height: layer.offsetHeight
+              }))
+            : []
+        };
+      })
+    );
+
+    expect(scenes.map((scene) => scene.kind)).toEqual([
+      scenario.kind,
+      scenario.kind,
+      scenario.kind
+    ]);
+    expect(new Set(scenes.map((scene) => scene.content)).size).toBe(1);
+    expect(new Set(scenes.map((scene) => `${scene.width}x${scene.height}`)).size).toBe(1);
+    if (scenario.kind === "continuity") {
+      expect(new Set(scenes.map((scene) => JSON.stringify(scene.layers))).size).toBe(1);
+      expect(scenes[0].layers).toHaveLength(2);
+      expect(scenes[0].layers.every((layer) => layer.position === "absolute")).toBe(true);
+    }
+  }
+});
+
 test("Finder remains readable on a mobile viewport", async ({ page }, testInfo) => {
   test.skip(!testInfo.project.name.includes("mobile"), "Mobile layout runs once in the mobile project.");
 
   await page.goto(`/en/finder/?q=${encodeURIComponent("bring in a list one by one")}`);
   await expect(page.getByRole("heading", { level: 1, name: /Describe the feel/ })).toBeVisible();
   await expect(page.locator(".finder-candidate")).toHaveCount(3);
+
+  const alternative = page.locator(".apple-motion-alternative").first();
+  const alternativeId = await alternative.getAttribute("data-variant-id");
+  const selectAlternative = alternative.locator(".finder-select");
+  await expect(selectAlternative).toBeVisible();
+  const target = await selectAlternative.boundingBox();
+  expect(target?.height ?? 0).toBeGreaterThanOrEqual(44);
+  await selectAlternative.click();
+  await expect(page.locator(`[data-variant-id='${alternativeId}']`)).toHaveClass(/is-selected/);
 
   const hasHorizontalOverflow = await page.evaluate(
     () => document.documentElement.scrollWidth > window.innerWidth


### PR DESCRIPTION
## What changed

- Added an English / 简体中文 switch to the default product README and a complete Chinese product README.
- Kept the product story, screenshots, Finder, Library, CLI, Skill, and open data prominent in both languages.
- Restored the current release snapshot, route model, prerender pipeline, SEO artifacts, static deployment contract, and complete quality gates in a compact contributor disclosure.
- Added the Chinese README to the published package.
- Rebuilt Finder comparison previews around one neutral scene per intent group, so candidates share content, DOM, and geometry while their motion behavior changes.
- Kept full Top 3 comparison links when CLI `--limit` trims returned items.
- Restored direct mobile selection for alternative Finder candidates.
- Raised catalog category filters to the 44px touch-target baseline.

## Why

This addresses all five still-current Codex Review findings from PRs #23, #25, and #26. The changes restore the core Describe → Choose → Tune → Use flow on mobile, make visual comparison trustworthy, keep CLI and web share state aligned, and preserve README as both a product introduction and a concise project source of truth.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test` — 52 passed
- `npm run i18n:check`
- `npm run vocabulary:check`
- `npm run seo:check`
- `npm run motion:check`
- `npm run a11y:check`
- `npm run build`
- `npm run bundle:check` — 230 KiB gzip
- `npm run crawl:dist` — 120 canonical routes
- `npm run test:visual` — 35 passed, 11 device-conditional skips
- Markdownlint — 0 issues
- Package dry run includes both README files

## Codex Review follow-up

The follow-up review correctly identified a pointer-only Spring target inside the neutral comparison scene. The comparison canvas is now pointer-inert for every candidate, and the shared **Replay together** button is the single keyboard-focusable replay control. The browser regression verifies the inert Spring target, focus transfer, and keyboard-operable shared replay. Final Quality and Browser CI checks pass on commit `47853b2`.