### PR TITLE
Avoid subpixel target-size rounding

### DIFF
--- a/src/apple-redesign.css
+++ b/src/apple-redesign.css
@@ -888,7 +888,7 @@ summary {
 
 .library-utility-settings .theme-select,
 .library-utility-settings .icon-link {
-  min-height: 44px;
+  min-height: 45px;
   flex: 1;
   justify-content: center;
   border: 1px solid var(--apple-line);

--- a/src/interior-theme.css
+++ b/src/interior-theme.css
@@ -361,7 +361,7 @@ a,
 
 .library-utility-settings .interior-theme-select > button {
   width: 100%;
-  min-height: 44px;
+  min-height: 45px;
   justify-content: center;
   border-color: var(--interior-line);
   border-radius: 9px;


### PR DESCRIPTION
## Summary

- raise resource-panel theme and icon controls from 44px to 45px
- preserve the 44px accessibility baseline after Linux device-scale rounding

## Verification

- targeted coarse-pointer Playwright test passes
- lint, typecheck, accessibility, motion, and diff checks pass

## Context

GitHub Chromium measured a declared 44px control as 43.999969px. The extra CSS pixel removes that cross-platform boundary condition.