### PR TITLE
Fix seamless catalog previews and responsive overflow

### DIFF
--- a/src/apple-redesign.css
+++ b/src/apple-redesign.css
@@ -472,12 +472,11 @@ summary {
 }
 
 .apple-scene-card strong {
-  overflow: hidden;
+  min-width: 0;
+  overflow-wrap: anywhere;
   color: var(--apple-ink);
   font-size: 0.86rem;
   font-weight: 650;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .apple-scene-card div > i { width: 86%; height: 5px; }
@@ -657,9 +656,10 @@ summary {
 
   .apple-hero-examples button {
     min-height: 44px;
-    overflow: hidden;
+    padding-block: 0.65rem;
+    overflow-wrap: anywhere;
     text-align: start;
-    text-overflow: ellipsis;
+    white-space: normal;
   }
 
   .apple-hero-proof { gap: 0.55rem; }
@@ -1127,7 +1127,8 @@ summary {
 
 .finder-inspector-controls {
   max-height: min(52dvh, 570px);
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   margin: 0.9rem -0.35rem 0;
   padding: 0 0.35rem;
   overscroll-behavior: contain;
@@ -1305,6 +1306,7 @@ summary {
 
 .library-category-filter {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.8rem;
 }
@@ -1343,14 +1345,12 @@ summary {
 
 .library-category-filter-options {
   min-width: 0;
+  flex: 1 1 42rem;
   display: flex;
+  flex-wrap: wrap;
   gap: 0.3rem;
-  overflow-x: auto;
   padding: 0.15rem 0.2rem 0.25rem;
-  scrollbar-width: none;
 }
-
-.library-category-filter-options::-webkit-scrollbar { display: none; }
 
 .library-category-filter-options button {
   min-height: 44px;
@@ -1719,16 +1719,14 @@ summary {
   }
 
   .library-surface-control.library-surface-tabs {
-    overflow-x: auto;
-    scrollbar-width: none;
-    mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 24px), transparent 100%);
-    -webkit-mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 24px), transparent 100%);
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
-  .library-surface-control.library-surface-tabs::-webkit-scrollbar { display: none; }
-
   .library-surface-control.library-surface-tabs button {
-    flex: 0 0 auto;
+    width: 100%;
+    min-width: 0;
+    grid-template-columns: 14px minmax(0, 1fr);
     padding: 0 0.7rem;
   }
 
@@ -1756,23 +1754,15 @@ summary {
   .library-catalog-layout.is-unified .library-card-grid.is-component,
   .library-catalog-layout.is-unified .library-card-grid.is-playground,
   .library-catalog-layout.is-unified .library-card-grid.is-guide {
-    display: flex;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
     gap: 0.75rem;
-    overflow-x: auto;
-    padding: 0.15rem 0.15rem 1rem;
-    scroll-padding-inline: 0.15rem;
-    scroll-snap-type: x proximity;
-    scrollbar-width: none;
-  }
-
-  .library-catalog-layout.is-unified .library-card-grid::-webkit-scrollbar {
-    display: none;
+    padding: 0.15rem;
   }
 
   .library-catalog-layout.is-unified .library-card {
-    width: min(82vw, 300px);
-    flex: 0 0 min(82vw, 300px);
-    scroll-snap-align: start;
+    width: 100%;
+    min-width: 0;
   }
 
   .library-footer-compact.library-footer {
@@ -2536,23 +2526,21 @@ summary {
 }
 
 .vocabulary-index {
-  overflow-x: auto;
+  min-width: 0;
   border: 0;
   margin: 1rem 0 0;
   padding: 0.3rem;
   background: transparent;
-  scrollbar-width: none;
 }
 
-.vocabulary-index::-webkit-scrollbar { display: none; }
-
 .vocabulary-index a {
+  min-width: 0;
   min-height: 44px;
-  flex: 0 0 auto;
   border: 0;
   border-radius: var(--ui-radius-nav);
   background: var(--apple-surface);
   box-shadow: inset 0 0 0 1px var(--apple-line);
+  overflow-wrap: anywhere;
 }
 
 .vocabulary-group {
@@ -3147,17 +3135,15 @@ summary {
 
 .finder-candidate-choice > span,
 .finder-candidate-choice > small {
-  overflow: hidden;
+  min-width: 0;
+  overflow-wrap: anywhere;
   color: var(--apple-secondary);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .finder-candidate-choice > strong {
-  overflow: hidden;
+  min-width: 0;
+  overflow-wrap: anywhere;
   color: var(--apple-ink);
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .finder-candidate-choice > svg {
@@ -3291,7 +3277,8 @@ summary {
 
 .library-code-file pre {
   max-height: 360px;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   margin: 0;
   padding: 16px;
   color: var(--apple-ink);
@@ -3299,6 +3286,9 @@ summary {
   font-size: 12px;
   line-height: 1.65;
   tab-size: 2;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 /* Catalog controls and real recipe previews. */
@@ -3319,23 +3309,11 @@ summary {
   height: 100%;
   display: grid;
   place-items: center;
-  opacity: 1;
-  transition: opacity 100ms ease-out;
 }
 
 .library-motion-thumb .motion-thumbnail-runtime {
   z-index: 2;
-  opacity: 0;
   background: var(--apple-surface-soft);
-  transition: opacity 120ms ease-out;
-}
-
-.library-motion-thumb.is-runtime-active .motion-thumbnail-fallback {
-  opacity: 0;
-}
-
-.library-motion-thumb.is-runtime-active .motion-thumbnail-runtime {
-  opacity: 1;
 }
 
 @media (max-width: 760px) {
@@ -3396,9 +3374,83 @@ summary {
   }
 
   .library-category-filter-options {
-    padding-inline-end: 32px;
-    mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 30px), transparent 100%);
-    -webkit-mask-image: linear-gradient(to right, #000 0, #000 calc(100% - 30px), transparent 100%);
+    padding-inline: 0;
+  }
+
+  .apple-reference-topic,
+  .apple-reference-section .library-table-scroll {
+    min-width: 0;
+  }
+
+  .apple-reference-section .library-table-scroll {
+    border: 0;
+  }
+
+  .apple-reference-section .library-parameter-table,
+  .apple-reference-section .library-parameter-table tbody,
+  .apple-reference-section .library-parameter-table tr,
+  .apple-reference-section .library-parameter-table td {
+    width: 100%;
+    min-width: 0;
+    display: block;
+  }
+
+  .apple-reference-section .library-parameter-table thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+  }
+
+  .apple-reference-section .library-parameter-table tbody {
+    display: grid;
+    gap: 10px;
+  }
+
+  .apple-reference-section .library-parameter-table tr {
+    overflow: hidden;
+    border: 1px solid var(--apple-line);
+    border-radius: var(--ui-radius-card);
+    background: var(--apple-surface);
+  }
+
+  .apple-reference-section .library-parameter-table td {
+    display: grid;
+    grid-template-columns: minmax(88px, 0.36fr) minmax(0, 1fr);
+    gap: 12px;
+    border-bottom: 1px solid var(--apple-line);
+    padding: 11px 12px;
+  }
+
+  .apple-reference-section .library-parameter-table td::before {
+    content: attr(data-label);
+    color: var(--apple-secondary);
+    font-size: var(--type-xs);
+    font-weight: 500;
+  }
+}
+
+@media (max-width: 480px) {
+  .library-surface-control.library-surface-tabs button {
+    grid-template-columns: minmax(0, 1fr);
+    padding-inline: 6px;
+    font-size: var(--type-xs);
+    text-align: center;
+  }
+
+  .library-surface-control.library-surface-tabs button > svg {
+    display: none;
+  }
+
+  .library-surface-control.library-surface-tabs button span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .vocabulary-index {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 
@@ -3408,8 +3460,6 @@ summary {
     animation: none;
   }
 
-  .library-motion-thumb .motion-thumbnail-fallback,
-  .library-motion-thumb .motion-thumbnail-runtime,
   .finder-candidate-choice {
     transition: none;
   }

--- a/src/components/MotionThumbnail.tsx
+++ b/src/components/MotionThumbnail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef } from "react";
 import type { CompactCatalogEntry } from "../data/compact-catalog";
 import type { Locale, MotionFamily, MotionRecipe, ParamValues } from "../data/types";
 import { text } from "../data/site";
@@ -37,20 +37,23 @@ function mountCatalogSample(
   values: ParamValues
 ) {
   const id = recipe.canonicalId;
-  const config = getMotionRuntimeConfig(recipe, values, true);
+  const config = getMotionRuntimeConfig(recipe, values, false);
   const duration = Math.min(440, Math.max(160, config.duration));
   const animations: Animation[] = [];
-  const resets: Array<() => void> = [];
   const options: KeyframeAnimationOptions = {
     duration,
     easing: "cubic-bezier(0.23, 1, 0.32, 1)",
     iterations: 2,
-    direction: "alternate"
+    direction: "alternate",
+    fill: "both"
   };
 
   function play(target: Element | null, keyframes: Keyframe[]) {
     if (!target) return;
-    animations.push(target.animate(keyframes, options));
+    const animation = target.animate(keyframes, options);
+    animation.pause();
+    animation.currentTime = 0;
+    animations.push(animation);
   }
 
   if (id === "hover-effect") {
@@ -67,20 +70,10 @@ function mountCatalogSample(
     ]);
   } else if (id === "hold-to-confirm") {
     const progress = root.querySelector<HTMLElement>(".motion-progress");
-    if (progress) {
-      const previousClip = progress.style.clipPath;
-      const previousOrigin = progress.style.transformOrigin;
-      progress.style.clipPath = "none";
-      progress.style.transformOrigin = "left center";
-      resets.push(() => {
-        progress.style.clipPath = previousClip;
-        progress.style.transformOrigin = previousOrigin;
-      });
-      play(progress, [
-        { transform: "scaleX(0)", opacity: 0.65 },
-        { transform: "scaleX(1)", opacity: 1 }
-      ]);
-    }
+    play(progress, [
+      { clipPath: "inset(0 100% 0 0)", opacity: 1 },
+      { clipPath: "inset(0 0 0 0)", opacity: 1 }
+    ]);
     play(root.querySelector(".motion-button"), [
       { transform: "scale(1)" },
       { transform: `scale(${numberParam(values, "scale", 98) / 100})` }
@@ -103,43 +96,96 @@ function mountCatalogSample(
   } else if (id === "ripple") {
     const button = root.querySelector<HTMLElement>("[data-ripple-button]");
     if (button) {
-      const bounds = button.getBoundingClientRect();
-      button.dispatchEvent(new PointerEvent("pointerdown", {
-        bubbles: true,
-        button: 0,
-        clientX: bounds.left + bounds.width / 2,
-        clientY: bounds.top + bounds.height / 2,
-        isPrimary: true,
-        pointerId: 1
-      }));
-    }
-  } else if (id === "before-after-slider") {
-    const comparison = root.querySelector<HTMLElement>(".motion-comparison");
-    const after = root.querySelector<HTMLElement>(".motion-after");
-    if (after) {
-      const previousClip = after.style.clipPath;
-      const previousOrigin = after.style.transformOrigin;
-      after.style.clipPath = "none";
-      after.style.transformOrigin = "left center";
-      resets.push(() => {
-        after.style.clipPath = previousClip;
-        after.style.transformOrigin = previousOrigin;
-      });
-      play(after, [
-        { transform: "scaleX(0.28)" },
-        { transform: "scaleX(0.76)" }
+      const ink = button.querySelector<HTMLElement>("[data-catalog-sample-ripple]");
+      play(ink, [
+        { opacity: 0, transform: "translate(-50%, -50%) scale(0.95)" },
+        { opacity: config.rippleOpacity / 100, transform: "translate(-50%, -50%) scale(6)" }
       ]);
     }
-    const comparisonWidth = comparison?.getBoundingClientRect().width ?? 220;
+  } else if (id === "before-after-slider") {
+    const after = root.querySelector<HTMLElement>(".motion-after");
+    const destination = config.position >= 62 ? 28 : 76;
+    play(after, [
+      { clipPath: `inset(0 ${100 - config.position}% 0 0)` },
+      { clipPath: `inset(0 ${100 - destination}% 0 0)` }
+    ]);
     play(root.querySelector(".motion-divider"), [
-      { transform: `translate3d(${comparisonWidth * 0.28}px, 0, 0)` },
-      { transform: `translate3d(${comparisonWidth * 0.76}px, 0, 0)` }
+      { insetInlineStart: `${config.position}%`, transform: "translate3d(-1px, 0, 0)" },
+      { insetInlineStart: `${destination}%`, transform: "translate3d(-1px, 0, 0)" }
+    ]);
+  } else if (["scroll-reveal", "scroll-driven-animation", "parallax"].includes(id)) {
+    play(root.querySelector(".motion-surface"), id === "scroll-reveal"
+      ? [
+          { transform: "translate3d(0, 0, 0)", opacity: 1 },
+          { transform: `translate3d(0, ${Math.max(24, config.distance)}px, 0)`, opacity: 0.2 }
+        ]
+      : [
+          { transform: "translate3d(0, 0, 0)" },
+          { transform: `translate3d(0, -${Math.max(24, config.distance)}px, 0)` }
+        ]);
+  } else if (id === "spring") {
+    play(root.querySelector("[data-spring-target]"), [
+      { transform: "translate3d(0, 0, 0) scale(1)", opacity: 1 },
+      { transform: `translate3d(0, -${config.distance}px, 0) scale(0.94)`, opacity: 0.78 },
+      { transform: `translate3d(0, ${Math.round(config.distance * 0.14)}px, 0) scale(1.02)`, opacity: 1 },
+      { transform: "translate3d(0, 0, 0) scale(1)", opacity: 1 }
     ]);
   }
 
   return () => {
     for (const animation of animations) animation.cancel();
-    for (const reset of resets) reset();
+  };
+}
+
+const catalogStaticPreviewTime = 5_000;
+
+function freezeCatalogAnimations(animations: readonly Animation[]) {
+  for (const animation of animations) {
+    const effect = animation.effect;
+    const computed = effect?.getComputedTiming();
+    const timing = effect?.getTiming();
+    const delay = typeof timing?.delay === "number" ? timing.delay : 0;
+
+    animation.pause();
+    if (typeof computed?.endTime === "number" && Number.isFinite(computed.endTime)) {
+      animation.currentTime = computed.endTime;
+    } else if (typeof computed?.endTime === "number") {
+      animation.currentTime = Math.max(0, delay + catalogStaticPreviewTime);
+    }
+  }
+}
+
+function playCatalogAnimations(animations: readonly Animation[]) {
+  const finishListeners: Array<[Animation, () => void]> = [];
+
+  for (const animation of animations) {
+    animation.pause();
+    const endTime = animation.effect?.getComputedTiming().endTime;
+    if (typeof endTime === "number" && Number.isFinite(endTime)) {
+      const currentTime = animation.currentTime;
+      const speed = Math.max(0.01, Math.abs(animation.playbackRate || 1));
+      if (typeof currentTime === "number" && currentTime >= endTime - 1) {
+        animation.updatePlaybackRate(-speed);
+      } else if (typeof currentTime === "number" && currentTime <= 1) {
+        animation.updatePlaybackRate(speed);
+      }
+
+      const bounce = () => {
+        const nextSpeed = Math.max(0.01, Math.abs(animation.playbackRate || 1));
+        animation.updatePlaybackRate(animation.playbackRate >= 0 ? -nextSpeed : nextSpeed);
+        void animation.play();
+      };
+      animation.addEventListener("finish", bounce);
+      finishListeners.push([animation, bounce]);
+    }
+    void animation.play();
+  }
+
+  return () => {
+    for (const [animation, listener] of finishListeners) {
+      animation.removeEventListener("finish", listener);
+    }
+    for (const animation of animations) animation.pause();
   };
 }
 
@@ -264,6 +310,36 @@ function ThumbnailVisual({ family, label }: { family: MotionFamily; label: strin
   );
 }
 
+const useBrowserLayoutEffect = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+function buildThumbnailShadowMarkup(recipe: MotionRecipe, css: string, html: string) {
+  const previewHtml = recipe.canonicalId === "ripple"
+    ? html.replace(
+        "</button>",
+        '<span class="motion-ripple-ink" data-catalog-sample-ripple aria-hidden="true" style="left:50%;top:50%"></span></button>'
+      )
+    : html;
+  const shadowCss = `:host{position:absolute;inset:0;display:block;overflow:hidden;pointer-events:none}
+:host(:not([data-runtime-initialized])) .motion-thumbnail-canvas *,
+:host(:not([data-runtime-initialized])) .motion-thumbnail-canvas *::before,
+:host(:not([data-runtime-initialized])) .motion-thumbnail-canvas *::after{animation-delay:-${catalogStaticPreviewTime}ms!important;animation-play-state:paused!important;transition:none!important}
+:host([data-runtime-initialized]:not([data-runtime-active])) .motion-thumbnail-canvas *,
+:host([data-runtime-initialized]:not([data-runtime-active])) .motion-thumbnail-canvas *::before,
+:host([data-runtime-initialized]:not([data-runtime-active])) .motion-thumbnail-canvas *::after{animation-play-state:paused!important}
+[data-motion="scroll-reveal"] .motion-surface,
+[data-motion="scroll-driven-animation"] .motion-surface,
+[data-motion="parallax"] .motion-surface{animation:none!important}
+:host(:not([data-runtime-initialized])) [data-motion="scroll-reveal"] .motion-surface,
+:host(:not([data-runtime-initialized])) [data-motion="scroll-driven-animation"] .motion-surface,
+:host(:not([data-runtime-initialized])) [data-motion="parallax"] .motion-surface{opacity:1!important;transform:none!important}
+.motion-thumbnail-canvas{width:200%;height:200%;display:grid;place-items:center;transform:scale(.5);transform-origin:top left}
+.motion-thumbnail-canvas>.motion-demo{width:100%;height:100%;min-height:20rem}
+.motion-thumbnail-canvas .motion-action-row{display:none!important}
+${css}`.replace(/<\/style/gi, "<\\/style");
+
+  return `<template shadowrootmode="open" data-motion-shadow-template><style>${shadowCss}</style><div class="motion-thumbnail-canvas" inert>${previewHtml}</div></template>`;
+}
+
 export function MotionThumbnail({ locale, recipe }: MotionThumbnailProps) {
   const runtimeHostRef = useRef<HTMLDivElement>(null);
   const runtimeRecipe = isRuntimeRecipe(recipe) ? recipe : null;
@@ -278,12 +354,15 @@ export function MotionThumbnail({ locale, recipe }: MotionThumbnailProps) {
     }) : null,
     [locale, runtimeRecipe, values]
   );
+  const shadowMarkup = useMemo(
+    () => runtimeRecipe && output ? buildThumbnailShadowMarkup(runtimeRecipe, output.css, output.html) : null,
+    [output, runtimeRecipe]
+  );
 
-  useEffect(() => {
-    if (!runtimeRecipe || !values || !output) return;
+  useBrowserLayoutEffect(() => {
+    if (!runtimeRecipe || !values || !shadowMarkup) return;
     const activeRecipe = runtimeRecipe;
     const activeValues = values;
-    const activeOutput = output;
     const host = runtimeHostRef.current;
     const thumbnail = host?.closest<HTMLElement>(".library-motion-thumb");
     const card = host?.closest<HTMLElement>(".library-card, .library-hero-preview");
@@ -292,77 +371,125 @@ export function MotionThumbnail({ locale, recipe }: MotionThumbnailProps) {
     const runtimeThumbnail = thumbnail;
     runtimeHost.setAttribute("inert", "");
 
+    const template = runtimeHost.querySelector<HTMLTemplateElement>(
+      ":scope > template[data-motion-shadow-template]"
+    );
+    let shadow = runtimeHost.shadowRoot;
+    if (template) {
+      shadow ??= runtimeHost.attachShadow({ mode: "open" });
+      shadow.replaceChildren(template.content);
+      template.remove();
+    }
+    if (!shadow) return;
+    const canvas = shadow.querySelector<HTMLElement>(".motion-thumbnail-canvas");
+    const root = canvas?.querySelector<HTMLElement>(".motion-demo");
+    if (!canvas || !root) return;
+    const runtimeRoot = root;
+    canvas.setAttribute("inert", "");
+    for (const interactive of canvas.querySelectorAll<HTMLElement>(
+      'a[href],button,input,select,textarea,summary,[tabindex],[contenteditable="true"]'
+    )) {
+      interactive.tabIndex = -1;
+    }
+
     const finePointer = window.matchMedia("(hover: hover) and (pointer: fine)");
     const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const runtimeConfig = getMotionRuntimeConfig(activeRecipe, activeValues, false);
+    let disposed = false;
+    let initialized = false;
+    let wantsPlayback = false;
+    let catalogAnimations: Animation[] = [];
     let cleanupRuntime: (() => void) | undefined;
     let cleanupSample: (() => void) | undefined;
+    let cleanupPlayback: (() => void) | undefined;
+    let visibilityObserver: IntersectionObserver | undefined;
 
     function stopPreview() {
-      cleanupSample?.();
-      cleanupSample = undefined;
-      cleanupRuntime?.();
-      cleanupRuntime = undefined;
-      runtimeHost.shadowRoot?.replaceChildren();
+      wantsPlayback = false;
+      cleanupPlayback?.();
+      cleanupPlayback = undefined;
       runtimeHost.removeAttribute("data-runtime-active");
       runtimeThumbnail.classList.remove("is-runtime-active");
     }
 
     function startPreview() {
-      if (!finePointer.matches || reducedMotion.matches) return;
-      stopPreview();
-      const shadow = runtimeHost.shadowRoot ?? runtimeHost.attachShadow({ mode: "open" });
-      const style = document.createElement("style");
-      const canvas = document.createElement("div");
-      style.textContent = `:host{position:absolute;inset:0;display:block;overflow:hidden;pointer-events:none}
-.motion-thumbnail-canvas{width:200%;height:200%;display:grid;place-items:center;transform:scale(.5);transform-origin:top left}
-.motion-thumbnail-canvas>.motion-demo{width:100%;height:100%;min-height:20rem}
-.motion-thumbnail-canvas .motion-action-row{display:none!important}
-${activeOutput.css}`;
-      canvas.className = "motion-thumbnail-canvas";
-      canvas.innerHTML = activeOutput.html;
-      canvas.setAttribute("inert", "");
-      for (const interactive of canvas.querySelectorAll<HTMLElement>(
-        'a[href],button,input,select,textarea,summary,[tabindex],[contenteditable="true"]'
-      )) {
-        interactive.tabIndex = -1;
+      wantsPlayback = true;
+      if (!initialized) {
+        initializePreview();
+        return;
       }
-      shadow.replaceChildren(style, canvas);
-      const root = canvas.querySelector<HTMLElement>(".motion-demo");
-      if (!root) return;
-      cleanupRuntime = mountMotionRuntime(
-        root,
-        getMotionRuntimeConfig(activeRecipe, activeValues, true)
-      );
-      cleanupSample = mountCatalogSample(root, activeRecipe, activeValues);
+      if (!finePointer.matches || reducedMotion.matches || runtimeHost.hasAttribute("data-runtime-active")) return;
       runtimeHost.setAttribute("data-runtime-active", "true");
       runtimeThumbnail.classList.add("is-runtime-active");
+      cleanupPlayback = playCatalogAnimations(catalogAnimations);
+    }
+
+    function initializePreview() {
+      if (disposed || initialized) return;
+      initialized = true;
+      visibilityObserver?.disconnect();
+      cleanupRuntime = mountMotionRuntime(runtimeRoot, runtimeConfig);
+      cleanupSample = mountCatalogSample(runtimeRoot, activeRecipe, activeValues);
+      runtimeHost.setAttribute("data-runtime-initialized", "true");
+      catalogAnimations = runtimeRoot.getAnimations({ subtree: true });
+      freezeCatalogAnimations(catalogAnimations);
+      runtimeHost.setAttribute("data-runtime-ready", "true");
+      runtimeThumbnail.classList.add("is-runtime-ready");
+      if (wantsPlayback) startPreview();
     }
 
     card.addEventListener("pointerenter", startPreview);
     card.addEventListener("pointerleave", stopPreview);
+    finePointer.addEventListener("change", stopPreview);
     reducedMotion.addEventListener("change", stopPreview);
+
+    if ("IntersectionObserver" in window) {
+      visibilityObserver = new IntersectionObserver((entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) initializePreview();
+      }, { rootMargin: "240px 0px" });
+      visibilityObserver.observe(card);
+    } else {
+      initializePreview();
+    }
+
     return () => {
+      disposed = true;
+      visibilityObserver?.disconnect();
       card.removeEventListener("pointerenter", startPreview);
       card.removeEventListener("pointerleave", stopPreview);
+      finePointer.removeEventListener("change", stopPreview);
       reducedMotion.removeEventListener("change", stopPreview);
       stopPreview();
+      cleanupSample?.();
+      cleanupSample = undefined;
+      cleanupRuntime?.();
+      cleanupRuntime = undefined;
+      runtimeHost.removeAttribute("data-runtime-ready");
+      runtimeHost.removeAttribute("data-runtime-initialized");
+      runtimeThumbnail.classList.remove("is-runtime-ready");
     };
-  }, [output, runtimeRecipe, values]);
+  }, [runtimeRecipe, shadowMarkup, values]);
 
   return (
     <div
-      className={`motion-thumb library-motion-thumb family-${recipe.family} entry-${recipe.id}`}
+      className={`motion-thumb library-motion-thumb family-${recipe.family} entry-${recipe.id} ${runtimeRecipe ? "has-runtime-preview" : "has-compact-preview"}`}
       data-motion-family={recipe.family}
       aria-hidden="true"
     >
-      <div className="motion-thumbnail-fallback">
-        <ThumbnailVisual family={recipe.family} label={text(recipe.name, locale)} />
-      </div>
-      <div
-        ref={runtimeHostRef}
-        className="motion-thumbnail-runtime"
-        data-motion-thumbnail={runtimeRecipe?.canonicalId ?? recipe.id}
-      />
+      {!runtimeRecipe ? (
+        <div className="motion-thumbnail-fallback">
+          <ThumbnailVisual family={recipe.family} label={text(recipe.name, locale)} />
+        </div>
+      ) : null}
+      {runtimeRecipe && shadowMarkup ? (
+        <div
+          ref={runtimeHostRef}
+          className="motion-thumbnail-runtime"
+          data-motion-thumbnail={runtimeRecipe.canonicalId}
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: shadowMarkup }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/src/components/RecipeWorkspace.tsx
+++ b/src/components/RecipeWorkspace.tsx
@@ -523,10 +523,10 @@ export function RecipeWorkspace({ locale, recipe, mode = "embedded" }: RecipeWor
                         <tbody>
                           {recipe.params.map((param) => (
                             <tr key={param.id}>
-                              <td><code>{param.id}</code></td>
-                              <td>{paramRange(param, locale)}</td>
-                              <td>{paramDefault(param, locale)}</td>
-                              <td>{text(param.description, locale)}</td>
+                              <td data-label={t("workspace.parameterName")}><code>{param.id}</code></td>
+                              <td data-label={t("workspace.parameterRange")}>{paramRange(param, locale)}</td>
+                              <td data-label={t("workspace.parameterDefault")}>{paramDefault(param, locale)}</td>
+                              <td data-label={t("workspace.parameterPurpose")}>{text(param.description, locale)}</td>
                             </tr>
                           ))}
                         </tbody>

--- a/src/lib/motion-engine.ts
+++ b/src/lib/motion-engine.ts
@@ -210,6 +210,7 @@ export function getMotionRuntimeConfig(
 
 function baseCss(root: string) {
   return `${root} {
+  box-sizing: border-box;
   position: relative;
   display: grid;
   place-items: center;
@@ -564,7 +565,7 @@ ${root} .motion-state--to { animation: ${name}-in ${duration}ms ${ease} both; }$
 
   if (id === "scroll-reveal") {
     const threshold = numberValue(values, "threshold", 20);
-    return `${root} { max-height: 15rem; overflow-y: auto; place-items: start center; }
+    return `${root} { max-height: 15rem; overflow-x: hidden; overflow-y: auto; place-items: start center; }
 ${root} .motion-scroll-track { display: grid; place-items: center; gap: 10rem; width: 100%; min-height: 48rem; padding-block: 5rem; }
 ${root} .motion-surface { animation: ${name} ${duration}ms ${ease} both; }
 @supports (animation-timeline: view()) {
@@ -580,7 +581,7 @@ ${root} .motion-surface { animation: ${name} ${duration}ms ${ease} both; }
     const speed = numberValue(values, "speed", 35) / 100;
     const travel = id === "parallax" ? Math.round(distance * speed) : distance;
     const translate = axis === "x" ? `translateX(${travel}px)` : `translateY(${travel}px)`;
-    return `${root} { max-height: 15rem; overflow-y: auto; place-items: start center; }
+    return `${root} { max-height: 15rem; overflow-x: hidden; overflow-y: auto; place-items: start center; }
 ${root} .motion-scroll-track { display: grid; place-items: center; gap: 10rem; width: 100%; min-height: 48rem; padding-block: 5rem; }
 ${root} .motion-surface { animation: ${name} linear both; animation-timeline: scroll(nearest); animation-range: ${start}% ${end}%; }
 @keyframes ${name} { from { transform: ${translate}; } to { transform: none; } }
@@ -692,7 +693,7 @@ ${root} .motion-orbit-item { position: absolute; left: 50%; top: 50%; width: 1.4
     return `${root} .motion-comparison { position: relative; width: min(100%, 22rem); aspect-ratio: 16 / 9; overflow: hidden; border-radius: 16px; background: #52525b; }
 ${root} .motion-before, ${root} .motion-after { position: absolute; inset: 0; display: grid; place-items: center; color: white; }
 ${root} .motion-after { overflow: hidden; background: #2563eb; clip-path: inset(0 ${100 - position}% 0 0); }
-${root} .motion-divider { position: absolute; inset: 0 auto 0 0; width: 2px; pointer-events: none; background: white; box-shadow: 0 0 0 1px rgb(0 0 0 / 18%); transform: translate3d(0, 0, 0); }
+${root} .motion-divider { position: absolute; inset: 0 auto 0 ${position}%; width: 2px; pointer-events: none; background: white; box-shadow: 0 0 0 1px rgb(0 0 0 / 18%); transform: translate3d(-1px, 0, 0); }
 ${root} .motion-divider::after { content: "↔"; position: absolute; top: 50%; left: 50%; width: 2.25rem; height: 2.25rem; display: grid; place-items: center; color: #18181b; background: white; border-radius: 50%; transform: translate(-50%, -50%); box-shadow: 0 2px 8px rgb(0 0 0 / 18%); }
 ${root} .motion-comparison-control { position: absolute; inset: 0; z-index: 2; width: 100%; height: 100%; margin: 0; cursor: ew-resize; opacity: 0; }`;
   }

--- a/src/lib/motion-runtime.ts
+++ b/src/lib/motion-runtime.ts
@@ -161,7 +161,7 @@ function mountRippleRuntime(root: HTMLElement, config: MotionRuntimeConfig) {
   return () => {
     button.removeEventListener("pointerdown", showRipple);
     for (const animation of active) animation.cancel();
-    for (const ink of button.querySelectorAll(".motion-ripple-ink")) ink.remove();
+    for (const ink of button.querySelectorAll(".motion-ripple-ink:not([data-catalog-sample-ripple])")) ink.remove();
   };
 }
 
@@ -820,13 +820,15 @@ function mountComparisonRuntime(root: HTMLElement, config: MotionRuntimeConfig) 
   if (!comparison || !after || !divider || !input) return () => undefined;
   const initialValue = input.value;
   const initialClipPath = after.style.clipPath;
+  const initialDividerInset = divider.style.insetInlineStart;
   const initialDividerTransform = divider.style.transform;
   const initialValueText = input.getAttribute("aria-valuetext");
 
   function update() {
     const value = Math.min(100, Math.max(0, Number(input.value || config.position)));
     after.style.clipPath = `inset(0 ${100 - value}% 0 0)`;
-    divider.style.transform = `translate3d(${comparison.clientWidth * value / 100}px, 0, 0)`;
+    divider.style.insetInlineStart = `${value}%`;
+    divider.style.transform = "translate3d(-1px, 0, 0)";
     input.setAttribute("aria-valuetext", `${Math.round(value)}%`);
   }
 
@@ -839,6 +841,7 @@ function mountComparisonRuntime(root: HTMLElement, config: MotionRuntimeConfig) 
     observer?.disconnect();
     input.value = initialValue;
     after.style.clipPath = initialClipPath;
+    divider.style.insetInlineStart = initialDividerInset;
     divider.style.transform = initialDividerTransform;
     if (initialValueText === null) input.removeAttribute("aria-valuetext");
     else input.setAttribute("aria-valuetext", initialValueText);
@@ -1101,7 +1104,7 @@ const copiedRippleRuntime = String.raw`
     };
     addCleanup(() => {
       active.forEach((animation) => animation.cancel());
-      button.querySelectorAll(".motion-ripple-ink").forEach((ink) => ink.remove());
+      button.querySelectorAll(".motion-ripple-ink:not([data-catalog-sample-ripple])").forEach((ink) => ink.remove());
     });
     on(button, "pointerdown", show);
     return cleanup;
@@ -1116,13 +1119,15 @@ const copiedComparisonRuntime = String.raw`
     const initial = {
       value: input.value,
       clipPath: after.style.clipPath,
+      insetInlineStart: divider.style.insetInlineStart,
       transform: divider.style.transform,
       valueText: input.getAttribute("aria-valuetext")
     };
     const update = () => {
       const value = Math.min(100, Math.max(0, Number(input.value || config.position)));
       after.style.clipPath = "inset(0 " + String(100 - value) + "% 0 0)";
-      divider.style.transform = "translate3d(" + String(comparison.clientWidth * value / 100) + "px, 0, 0)";
+      divider.style.insetInlineStart = String(value) + "%";
+      divider.style.transform = "translate3d(-1px, 0, 0)";
       input.setAttribute("aria-valuetext", String(Math.round(value)) + "%");
     };
     const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(update);
@@ -1130,6 +1135,7 @@ const copiedComparisonRuntime = String.raw`
       if (observer) observer.disconnect();
       input.value = initial.value;
       after.style.clipPath = initial.clipPath;
+      divider.style.insetInlineStart = initial.insetInlineStart;
       divider.style.transform = initial.transform;
       if (initial.valueText === null) input.removeAttribute("aria-valuetext");
       else input.setAttribute("aria-valuetext", initial.valueText);

--- a/src/library.css
+++ b/src/library.css
@@ -980,6 +980,7 @@ kbd {
   inset-block-start: calc(var(--library-header-height) + 16px);
   height: calc(100dvh - var(--library-header-height) - 32px);
   overflow-y: auto;
+  overflow-x: hidden;
   scrollbar-width: thin;
   border-inline-end: 1px solid var(--library-line);
   padding: 0 1.1rem 2rem 0;
@@ -1201,16 +1202,13 @@ kbd {
   inset-block-start: var(--library-header-height);
   z-index: 12;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 1.25rem;
-  overflow-x: auto;
   border-top: 1px solid var(--library-line);
   border-bottom: 1px solid var(--library-line);
   background: var(--bg);
-  scrollbar-width: none;
 }
-
-.library-entry-tabs::-webkit-scrollbar { display: none; }
 
 .library-entry-tabs a {
   min-width: 44px;
@@ -1218,7 +1216,7 @@ kbd {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  flex: 0 0 auto;
+  flex: 0 1 auto;
   color: var(--ink-dim);
   font-size: 0.72rem;
   font-weight: 620;
@@ -1593,7 +1591,8 @@ kbd {
 .library-code-content pre {
   min-height: 320px;
   max-height: 520px;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   margin: 0;
   padding: 1.2rem;
   color: var(--code-text);
@@ -1601,6 +1600,9 @@ kbd {
   font-size: 0.72rem;
   line-height: 1.75;
   tab-size: 2;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .library-prompt-content > p {
@@ -1724,14 +1726,14 @@ kbd {
 }
 
 .library-table-scroll {
-  overflow-x: auto;
   border: 1px solid var(--library-line);
   border-radius: 8px;
 }
 
 .library-parameter-table {
   width: 100%;
-  min-width: 680px;
+  min-width: 0;
+  table-layout: fixed;
   border-collapse: collapse;
   text-align: start;
 }
@@ -1755,6 +1757,7 @@ kbd {
 .library-parameter-table td {
   font-size: 0.76rem;
   line-height: 1.55;
+  overflow-wrap: anywhere;
 }
 
 .library-parameter-table tr:last-child td { border-bottom: 0; }
@@ -1998,8 +2001,8 @@ kbd {
   .library-section-heading h2 { font-size: 1.9rem; }
 
   .library-directory-tools { grid-template-columns: 1fr; }
-  .library-filter-row { overflow-x: auto; }
-  .library-filter-row button { flex: 0 0 auto; }
+  .library-filter-row { flex-wrap: wrap; }
+  .library-filter-row button { flex: 0 1 auto; }
 
   .library-workflow-steps { grid-template-columns: 1fr; }
   .library-workflow-steps li,
@@ -2013,10 +2016,10 @@ kbd {
   .library-workflow-steps h3 { margin-top: 1.2rem; }
 
   .library-surface-tabs {
-    display: flex;
-    overflow-x: auto;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
-  .library-surface-tabs button { min-width: 210px; flex: 1 0 auto; }
+  .library-surface-tabs button { min-width: 0; width: 100%; }
 
   .library-catalog-layout { grid-template-columns: 1fr; }
   .library-catalog-layout > .library-sidebar { display: none; }

--- a/src/vocabulary.css
+++ b/src/vocabulary.css
@@ -54,8 +54,11 @@
 }
 
 .vocabulary-toolbar label {
-  min-width: min(520px, 65vw);
+  width: min(520px, 100%);
+  max-width: 520px;
+  min-width: 0;
   min-height: 44px;
+  flex: 1 1 320px;
   display: grid;
   grid-template-columns: auto 1fr;
   align-items: center;
@@ -81,10 +84,11 @@
 }
 
 .vocabulary-toolbar > span {
+  min-width: 0;
   color: var(--ink-dim);
   font-family: var(--mono);
   font-size: 0.66rem;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .vocabulary-index {
@@ -371,7 +375,12 @@
 
   .vocabulary-hero h1 { font-size: clamp(2.8rem, 15vw, 4.5rem); }
   .vocabulary-toolbar { align-items: flex-start; flex-direction: column; gap: 0; padding: 0.45rem 0; }
-  .vocabulary-toolbar label { min-width: 100%; }
+  .vocabulary-toolbar label {
+    width: 100%;
+    max-width: none;
+    min-width: 0;
+    flex: 0 0 auto;
+  }
   .vocabulary-toolbar > span { padding: 0 0 0.4rem 1.65rem; }
   .vocabulary-index { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .vocabulary-group > header { grid-template-columns: 2rem minmax(0, 1fr) auto; }

--- a/tests/e2e/design-system.spec.ts
+++ b/tests/e2e/design-system.spec.ts
@@ -64,6 +64,69 @@ async function expectMinimumTargets(page: Page, selector: string) {
   }
 }
 
+type HorizontalLayoutIssue = {
+  element: string;
+  overflowX: string;
+  clientWidth: number;
+  scrollWidth: number;
+};
+
+async function horizontalLayoutSnapshot(page: Page) {
+  return page.evaluate(() => {
+    const scrollContainers: HorizontalLayoutIssue[] = [];
+
+    const visit = (root: Document | ShadowRoot) => {
+      for (const element of root.querySelectorAll<HTMLElement>("*")) {
+        const style = getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+        const visible = style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0;
+
+        if (visible && ["auto", "scroll", "overlay"].includes(style.overflowX)) {
+          const className = element.getAttribute("class")?.trim().replace(/\s+/g, ".");
+          scrollContainers.push({
+            element: `${element.tagName.toLowerCase()}${element.id ? `#${element.id}` : ""}${className ? `.${className}` : ""}`,
+            overflowX: style.overflowX,
+            clientWidth: element.clientWidth,
+            scrollWidth: element.scrollWidth
+          });
+        }
+
+        if (element.shadowRoot) visit(element.shadowRoot);
+      }
+    };
+
+    visit(document);
+    return {
+      documentClientWidth: document.documentElement.clientWidth,
+      documentScrollWidth: document.documentElement.scrollWidth,
+      scrollContainers
+    };
+  });
+}
+
+async function expectHorizontalFit(page: Page, selector: string, context: string) {
+  const locator = page.locator(selector);
+  await expect.soft(locator.first(), `${context} is missing ${selector}`).toBeVisible();
+  const metrics = await locator.evaluateAll((elements) => elements
+    .filter((element) => {
+      const style = getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return style.display !== "none" && style.visibility !== "hidden" && rect.width > 0 && rect.height > 0;
+    })
+    .map((element) => ({
+      clientWidth: element.clientWidth,
+      scrollWidth: element.scrollWidth
+    })));
+
+  expect.soft(metrics.length, `${context} has no visible ${selector}`).toBeGreaterThan(0);
+  for (const metric of metrics) {
+    expect.soft(
+      metric.scrollWidth,
+      `${context} ${selector} needs ${metric.scrollWidth}px inside ${metric.clientWidth}px`
+    ).toBeLessThanOrEqual(metric.clientWidth + 1);
+  }
+}
+
 test("critical routes keep the four-level SF Pro type system", async ({ page }) => {
   for (const route of productRoutes) {
     await page.goto(route);
@@ -75,39 +138,162 @@ test("critical routes keep the four-level SF Pro type system", async ({ page }) 
   }
 });
 
-test("320, 768, and 1024 pixel layouts keep controls readable without page overflow", async ({ page }, testInfo) => {
+test("key Chinese and English layouts have no horizontal scrolling at product breakpoints", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name.includes("mobile"), "Explicit responsive widths run once in desktop Chromium.");
+  test.setTimeout(150_000);
 
-  const cases = [
-    { width: 320, route: "/en/catalog/?surface=components" },
-    { width: 768, route: productRoutes[2] },
-    { width: 1024, route: "/zh/sequencing/stagger/" }
+  const widths = [320, 390, 768, 1024, 1440];
+  const routes: Array<{
+    route: string;
+    selectors: string[];
+    codeTab?: string;
+    parameterTable?: boolean;
+  }> = [
+    {
+      route: "/en/",
+      selectors: [".apple-hero-examples", ".apple-hero-examples button", ".apple-hero-preview"]
+    },
+    {
+      route: "/zh/catalog/?surface=components",
+      selectors: [
+        ".library-surface-control.library-surface-tabs",
+        ".library-category-filter-options",
+        ".library-card-grid"
+      ]
+    },
+    {
+      route: "/en/catalog/?surface=components",
+      selectors: [
+        ".library-surface-control.library-surface-tabs",
+        ".library-category-filter-options",
+        ".library-card-grid"
+      ]
+    },
+    {
+      route: productRoutes[2],
+      codeTab: "代码",
+      selectors: [
+        ".finder-workspace-shell",
+        ".finder-active-preview",
+        ".finder-candidate-switcher",
+        ".finder-inspector-controls",
+        ".library-code-file pre"
+      ]
+    },
+    {
+      route: "/en/finder/?q=make%20a%20card%20feel%20weighty&compare=spring,pop-in,scale-in&selected=spring",
+      codeTab: "Code",
+      selectors: [
+        ".finder-workspace-shell",
+        ".finder-active-preview",
+        ".finder-candidate-switcher",
+        ".finder-inspector-controls",
+        ".library-code-file pre"
+      ]
+    },
+    {
+      route: "/zh/vocabulary/",
+      selectors: [".vocabulary-toolbar", ".vocabulary-index", ".vocabulary-groups"]
+    },
+    {
+      route: "/en/vocabulary/",
+      selectors: [".vocabulary-toolbar", ".vocabulary-index", ".vocabulary-groups"]
+    },
+    {
+      route: "/zh/sequencing/stagger/",
+      codeTab: "代码",
+      parameterTable: true,
+      selectors: [".apple-output-disclosure", ".library-code-files", ".library-code-file pre"]
+    },
+    {
+      route: "/en/sequencing/stagger/",
+      codeTab: "Code",
+      parameterTable: true,
+      selectors: [".apple-output-disclosure", ".library-code-files", ".library-code-file pre"]
+    }
   ];
 
-  for (const item of cases) {
-    await page.setViewportSize({ width: item.width, height: 900 });
-    await page.goto(item.route);
-    if (item.route.includes("/finder/")) await expect(page.locator(".finder-workspace-shell")).toBeVisible();
-    const bounds = await page.evaluate(() => ({
-      clientWidth: document.documentElement.clientWidth,
-      scrollWidth: document.documentElement.scrollWidth
-    }));
-    expect(bounds.scrollWidth, `${item.width}px ${item.route} overflows horizontally`).toBeLessThanOrEqual(bounds.clientWidth);
-  }
+  for (const width of widths) {
+    await page.setViewportSize({ width, height: 900 });
 
-  await page.setViewportSize({ width: 320, height: 900 });
-  await page.goto("/en/catalog/?surface=components");
-  const surfaceButtons = page.locator(".library-surface-tabs button");
-  await expect(surfaceButtons).toHaveCount(3);
-  for (let index = 0; index < await surfaceButtons.count(); index += 1) {
-    const button = surfaceButtons.nth(index);
-    await expect(button).toHaveCSS("white-space", "nowrap");
-    expect((await button.boundingBox())?.height ?? 0).toBeGreaterThanOrEqual(44);
+    for (const item of routes) {
+      const context = `${width}px ${item.route}`;
+      await page.goto(item.route);
+      await expect(page.locator("#main-content"), `${context} did not render`).toBeVisible();
+
+      if (item.codeTab) {
+        await page.locator(".apple-code-output").getByRole("tab", { name: item.codeTab, exact: true }).click();
+        await expect(page.locator(".library-code-files")).toBeVisible();
+      }
+
+      if (item.parameterTable && width <= 390) {
+        const disclosure = page.locator("#implementation > .apple-disclosure");
+        await disclosure.locator("summary").click();
+        await expect(disclosure).toHaveAttribute("open", "");
+        const containment = await disclosure.evaluate((element) => {
+          const disclosureRect = element.getBoundingClientRect();
+          const tableWrapper = element.querySelector<HTMLElement>(".library-table-scroll");
+          const table = element.querySelector<HTMLElement>(".library-parameter-table");
+          if (!tableWrapper || !table) return null;
+          const wrapperRect = tableWrapper.getBoundingClientRect();
+          const tableRect = table.getBoundingClientRect();
+          return {
+            disclosureLeft: disclosureRect.left,
+            disclosureRight: disclosureRect.right,
+            wrapperLeft: wrapperRect.left,
+            wrapperRight: wrapperRect.right,
+            tableLeft: tableRect.left,
+            tableRight: tableRect.right,
+            wrapperClientWidth: tableWrapper.clientWidth,
+            wrapperScrollWidth: tableWrapper.scrollWidth
+          };
+        });
+        expect.soft(containment, `${context} parameter table is missing`).not.toBeNull();
+        if (containment) {
+          expect.soft(containment.wrapperLeft).toBeGreaterThanOrEqual(containment.disclosureLeft - 1);
+          expect.soft(containment.wrapperRight).toBeLessThanOrEqual(containment.disclosureRight + 1);
+          expect.soft(containment.tableLeft).toBeGreaterThanOrEqual(containment.disclosureLeft - 1);
+          expect.soft(containment.tableRight).toBeLessThanOrEqual(containment.disclosureRight + 1);
+          expect.soft(containment.wrapperScrollWidth).toBeLessThanOrEqual(containment.wrapperClientWidth + 1);
+        }
+      }
+
+      for (const selector of item.selectors) await expectHorizontalFit(page, selector, context);
+
+      const snapshot = await horizontalLayoutSnapshot(page);
+      expect.soft(
+        snapshot.documentScrollWidth,
+        `${context} document needs ${snapshot.documentScrollWidth}px inside ${snapshot.documentClientWidth}px`
+      ).toBeLessThanOrEqual(snapshot.documentClientWidth);
+      expect.soft(snapshot.scrollContainers, `${context} exposes horizontal scroll containers`).toEqual([]);
+    }
   }
-  const scrollCue = await page.locator(".library-category-filter-options").evaluate(
-    (element) => getComputedStyle(element).maskImage || getComputedStyle(element).webkitMaskImage
-  );
-  expect(scrollCue).not.toBe("none");
+});
+
+test("vocabulary search stays compact across stacked and horizontal toolbars", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Explicit vocabulary widths run once in desktop Chromium.");
+
+  for (const width of [320, 390, 620, 768, 1440]) {
+    await page.setViewportSize({ width, height: 900 });
+    for (const locale of ["zh", "en"] as const) {
+      await page.goto(`/${locale}/vocabulary/`);
+      const dimensions = await page.locator(".vocabulary-toolbar").evaluate((toolbar) => {
+        const label = toolbar.querySelector<HTMLElement>("label")!;
+        const toolbarRect = toolbar.getBoundingClientRect();
+        const labelRect = label.getBoundingClientRect();
+        return {
+          toolbarHeight: toolbarRect.height,
+          labelWidth: labelRect.width,
+          labelHeight: labelRect.height
+        };
+      });
+      expect(dimensions.labelHeight, `${width}px /${locale}/ search grew vertically`).toBeLessThanOrEqual(52);
+      expect(dimensions.toolbarHeight, `${width}px /${locale}/ toolbar obscures content`).toBeLessThanOrEqual(110);
+      if (width > 620) {
+        expect(dimensions.labelWidth, `${width}px /${locale}/ search exceeds its desktop measure`).toBeLessThanOrEqual(521);
+      }
+    }
+  }
 });
 
 test("dark Finder, Catalog, and recipe states render without overflow", async ({ page }, testInfo) => {

--- a/tests/e2e/release.spec.ts
+++ b/tests/e2e/release.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 import { catalogRecipes } from "../../src/data/recipes";
 import { text } from "../../src/data/site";
 import {
@@ -9,6 +9,47 @@ import {
 } from "../../src/lib/motion-engine";
 
 const hydrationError = /hydration|server rendered html|did not match|React error #(?:418|423)/i;
+
+async function expectScrollCatalogContinuity(page: Page, scrollRecipe: string) {
+  const scrollCard = page.locator(`a.library-card[href="/zh/scroll/${scrollRecipe}/"]`);
+  const scrollRuntime = scrollCard.locator(".motion-thumbnail-runtime");
+  await scrollCard.scrollIntoViewIfNeeded();
+  await expect(scrollRuntime).toHaveAttribute("data-runtime-ready", "true");
+  const continuity = await scrollRuntime.evaluate(async (host) => {
+    const card = host.closest<HTMLElement>(".library-card")!;
+    const shadow = host.shadowRoot!;
+    const surface = shadow.querySelector<HTMLElement>(".motion-surface")!;
+    const root = shadow.querySelector(".motion-demo");
+    const snapshot = () => {
+      const style = getComputedStyle(surface);
+      return {
+        active: host.hasAttribute("data-runtime-active"),
+        opacity: style.opacity,
+        transform: style.transform,
+        root: shadow.querySelector(".motion-demo")
+      };
+    };
+    const resting = snapshot();
+    card.dispatchEvent(new PointerEvent("pointerenter"));
+    const entered = snapshot();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+    const playing = snapshot();
+    card.dispatchEvent(new PointerEvent("pointerleave"));
+    const left = snapshot();
+    return {
+      activeStates: [resting.active, entered.active, playing.active, left.active],
+      enterStable: resting.opacity === entered.opacity && resting.transform === entered.transform,
+      moved: resting.opacity !== playing.opacity || resting.transform !== playing.transform,
+      leaveStable: playing.opacity === left.opacity && playing.transform === left.transform,
+      rootStable: root === resting.root && resting.root === entered.root && entered.root === playing.root && playing.root === left.root
+    };
+  });
+  expect(continuity.activeStates, scrollRecipe).toEqual([false, true, true, false]);
+  expect(continuity.enterStable, `${scrollRecipe} jumps on pointer enter`).toBe(true);
+  expect(continuity.moved, `${scrollRecipe} does not play on pointer enter`).toBe(true);
+  expect(continuity.leaveStable, `${scrollRecipe} jumps on pointer leave`).toBe(true);
+  expect(continuity.rootStable, `${scrollRecipe} replaces its preview root`).toBe(true);
+}
 
 test("query presets hydrate cleanly and become the active output", async ({ page }) => {
   const runtimeErrors: string[] = [];
@@ -106,9 +147,135 @@ test("parameter edits preserve the reader's scroll position", async ({ page }) =
   expect(Math.abs(after - before)).toBeLessThanOrEqual(1);
 });
 
-test("catalog hover mounts one exact recipe runtime at a time while keyboard focus stays static", async ({ page }, testInfo) => {
+test("catalog HTML contains every exact recipe preview without JavaScript", async ({ browser }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "The server-rendered catalog contract is verified once on desktop.");
+
+  const baseURL = testInfo.project.use.baseURL as string;
+  const context = await browser.newContext({
+    baseURL,
+    javaScriptEnabled: false,
+    viewport: { width: 1440, height: 1100 }
+  });
+  const page = await context.newPage();
+  await page.goto("/zh/catalog/?surface=components");
+
+  const componentRecipes = catalogRecipes.filter((recipe) => recipe.surfaceType === "component");
+  const runtimeHosts = page.locator(".motion-thumbnail-runtime");
+  await expect(runtimeHosts).toHaveCount(componentRecipes.length);
+  await expect(page.locator(".motion-thumbnail-runtime .motion-demo")).toHaveCount(componentRecipes.length);
+  await expect(page.locator(".motion-thumbnail-fallback")).toHaveCount(0);
+
+  const serverRenderedRecipes = await runtimeHosts.evaluateAll((hosts) => hosts.map((host) => ({
+    hostId: host.getAttribute("data-motion-thumbnail"),
+    canonicalId: host.shadowRoot?.querySelector<HTMLElement>(".motion-demo")?.dataset.motion ?? null,
+    rootCount: host.shadowRoot?.querySelectorAll(".motion-demo").length ?? 0,
+    runningAnimations: host.shadowRoot
+      ? host.shadowRoot.querySelector<HTMLElement>(".motion-demo")
+        ?.getAnimations({ subtree: true })
+        .filter((animation) => animation.playState !== "paused")
+        .length ?? 0
+      : 0
+  })));
+  expect(serverRenderedRecipes.every(({ hostId, canonicalId, rootCount, runningAnimations }) =>
+    rootCount === 1 && hostId === canonicalId && runningAnimations === 0
+  )).toBe(true);
+  expect(serverRenderedRecipes.map(({ canonicalId }) => canonicalId).sort()).toEqual(
+    componentRecipes.map(({ canonicalId }) => canonicalId).sort()
+  );
+  expect(await page.evaluate(() => document.documentElement.scrollWidth)).toBeLessThanOrEqual(
+    await page.evaluate(() => document.documentElement.clientWidth)
+  );
+
+  await context.close();
+});
+
+test("catalog hydration preserves server preview nodes and first-frame styles", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "The production hydration boundary is verified once on desktop.");
+  const runtimeErrors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") runtimeErrors.push(message.text());
+  });
+  page.on("pageerror", (error) => runtimeErrors.push(error.message));
+
+  await page.route("**/zh/catalog/**", async (route) => {
+    if (route.request().resourceType() !== "document") {
+      await route.continue();
+      return;
+    }
+    const response = await route.fetch();
+    const body = (await response.text()).replace(
+      '<script type="module" crossorigin src=',
+      '<script type="application/x-motion-delayed" data-delayed-module crossorigin src='
+    );
+    await route.fulfill({ response, body });
+  });
+
+  await page.goto("/zh/catalog/?surface=components");
+  const runtimeHosts = page.locator(".motion-thumbnail-runtime");
+  await expect(runtimeHosts).toHaveCount(31);
+  const firstRuntime = runtimeHosts.first();
+
+  const serverRoots = await runtimeHosts.evaluateAll((hosts) => hosts.map((host) => {
+    const root = host.shadowRoot?.querySelector<HTMLElement>(".motion-demo") ?? null;
+    (host as HTMLElement & { __motionLexiconServerRoot?: HTMLElement | null }).__motionLexiconServerRoot = root;
+    return root?.dataset.motion ?? null;
+  }));
+  expect(serverRoots.filter(Boolean)).toHaveLength(31);
+
+  const visualSnapshot = () => firstRuntime.evaluate((host) => {
+    const hostRect = host.getBoundingClientRect();
+    return Array.from(host.shadowRoot?.querySelectorAll<HTMLElement>("*") ?? []).map((element) => {
+      const style = getComputedStyle(element);
+      const before = getComputedStyle(element, "::before");
+      const after = getComputedStyle(element, "::after");
+      const rect = element.getBoundingClientRect();
+      const pseudo = (value: CSSStyleDeclaration) => ({
+        content: value.content,
+        opacity: value.opacity,
+        transform: value.transform,
+        clipPath: value.clipPath,
+        backgroundImage: value.backgroundImage
+      });
+      return {
+        tag: element.tagName,
+        className: element.getAttribute("class"),
+        opacity: style.opacity,
+        transform: style.transform,
+        clipPath: style.clipPath,
+        filter: style.filter,
+        backgroundColor: style.backgroundColor,
+        backgroundImage: style.backgroundImage,
+        rect: [
+          Math.round((rect.left - hostRect.left) * 100) / 100,
+          Math.round((rect.top - hostRect.top) * 100) / 100,
+          Math.round(rect.width * 100) / 100,
+          Math.round(rect.height * 100) / 100
+        ],
+        before: pseudo(before),
+        after: pseudo(after)
+      };
+    });
+  });
+  const beforeHydration = await visualSnapshot();
+  const moduleSource = await page.locator("script[data-delayed-module]").getAttribute("src");
+  expect(moduleSource).toBeTruthy();
+  await page.addScriptTag({
+    type: "module",
+    url: new URL(moduleSource!, testInfo.project.use.baseURL as string).href
+  });
+  await expect(firstRuntime).toHaveAttribute("data-runtime-ready", "true");
+
+  expect(await runtimeHosts.evaluateAll((hosts) => hosts.every((host) =>
+    host.shadowRoot?.querySelector(".motion-demo") ===
+      (host as HTMLElement & { __motionLexiconServerRoot?: HTMLElement | null }).__motionLexiconServerRoot
+  ))).toBe(true);
+  expect(await visualSnapshot()).toEqual(beforeHydration);
+  expect(runtimeErrors).toEqual([]);
+});
+
+test("catalog keeps every exact recipe preview mounted while hover only changes playback", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name.includes("mobile"), "Fine-pointer hover is verified once on desktop.");
-  test.setTimeout(45_000);
+  test.setTimeout(60_000);
   const runtimeErrors: string[] = [];
   page.on("console", (message) => {
     if (message.type() === "error") runtimeErrors.push(message.text());
@@ -117,22 +284,152 @@ test("catalog hover mounts one exact recipe runtime at a time while keyboard foc
 
   await page.goto("/zh/catalog/?surface=components");
   const componentRecipes = catalogRecipes.filter((recipe) => recipe.surfaceType === "component");
+  const runtimeHosts = page.locator(".motion-thumbnail-runtime");
+
+  await expect(runtimeHosts).toHaveCount(componentRecipes.length);
+  await expect(page.locator(".motion-thumbnail-runtime .motion-demo")).toHaveCount(componentRecipes.length);
+
+  const mountedBeforeHover = await runtimeHosts.evaluateAll((hosts) => hosts.map((host) => {
+    const root = host.shadowRoot?.querySelector<HTMLElement>(".motion-demo") ?? null;
+    (host as HTMLElement & { __motionLexiconRoot?: HTMLElement | null }).__motionLexiconRoot = root;
+    return {
+      canonicalId: root?.dataset.motion ?? null,
+      rootCount: host.shadowRoot?.querySelectorAll(".motion-demo").length ?? 0,
+      nodeCount: root?.querySelectorAll("*").length ?? 0
+    };
+  }));
+  expect(mountedBeforeHover.every(({ rootCount }) => rootCount === 1)).toBe(true);
+  expect(mountedBeforeHover.map(({ canonicalId }) => canonicalId).sort()).toEqual(
+    componentRecipes.map(({ canonicalId }) => canonicalId).sort()
+  );
+
   const firstCard = page.locator(
     `a.library-card[href="/zh/${componentRecipes[0].categoryId}/${componentRecipes[0].id}/"]`
   );
-  const fallbackActor = firstCard.locator(".thumb-actor").first();
+  const firstRuntime = firstCard.locator(".motion-thumbnail-runtime");
+  const lastRuntime = page.locator(
+    `a.library-card[href="/zh/${componentRecipes.at(-1)?.categoryId}/${componentRecipes.at(-1)?.id}/"] .motion-thumbnail-runtime`
+  );
+
+  await expect(firstRuntime).toHaveAttribute("data-runtime-ready", "true");
+  await expect(lastRuntime).not.toHaveAttribute("data-runtime-ready", "true");
+  const initialReadyCount = await page.locator('.motion-thumbnail-runtime[data-runtime-ready="true"]').count();
+  expect(initialReadyCount).toBeGreaterThan(0);
+  expect(initialReadyCount).toBeLessThan(componentRecipes.length);
 
   await firstCard.focus();
   await expect(page.locator('.motion-thumbnail-runtime[data-runtime-active="true"]')).toHaveCount(0);
-  await expect.poll(() => fallbackActor.evaluate((element) => getComputedStyle(element).animationName)).toBe("none");
+  expect(await firstRuntime.evaluate((host) =>
+    host.shadowRoot?.querySelector(".motion-demo") ===
+      (host as HTMLElement & { __motionLexiconRoot?: HTMLElement | null }).__motionLexiconRoot
+  )).toBe(true);
+  const restingAnimationStates = await firstRuntime.locator(".motion-demo").evaluate((root) =>
+    root.getAnimations({ subtree: true }).map((animation) => animation.playState)
+  );
+  expect(restingAnimationStates.length).toBeGreaterThan(0);
+  expect(restingAnimationStates.every((state) => state === "paused")).toBe(true);
+  const restingTimeline = await firstRuntime.locator(".motion-demo").evaluate((root) => {
+    const currentTime = root.getAnimations({ subtree: true })[0]?.currentTime;
+    return typeof currentTime === "number" ? currentTime : null;
+  });
+
+  await firstCard.hover();
+  const enteredTimeline = await firstRuntime.locator(".motion-demo").evaluate((root) => {
+    const animation = root.getAnimations({ subtree: true })[0];
+    return {
+      currentTime: typeof animation?.currentTime === "number" ? animation.currentTime : null,
+      playState: animation?.playState ?? null
+    };
+  });
+  expect(enteredTimeline.playState).toBe("running");
+  if (restingTimeline !== null && enteredTimeline.currentTime !== null) {
+    expect(Math.abs(enteredTimeline.currentTime - restingTimeline)).toBeLessThan(50);
+  }
+  await page.getByRole("heading", { level: 1 }).hover();
+  await expect(firstRuntime).not.toHaveAttribute("data-runtime-active", "true");
 
   const comparisonCard = page.locator(
     'a.library-card[href="/zh/polish-effects/before-after-slider/"]'
   );
   const comparisonRuntime = comparisonCard.locator(".motion-thumbnail-runtime");
-  await comparisonCard.hover();
-  await expect(comparisonRuntime).toHaveAttribute("data-runtime-active", "true");
+  await expect(comparisonRuntime).not.toHaveAttribute("data-runtime-ready", "true");
+  const comparisonBeforeHover = await comparisonRuntime.evaluate((host) => {
+    const shadow = host.shadowRoot;
+    const surface = shadow?.querySelector<HTMLElement>(".motion-comparison");
+    const divider = shadow?.querySelector<HTMLElement>(".motion-divider");
+    if (!surface || !divider) return null;
+    const surfaceRect = surface.getBoundingClientRect();
+    const dividerRect = divider.getBoundingClientRect();
+    return {
+      dividerRatio: (dividerRect.left - surfaceRect.left) / surfaceRect.width,
+      rootCount: shadow?.querySelectorAll(".motion-demo").length ?? 0
+    };
+  });
+  await comparisonCard.scrollIntoViewIfNeeded();
+  await expect(comparisonRuntime).toHaveAttribute("data-runtime-ready", "true");
+  const comparisonAfterInitialization = await comparisonRuntime.evaluate((host) => {
+    const shadow = host.shadowRoot;
+    const surface = shadow?.querySelector<HTMLElement>(".motion-comparison");
+    const divider = shadow?.querySelector<HTMLElement>(".motion-divider");
+    if (!surface || !divider) return null;
+    const surfaceRect = surface.getBoundingClientRect();
+    const dividerRect = divider.getBoundingClientRect();
+    return {
+      dividerRatio: (dividerRect.left - surfaceRect.left) / surfaceRect.width,
+      rootCount: shadow?.querySelectorAll(".motion-demo").length ?? 0
+    };
+  });
+  expect(comparisonBeforeHover).not.toBeNull();
+  expect(comparisonAfterInitialization).not.toBeNull();
+  if (comparisonBeforeHover && comparisonAfterInitialization) {
+    expect(Math.abs(comparisonAfterInitialization.dividerRatio - comparisonBeforeHover.dividerRatio)).toBeLessThan(0.005);
+    expect(comparisonAfterInitialization.rootCount).toBe(comparisonBeforeHover.rootCount);
+  }
+
+  const comparisonContinuity = await comparisonRuntime.evaluate(async (host) => {
+    const card = host.closest<HTMLElement>(".library-card")!;
+    const shadow = host.shadowRoot!;
+    const surface = shadow.querySelector<HTMLElement>(".motion-comparison")!;
+    const divider = shadow.querySelector<HTMLElement>(".motion-divider")!;
+    const after = shadow.querySelector<HTMLElement>(".motion-after")!;
+    const snapshot = () => {
+      const surfaceRect = surface.getBoundingClientRect();
+      const dividerRect = divider.getBoundingClientRect();
+      return {
+        active: host.hasAttribute("data-runtime-active"),
+        clipPath: getComputedStyle(after).clipPath,
+        dividerRatio: (dividerRect.left - surfaceRect.left) / surfaceRect.width,
+        root: shadow.querySelector(".motion-demo")
+      };
+    };
+    const resting = snapshot();
+    card.dispatchEvent(new PointerEvent("pointerenter"));
+    const entered = snapshot();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
+    const playing = snapshot();
+    card.dispatchEvent(new PointerEvent("pointerleave"));
+    const left = snapshot();
+    return {
+      activeStates: [resting.active, entered.active, playing.active, left.active],
+      enterClipStable: resting.clipPath === entered.clipPath,
+      enterDividerDelta: Math.abs(resting.dividerRatio - entered.dividerRatio),
+      leaveClipStable: playing.clipPath === left.clipPath,
+      leaveDividerDelta: Math.abs(playing.dividerRatio - left.dividerRatio),
+      rootStable: resting.root === entered.root && entered.root === playing.root && playing.root === left.root
+    };
+  });
+  expect(comparisonContinuity.activeStates).toEqual([false, true, true, false]);
+  expect(comparisonContinuity.enterClipStable).toBe(true);
+  expect(comparisonContinuity.enterDividerDelta).toBeLessThan(0.005);
+  expect(comparisonContinuity.leaveClipStable).toBe(true);
+  expect(comparisonContinuity.leaveDividerDelta).toBeLessThan(0.005);
+  expect(comparisonContinuity.rootStable).toBe(true);
+
   await expect(comparisonRuntime).toHaveAttribute("inert", "");
+  expect(await comparisonRuntime.evaluate((host) =>
+    host.shadowRoot?.querySelector(".motion-demo") ===
+      (host as HTMLElement & { __motionLexiconRoot?: HTMLElement | null }).__motionLexiconRoot
+  )).toBe(true);
   expect(await comparisonRuntime.evaluate((host) =>
     Array.from(host.shadowRoot?.querySelectorAll<HTMLElement>(
       'a[href],button,input,select,textarea,summary,[tabindex],[contenteditable="true"]'
@@ -155,6 +452,23 @@ test("catalog hover mounts one exact recipe runtime at a time while keyboard foc
     )).toBeNull();
   }
 
+  const rippleCard = page.locator('a.library-card[href="/zh/feedback/ripple/"]');
+  const rippleRuntime = rippleCard.locator(".motion-thumbnail-runtime");
+  const rippleStyle = () => rippleRuntime.evaluate((host) => {
+    const ink = host.shadowRoot?.querySelector<HTMLElement>("[data-catalog-sample-ripple]");
+    if (!ink) return null;
+    const style = getComputedStyle(ink);
+    return { opacity: style.opacity, transform: style.transform };
+  });
+  const rippleBeforeInitialization = await rippleStyle();
+  await rippleCard.scrollIntoViewIfNeeded();
+  await expect(rippleRuntime).toHaveAttribute("data-runtime-ready", "true");
+  expect(await rippleStyle()).toEqual(rippleBeforeInitialization);
+
+  for (const scrollRecipe of ["scroll-reveal", "parallax"]) {
+    await expectScrollCatalogContinuity(page, scrollRecipe);
+  }
+
   for (const recipe of componentRecipes) {
     const card = page.locator(
       `a.library-card[href="/zh/${recipe.categoryId}/${recipe.id}/"]`
@@ -162,10 +476,27 @@ test("catalog hover mounts one exact recipe runtime at a time while keyboard foc
     const runtimeHost = card.locator(".motion-thumbnail-runtime");
 
     await card.hover();
+    await expect(runtimeHost).toHaveAttribute("data-runtime-ready", "true");
     await expect(runtimeHost).toHaveAttribute("data-runtime-active", "true");
     await expect(runtimeHost.locator(".motion-demo")).toHaveAttribute("data-motion", recipe.canonicalId);
+    expect(await runtimeHost.evaluate((host) =>
+      host.shadowRoot?.querySelector(".motion-demo") ===
+        (host as HTMLElement & { __motionLexiconRoot?: HTMLElement | null }).__motionLexiconRoot
+    )).toBe(true);
     await expect(page.locator('.motion-thumbnail-runtime[data-runtime-active="true"]')).toHaveCount(1);
-    await expect(page.locator(".motion-thumbnail-runtime .motion-demo")).toHaveCount(1);
+    await expect(page.locator(".motion-thumbnail-runtime .motion-demo")).toHaveCount(componentRecipes.length);
+
+    if (recipe.canonicalId === componentRecipes[0].canonicalId) {
+      await expect.poll(() => runtimeHost.locator(".motion-demo").evaluate((root) =>
+        root.getAnimations({ subtree: true }).some((animation) => animation.playState === "running")
+      )).toBe(true);
+    }
+
+    if (recipe.canonicalId === "ripple") {
+      const beforeNodeCount = mountedBeforeHover.find(({ canonicalId }) => canonicalId === "ripple")?.nodeCount;
+      expect(await runtimeHost.locator(".motion-demo").evaluate((root) => root.querySelectorAll("*").length))
+        .toBe(beforeNodeCount);
+    }
 
     if ([
       "hover-effect",
@@ -183,8 +514,21 @@ test("catalog hover mounts one exact recipe runtime at a time while keyboard foc
 
   await page.getByRole("heading", { level: 1 }).hover();
   await expect(page.locator('.motion-thumbnail-runtime[data-runtime-active="true"]')).toHaveCount(0);
-  await expect(page.locator(".motion-thumbnail-runtime .motion-demo")).toHaveCount(0);
+  await expect(page.locator(".motion-thumbnail-runtime .motion-demo")).toHaveCount(componentRecipes.length);
+  expect(await firstRuntime.locator(".motion-demo").evaluate((root) =>
+    root.getAnimations({ subtree: true }).every((animation) => animation.playState === "paused")
+  )).toBe(true);
+  expect(await runtimeHosts.evaluateAll((hosts) => hosts.every((host) =>
+    host.shadowRoot?.querySelector(".motion-demo") ===
+      (host as HTMLElement & { __motionLexiconRoot?: HTMLElement | null }).__motionLexiconRoot
+  ))).toBe(true);
   expect(runtimeErrors).toEqual([]);
+});
+
+test("scroll-driven playground preview keeps continuous hover playback", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Fine-pointer hover is verified once on desktop.");
+  await page.goto("/zh/catalog/?surface=playgrounds");
+  await expectScrollCatalogContinuity(page, "scroll-driven-animation");
 });
 
 test("continuous motion can pause and resume its active animation", async ({ page }, testInfo) => {


### PR DESCRIPTION
## Summary

- Server-render every catalog card with its exact recipe DOM inside declarative Shadow DOM.
- Keep preview nodes mounted and let hover control only persistent animation timelines.
- Remove horizontal scrolling from catalog, Finder, vocabulary, code, and responsive parameter layouts.
- Preserve before-after and scroll-preview state across initialization, pointer entry, and pointer exit.
- Keep the vocabulary toolbar compact across stacked and desktop layouts.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run test` — 52 passed
- `npm run i18n:check`
- `npm run vocabulary:check`
- `npm run seo:check`
- `npm run motion:check`
- `npm run a11y:check`
- `npm run build`
- `npm run bundle:check`
- `npm run crawl:dist` — 120 canonical routes
- `npm run test:visual` — 70 passed, 38 project-conditional skips
- 240 responsive route states audited at 320px and 1440px with zero horizontal overflow issues
- Independent final diff review: no P0-P2 findings