### PR TITLE
Polish shared controls and product layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@radix-ui/react-slider": "^1.4.7",
         "motion": "^12.43.0"
       },
       "bin": {
@@ -1190,6 +1191,249 @@
         "node": ">=18"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.3.tgz",
+      "integrity": "sha512-Road2bidD0uu/1BGDOWNdPI06g0lIRy6IF9GZcIrDK2KGItfor8IQwQa+yM2ERgHM1MmHxaxpTzk0/Jp42lNfA==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.7.tgz",
+      "integrity": "sha512-rqWnm76nYT8HoNNqEjpgJ7Pw/DrBj5iBTrmEPo6HTX5+VJyBNOqTdv4g89G63HuR5g0AaENoAcH7Is5fF2kZ8Q==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.15.tgz",
+      "integrity": "sha512-9W+B9NPF0NaaPh/1NJd3+KqsnlLqU9H7T2rvww+fp+T/evVXdNAyYcnfRQZFOjkR1ajQp3yORlqnI8soawLvNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.5.tgz",
+      "integrity": "sha512-+48PbAAbq3didjJxa+OaWY2ZwgAKsNiRGyeHKszblZMQ+kcpd9pAaT11cMkGEie0vsOi3QdeTE6d5Fe3Gn61kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.2.2.tgz",
+      "integrity": "sha512-RHCUGwKHDr0hDGg4X7ma4JG4/+12qxw8rkh5QKdDldlCvtja6nUx1Ef/8HVrJze81lEsgLQlqjzjGNHantgnQA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.4.tgz",
+      "integrity": "sha512-5pzg4FGQNpExhnhT2zlrP1wZFaYCd1K0nYWoFAdcYoYK868IEigqMX3B3f8yIoRlAhAeDWciLI6ZdCKHF9P4Vg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.10.tgz",
+      "integrity": "sha512-MucOnzh6hR5mid6VpkbglRAMYMjKLqRnGBbjXkzjK52fuQDd1qbkx78a5P40mkcnVXJdEVxm26E9OPAiUq7nBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.4.7.tgz",
+      "integrity": "sha512-mTSLf1GC/C0moWjTbvCM6Qn/gBjvlFt1azuWF2v7MN5C3Zq2U2J2lN3ZEYkpujuOU5Ro7A28wkviSxaKnG0BYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.3",
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-collection": "1.1.15",
+        "@radix-ui/react-compose-refs": "1.1.5",
+        "@radix-ui/react-context": "1.2.2",
+        "@radix-ui/react-direction": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.6",
+        "@radix-ui/react-use-layout-effect": "1.1.4",
+        "@radix-ui/react-use-previous": "1.1.4",
+        "@radix-ui/react-use-size": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.3.tgz",
+      "integrity": "sha512-qx7oqnYbxnK9kYI9m317qmFmEgo6ywqWvbTogdj7cL9p3/yx4M48p7Rnw5z3H890cL/ow/EeWJsuTykeZVXP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.6.tgz",
+      "integrity": "sha512-uEQJGT97ZA/TgP/Hydw47lHu+/vQj6z/0jA+WeTbK1o9Rx45GImjpD0tc3W5ad3D6XTSR6e1yEO0FvGq6WQfVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.7",
+        "@radix-ui/react-use-effect-event": "0.0.5",
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.5.tgz",
+      "integrity": "sha512-7cshFL8HGS/7HEiHH+9kL9HBwp2sa9yX18Knwek6KYWmXwM7pegMgta2AXMQKI+rq3JnfSj9x8wYqFMTdG1Jgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.4.tgz",
+      "integrity": "sha512-K20DkRkUwDnxEYMBPcg3Y6voLkEy5p5QQmszZgLngKKiC7dzBR/aEuK3w1qlx2JWDUNH6FluahYdgR3BP+QbYw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.4.tgz",
+      "integrity": "sha512-XoSLhbRbqxFtgJoi2fNHA3C6pDlY34x508vUpUGoFZfvePfHXHbE1lC4FYFMnJWgiCRroSTw6fOsXQoVS9RwZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.4.tgz",
+      "integrity": "sha512-D3anSY15EJoxrihpsXI6SMrmmonnQtR2ni7arO+Lfdg3O95b9hNXxONk8jA5C8ANdF/h5HMAxejgs8PWJ6rlhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.4"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "dev": true,
@@ -1540,12 +1784,12 @@
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.31",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1554,7 +1798,7 @@
     },
     "node_modules/@types/react-dom": {
       "version": "18.3.7",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -2124,7 +2368,7 @@
     },
     "node_modules/csstype": {
       "version": "3.2.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -3176,7 +3420,6 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/jsdom": {
@@ -3368,7 +3611,6 @@
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -3722,7 +3964,6 @@
     },
     "node_modules/react": {
       "version": "18.3.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -3733,7 +3974,6 @@
     },
     "node_modules/react-dom": {
       "version": "18.3.1",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -3879,7 +4119,6 @@
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "postcss": "8.5.23"
   },
   "dependencies": {
+    "@radix-ui/react-slider": "^1.4.7",
     "motion": "^12.43.0"
   }
 }

--- a/scripts/check-bundle.ts
+++ b/scripts/check-bundle.ts
@@ -21,9 +21,9 @@ assert(jsFiles.some((file) => file.startsWith("vendor-")), "Stable vendor bundle
 const maxChunkRawBytes = 650 * 1024;
 const maxChunkGzipBytes = 160 * 1024;
 // The Interior interaction system keeps Motion in its own vendor chunk. The
-// total budget includes that runtime while preserving a narrow growth margin.
+// total budget also includes the accessible Radix slider used by recipe controls.
 const maxMotionVendorGzipBytes = 48 * 1024;
-const maxTotalJsGzipBytes = 280 * 1024;
+const maxTotalJsGzipBytes = 286 * 1024;
 const maxTotalCssGzipBytes = 48 * 1024;
 let totalJsGzipBytes = 0;
 

--- a/src/apple-redesign.css
+++ b/src/apple-redesign.css
@@ -208,33 +208,13 @@ summary {
   margin-top: 2.2rem;
 }
 
-.apple-hero-finder > label {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  white-space: nowrap;
-}
-
-.apple-hero-finder > div {
-  min-height: 64px;
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
-  align-items: center;
-  gap: 0.8rem;
-  border: 1px solid var(--apple-control-line);
-  border-radius: var(--ui-radius-card);
-  padding: 0.45rem 0.45rem 0.45rem 1rem;
-  background: var(--apple-surface);
-  box-shadow: none;
-  transition: border-color 160ms ease, background-color 160ms ease;
-}
-
-.apple-hero-finder > div:focus-within {
-  border-color: var(--apple-blue);
-  outline: 2px solid var(--apple-blue);
-  outline-offset: 2px;
+.apple-hero-finder > .interior-hero-search {
+  width: 100%;
+  min-height: 44px;
+  display: block;
+  border: 0;
+  padding: 0;
+  background: transparent;
   box-shadow: none;
 }
 
@@ -254,26 +234,6 @@ summary {
 
 .apple-hero-finder input::placeholder {
   color: var(--apple-secondary);
-}
-
-.apple-hero-finder button {
-  min-height: 50px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.55rem;
-  border: 0;
-  border-radius: var(--ui-radius-cta);
-  padding: 0 1.05rem;
-  color: var(--apple-action-fg);
-  background: var(--apple-action-bg);
-  font-size: 0.88rem;
-  font-weight: 650;
-  box-shadow: 0 8px 22px color-mix(in srgb, var(--apple-ink) 18%, transparent);
-}
-
-.apple-hero-finder button:hover {
-  background: var(--apple-action-hover);
 }
 
 .apple-hero-examples {
@@ -632,17 +592,6 @@ summary {
     line-height: 1.62;
   }
 
-  .apple-hero-finder > div {
-    grid-template-columns: auto 1fr;
-    gap: 0.6rem;
-    padding: 0.45rem 0.55rem 0.55rem 0.9rem;
-  }
-
-  .apple-hero-finder button {
-    grid-column: 1 / -1;
-    width: 100%;
-  }
-
   .apple-hero-examples {
     display: grid;
   }
@@ -724,7 +673,7 @@ summary {
 }
 
 @media (prefers-contrast: more) {
-  .apple-hero-finder > div,
+  .apple-hero-finder .interior-hero-search > div,
   .apple-hero-preview.library-hero-preview,
   .apple-motion-card.library-card {
     border: 1px solid currentColor;
@@ -1773,13 +1722,13 @@ summary {
 }
 
 .apple-recipe-hero.library-entry-header {
-  min-height: 280px;
+  min-height: 0;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: end;
   gap: 2rem;
   border: 0;
-  padding: 3.2rem 0 3.5rem;
+  padding: 1.5rem 0 2.5rem;
 }
 
 .apple-recipe-identity {
@@ -1872,18 +1821,20 @@ summary {
 
 .apple-workbench-stage .apple-preview-toolbar.library-preview-toolbar {
   min-height: 52px;
+  align-items: center;
   border: 1px solid var(--apple-line);
   border-bottom: 0;
   border-radius: var(--ui-radius-card) var(--ui-radius-card) 0 0;
-  padding: 0 0.55rem;
+  padding: 4px 0.5rem;
   background: color-mix(in srgb, var(--apple-surface-raised) 82%, transparent);
   backdrop-filter: blur(20px) saturate(150%);
   -webkit-backdrop-filter: blur(20px) saturate(150%);
 }
 
-.apple-workbench-stage .library-device-switcher {
+.apple-workbench-stage .library-device-switcher,
+.apple-workbench-stage .library-reduced-toggle {
   border-radius: var(--ui-radius-nav);
-  padding: 0.15rem;
+  padding: 3px;
   background: color-mix(in srgb, var(--apple-ink) 6%, transparent);
 }
 
@@ -1899,9 +1850,11 @@ summary {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.04);
 }
 
-.apple-workbench-stage .library-reduced-toggle {
+.apple-workbench-stage .library-reduced-toggle button {
+  min-width: 58px;
+  height: 44px;
+  padding-inline: 12px;
   border-radius: var(--ui-radius-nav);
-  padding: 0 0.65rem;
 }
 
 .apple-workbench.library-workbench {
@@ -2247,6 +2200,8 @@ summary {
 
 .apple-related-motion .library-related-links {
   grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  border: 0;
 }
 
 .apple-related-motion .library-related-links a {
@@ -2509,7 +2464,7 @@ summary {
     min-height: auto;
     grid-template-columns: 1fr;
     align-items: start;
-    padding: 3rem 0 2.8rem;
+    padding: 1.5rem 0 2rem;
   }
 
   .apple-recipe-hero h1,
@@ -2527,7 +2482,7 @@ summary {
   }
 
   .apple-workbench-stage .apple-preview-toolbar.library-preview-toolbar {
-    min-height: 56px;
+    min-height: 52px;
     border-radius: var(--ui-radius-card) var(--ui-radius-card) 0 0;
   }
 
@@ -2822,8 +2777,7 @@ summary {
 .finder-primary-copy.apple-primary-action,
 .finder-active-preview-copy > a,
 .library-code-filebar .ml-button,
-.finder-search-field > button,
-.apple-hero-finder button[type="submit"] {
+.finder-search-field > button {
   border-radius: var(--ui-radius-cta);
 }
 

--- a/src/components/CatalogSidebar.tsx
+++ b/src/components/CatalogSidebar.tsx
@@ -69,7 +69,8 @@ export function CatalogSidebar({
         <Dropdown
           value={selectedCategoryId ?? "all"}
           onChange={(next) => onCategoryChange?.(next === "all" ? undefined : next)}
-          label={currentLabel}
+          label={t("common.category")}
+          placeholder={currentLabel}
           className="library-category-filter-options interior-category-dropdown"
           items={[
             {

--- a/src/components/CopyButton.tsx
+++ b/src/components/CopyButton.tsx
@@ -5,11 +5,15 @@ import { buttonVariants, type ButtonProps } from "./ui/button";
 type CopyButtonProps = Pick<ButtonProps, "className" | "variant" | "size" | "disabled"> & {
   getText: () => string;
   label: string;
+  copiedLabel?: string;
+  errorLabel?: string;
 };
 
 export function CopyButton({
   getText,
   label,
+  copiedLabel,
+  errorLabel,
   className,
   variant,
   size,
@@ -21,8 +25,8 @@ export function CopyButton({
     <InteriorCopyButton
       value={getText}
       label={label}
-      copiedLabel={t("common.copied")}
-      errorLabel={t("common.copyFailed")}
+      copiedLabel={copiedLabel ?? t("common.copied")}
+      errorLabel={errorLabel ?? t("common.copyFailed")}
       timeout={2200}
       disabled={disabled}
       className={buttonVariants({ variant, size, className })}

--- a/src/components/ExportPanel.tsx
+++ b/src/components/ExportPanel.tsx
@@ -1,4 +1,3 @@
-import { Code2, MessageSquareText } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -41,12 +40,14 @@ export function ExportPanel({ locale, recipe, values }: ExportPanelProps) {
     ? {
         prompt: "提示词",
         code: "代码",
-        copyAllCode: "复制全部代码"
+        copyAllCode: "复制全部代码",
+        copyFailed: "复制失败"
       }
     : {
         prompt: "Prompt",
         code: "Code",
-        copyAllCode: "Copy all code"
+        copyAllCode: "Copy all code",
+        copyFailed: "Copy failed"
       };
   const codeFiles = useMemo(
     () => [
@@ -69,22 +70,12 @@ export function ExportPanel({ locale, recipe, values }: ExportPanelProps) {
       {
         value: "prompt",
         ariaLabel: labels.prompt,
-        label: (
-          <span className="interior-tab-label">
-            <MessageSquareText aria-hidden="true" size={14} strokeWidth={1.8} />
-            {labels.prompt}
-          </span>
-        )
+        label: <span className="interior-tab-label">{labels.prompt}</span>
       },
       {
         value: "code",
         ariaLabel: labels.code,
-        label: (
-          <span className="interior-tab-label">
-            <Code2 aria-hidden="true" size={14} strokeWidth={1.8} />
-            {labels.code}
-          </span>
-        )
+        label: <span className="interior-tab-label">{labels.code}</span>
       }
     ],
     [labels.code, labels.prompt]
@@ -120,6 +111,15 @@ export function ExportPanel({ locale, recipe, values }: ExportPanelProps) {
           label={t("workspace.outputTabsLabel")}
           className="interior-output-tabs"
           panelClassName="interior-output-panel"
+          toolbar={(
+            <CopyButton
+              label={tab === "prompt" ? t("common.copyPrompt") : labels.copyAllCode}
+              getText={() => tab === "prompt" ? prompt : codeBundle}
+              errorLabel={labels.copyFailed}
+              variant="accent"
+              size="sm"
+            />
+          )}
           renderPanel={(activeTab) => activeTab === "prompt" ? (
             <div className="library-prompt-content">
               {teachingNotice ? (
@@ -129,14 +129,6 @@ export function ExportPanel({ locale, recipe, values }: ExportPanelProps) {
             </div>
           ) : (
             <div className="library-code-bundle">
-              <div className="library-code-filebar library-code-bundle-toolbar">
-                <CopyButton
-                  label={labels.copyAllCode}
-                  getText={() => codeBundle}
-                  variant="ghost"
-                  size="sm"
-                />
-              </div>
               <div className="library-code-files" data-testid="code-output-bundle">
                 {codeFiles.map((file) => (
                   <section className="library-code-file" key={file.id}>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -8,7 +8,6 @@ import { pathFor } from "../data/site";
 import { ExpandingSearch } from "./interior/expanding-search";
 import { Ripple } from "./interior/ripple";
 import { CardLink } from "./interior/card-link";
-import { Button } from "./ui/button";
 
 const exampleKeys = ["weight", "continuity", "sequence"] as const;
 
@@ -42,28 +41,21 @@ export function Hero({ locale }: { locale: Locale }) {
         <h1 id="hero-title">{t("landing.heroTitle")}</h1>
         <p>{t("landing.heroCopy")}</p>
 
-        <form className="apple-hero-finder" role="search" onSubmit={handleSubmit}>
-          <span className="sr-only">{t("finder.formLabel")}</span>
-          <div>
-            <ExpandingSearch
-              id="home-finder-query"
-              name="q"
-              value={query}
-              onChange={setQuery}
-              onSubmit={openFinder}
-              open
-              collapseOnBlur={false}
-              align="left"
-              label={t("finder.formLabel")}
-              clearLabel={t("catalog.clearSearch")}
-              placeholder={t("landing.finderExample")}
-              className="interior-hero-search"
-            />
-            <Button type="submit" variant="accent">
-              <span>{t("landing.openFinder")}</span>
-              <ArrowRight aria-hidden="true" size={17} strokeWidth={1.9} />
-            </Button>
-          </div>
+        <form className="apple-hero-finder" onSubmit={handleSubmit}>
+          <ExpandingSearch
+            id="home-finder-query"
+            name="q"
+            value={query}
+            onChange={setQuery}
+            onSubmit={openFinder}
+            open
+            collapseOnBlur={false}
+            align="left"
+            label={t("finder.formLabel")}
+            clearLabel={t("catalog.clearSearch")}
+            placeholder={t("landing.finderExample")}
+            className="interior-hero-search"
+          />
         </form>
 
         <div className="apple-hero-examples" aria-label={t("finder.examplesLabel")}>

--- a/src/components/ParameterControls.tsx
+++ b/src/components/ParameterControls.tsx
@@ -15,6 +15,15 @@ type ParameterControlsProps = {
   onReset: () => void;
 };
 
+function segmentedColumnCount(labels: string[]) {
+  const count = labels.length;
+  const longest = Math.max(0, ...labels.map((label) => label.length));
+  if (longest > 14) return Math.min(2, count);
+  if (longest > 8) return Math.min(3, count);
+  if (count > 4) return Math.min(4, Math.ceil(count / 2));
+  return count;
+}
+
 export function ParameterControls({
   locale,
   recipe,
@@ -49,6 +58,9 @@ export function ParameterControls({
         const label = text(param.label, locale);
         const visibleValue = displayValue(param, value);
         const controlId = `motion-control-${recipe.id}-${param.id}`;
+        const segmentedLabels = param.kind === "segmented"
+          ? param.options.map((option) => text(option.label, locale))
+          : [];
         return (
           <div className="control" key={param.id}>
             <div className="control-head">
@@ -89,6 +101,7 @@ export function ParameterControls({
               <SegmentedControl
                 value={String(value)}
                 label={label}
+                columns={segmentedColumnCount(segmentedLabels)}
                 className="ml-toggle-group interior-parameter-segment"
                 options={param.options.map((option) => ({
                   value: option.value,

--- a/src/components/RecipeWorkspace.tsx
+++ b/src/components/RecipeWorkspace.tsx
@@ -16,9 +16,8 @@ import { getMotionGuidance } from "../data/motion-guidance";
 import { catalogRecipes, getCanonicalRecipe } from "../data/recipes";
 import type { Locale, MotionParam, MotionRecipe } from "../data/types";
 import { text } from "../data/site";
-import { buildRecipePrompt, getParamDisplayValue } from "../lib/motion-engine";
+import { getParamDisplayValue } from "../lib/motion-engine";
 import { useRecipeParams } from "../lib/useRecipeParams";
-import { CopyButton } from "./CopyButton";
 import { ExportPanel } from "./ExportPanel";
 import { MotionPreview } from "./MotionPreview";
 import { ParameterControls } from "./ParameterControls";
@@ -262,15 +261,6 @@ export function RecipeWorkspace({ locale, recipe, mode = "embedded" }: RecipeWor
             <SectionTitle id="workspace-title">{text(recipe.name, locale)}</SectionTitle>
             <p>{text(recipe.shortDescription, locale)}</p>
           </div>
-          {!isGuide ? (
-            <div className="apple-recipe-primary-action">
-              <CopyButton
-                label={t("common.copyPrompt")}
-                getText={() => buildRecipePrompt(recipe, values, locale)}
-                variant="accent"
-              />
-            </div>
-          ) : null}
         </header>
 
         <section className="library-preview-section apple-workbench-stage" id="preview" aria-labelledby="preview-title">

--- a/src/components/ThemeLanguageControls.tsx
+++ b/src/components/ThemeLanguageControls.tsx
@@ -38,8 +38,10 @@ export function ThemeLanguageControls({ locale }: ControlsProps) {
         }))}
         value={mounted ? theme : "system"}
         onChange={(value) => setTheme(value as ThemeMode)}
-        label={t(`common.${mounted ? theme : "system"}`)}
+        label={t("common.theme")}
+        placeholder={t("common.system")}
         disabled={!mounted}
+        inline
         className="theme-select interior-theme-select"
       />
     </div>

--- a/src/components/interior/dropdown.tsx
+++ b/src/components/interior/dropdown.tsx
@@ -270,6 +270,7 @@ export type DropdownProps = {
   disabled?: boolean;
   emptyLabel?: string;
   className?: string;
+  inline?: boolean;
 };
 
 export function Dropdown({
@@ -282,6 +283,7 @@ export function Dropdown({
   disabled = false,
   emptyLabel = "Nothing to choose",
   className = "",
+  inline = false,
 }: DropdownProps) {
   const reduced = useReducedMotion();
   const {
@@ -298,7 +300,11 @@ export function Dropdown({
   const cell = reduced ? NONE : CELL;
 
   return (
-    <div ref={rootRef} className={`relative inline-block text-left ${className}`}>
+    <div
+      ref={rootRef}
+      data-open={open ? "" : undefined}
+      className={`${inline ? "block" : "relative inline-block"} text-left ${className}`}
+    >
       <button
         {...triggerProps}
         className={`flex h-9 select-none items-center gap-2 whitespace-nowrap rounded-[9px] border border-stone-200 bg-white px-3 text-[13px] font-medium text-stone-700 outline-none transition-[box-shadow,border-color] duration-150 disabled:opacity-50 dark:border-white/[0.16] dark:bg-[#1D1D1A] dark:text-stone-200 ${
@@ -310,7 +316,7 @@ export function Dropdown({
         <span className="sr-only">
           {label}: {selectedItem ? selectedItem.label : placeholder}
         </span>
-        <span aria-hidden>{label}</span>
+        <span aria-hidden>{selectedItem?.label ?? placeholder}</span>
         <motion.svg
           aria-hidden
           viewBox="0 0 12 12"
@@ -349,7 +355,7 @@ export function Dropdown({
                 : { ...OPEN, opacity: { duration: 0.12, ease: EASE } }
             }
             style={{ transformOrigin: "top left" }}
-            className="absolute left-0 top-[calc(100%+6px)] z-50 min-w-[224px] whitespace-nowrap rounded-[11px] border border-stone-200 bg-white p-[5px] shadow-[0_1px_2px_rgba(28,25,23,0.06),0_16px_36px_-18px_rgba(28,25,23,0.5)] dark:border-white/[0.16] dark:bg-[#1D1D1A] dark:shadow-[0_2px_12px_rgba(0,0,0,0.6)]"
+            className={`${inline ? "relative mt-1 w-full" : "absolute left-0 top-[calc(100%+6px)]"} z-50 min-w-[224px] whitespace-nowrap rounded-[11px] border border-stone-200 bg-white p-[5px] shadow-[0_1px_2px_rgba(28,25,23,0.06),0_16px_36px_-18px_rgba(28,25,23,0.5)] dark:border-white/[0.16] dark:bg-[#1D1D1A] dark:shadow-[0_2px_12px_rgba(0,0,0,0.6)]`}
           >
             <ul
               {...listProps}

--- a/src/components/interior/segmented-control.tsx
+++ b/src/components/interior/segmented-control.tsx
@@ -12,7 +12,7 @@ import {
 const CELL = { type: "spring", stiffness: 520, damping: 34, mass: 0.45 } as const;
 
 const SEG =
-  "px-3 py-[7px] text-center text-[13px] font-medium leading-[18px] tracking-[-0.01em] whitespace-nowrap";
+  "flex min-h-9 items-center justify-center px-3 text-center text-[13px] font-medium leading-[18px] tracking-[-0.01em] whitespace-nowrap";
 
 export type SegmentedOption = {
   value: string;
@@ -27,6 +27,7 @@ export type SegmentedControlProps = {
   value?: string;
   defaultValue?: string;
   onValueChange?: (value: string) => void;
+  columns?: number;
   className?: string;
 };
 
@@ -36,9 +37,12 @@ export function SegmentedControl({
   value,
   defaultValue,
   onValueChange,
+  columns: requestedColumns,
   className = "",
 }: SegmentedControlProps) {
   const count = Math.max(1, options.length);
+  const columns = Math.max(1, Math.min(count, requestedColumns ?? count));
+  const wraps = columns < count;
   const template = `repeat(${count}, minmax(0, 1fr))`;
 
   const [internal, setInternal] = useState(
@@ -129,58 +133,16 @@ export function SegmentedControl({
     <div
       role="radiogroup"
       aria-label={label}
+      data-segmented-layout={wraps ? "wrapped" : "single"}
       className={`relative inline-block select-none rounded-[9px] border border-stone-200 bg-stone-100/70 p-[3px] shadow-[inset_0_1px_2px_rgba(28,25,23,0.07)] dark:border-white/[0.16] dark:bg-[#1D1D1A] dark:shadow-[inset_0_1px_2px_rgba(0,0,0,0.45)] ${className}`}
     >
-      <div
-        className="relative grid"
-        style={{ gridTemplateColumns: template, touchAction: "manipulation" }}
-      >
-        {options.map((option, i) => (
-          <span
-            key={option.value}
-            aria-hidden
-            className={`${SEG} pointer-events-none ${
-              option.disabled
-                ? "text-stone-300 dark:text-stone-600"
-                : hovered === i && i !== index
-                  ? "text-stone-700 dark:text-stone-200"
-                  : "text-stone-500 dark:text-stone-400"
-            }`}
-          >
-            {option.label}
-          </span>
-        ))}
-
-        <motion.div
-          aria-hidden
-          className="pointer-events-none absolute inset-y-0 left-0 overflow-hidden rounded-[6px] bg-stone-800 shadow-[0_1px_2px_rgba(28,25,23,0.28)] dark:bg-stone-100 dark:shadow-[0_1px_2px_rgba(0,0,0,0.5)]"
-          style={{ width: `${100 / count}%`, transform: thumbTransform }}
-          initial={false}
-        >
-          <motion.div
-            className="absolute inset-0"
-            style={{ transform: maskTransform }}
-            initial={false}
-          >
-            <div
-              className="absolute inset-y-0 left-0 grid"
-              style={{ width: `${count * 100}%`, gridTemplateColumns: template }}
-            >
-              {options.map((option) => (
-                <span
-                  key={option.value}
-                  className={`${SEG} text-stone-50 dark:text-stone-900`}
-                >
-                  {option.label}
-                </span>
-              ))}
-            </div>
-          </motion.div>
-        </motion.div>
+      {wraps ? (
         <div
-          className="absolute inset-0 grid"
-          style={{ gridTemplateColumns: template }}
-          onPointerLeave={() => setHovered(-1)}
+          className="grid gap-[3px]"
+          style={{
+            gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))`,
+            touchAction: "manipulation",
+          }}
         >
           {options.map((option, i) => (
             <button
@@ -196,14 +158,97 @@ export function SegmentedControl({
               tabIndex={i === index ? 0 : -1}
               onClick={() => !option.disabled && select(option.value)}
               onKeyDown={(e) => onKeyDown(e, i)}
-              onPointerEnter={() => !option.disabled && setHovered(i)}
-              className="cursor-default rounded-[6px] outline-none focus-visible:bg-[#4568FF]/[0.06] focus-visible:shadow-[inset_0_0_0_1px_#4568FF] dark:focus-visible:bg-[#93B0FF]/[0.08] dark:focus-visible:shadow-[inset_0_0_0_1px_#93B0FF]"
+              className="group min-h-11 min-w-0 cursor-default rounded-[6px] bg-transparent p-[3px] text-center text-[12px] font-medium leading-4 outline-none focus-visible:shadow-[inset_0_0_0_1px_#4568FF] dark:focus-visible:shadow-[inset_0_0_0_1px_#93B0FF]"
             >
-              <span className="sr-only">{option.label}</span>
+              <span
+                className={`interior-segment-option flex min-h-8 min-w-0 items-center justify-center rounded-[6px] px-1.5 py-1 whitespace-normal break-words transition-colors duration-150 ${
+                  option.disabled
+                    ? "text-stone-300 dark:text-stone-600"
+                    : i === index
+                      ? "is-selected bg-stone-800 text-stone-50 shadow-[0_1px_2px_rgba(28,25,23,0.22)] dark:bg-stone-100 dark:text-stone-900"
+                      : "text-stone-500 group-hover:bg-stone-200/60 group-hover:text-stone-700 dark:text-stone-400 dark:group-hover:bg-white/[0.06] dark:group-hover:text-stone-200"
+                }`}
+              >
+                {option.label}
+              </span>
             </button>
           ))}
         </div>
-      </div>
+      ) : (
+        <div
+          className="relative grid"
+          style={{ gridTemplateColumns: template, touchAction: "manipulation" }}
+        >
+          {options.map((option, i) => (
+            <span
+              key={option.value}
+              aria-hidden
+              className={`${SEG} pointer-events-none ${
+                option.disabled
+                  ? "text-stone-300 dark:text-stone-600"
+                  : hovered === i && i !== index
+                    ? "text-stone-700 dark:text-stone-200"
+                    : "text-stone-500 dark:text-stone-400"
+              }`}
+            >
+              {option.label}
+            </span>
+          ))}
+
+          <motion.div
+            aria-hidden
+            className="interior-segment-thumb pointer-events-none absolute inset-y-0 left-0 overflow-hidden rounded-[6px] bg-stone-800 shadow-[0_1px_2px_rgba(28,25,23,0.28)] dark:bg-stone-100 dark:shadow-[0_1px_2px_rgba(0,0,0,0.5)]"
+            style={{ width: `${100 / count}%`, transform: thumbTransform }}
+            initial={false}
+          >
+            <motion.div
+              className="absolute inset-0"
+              style={{ transform: maskTransform }}
+              initial={false}
+            >
+              <div
+                className="absolute inset-y-0 left-0 grid"
+                style={{ width: `${count * 100}%`, gridTemplateColumns: template }}
+              >
+                {options.map((option) => (
+                  <span
+                    key={option.value}
+                    className={`${SEG} text-stone-50 dark:text-stone-900`}
+                  >
+                    {option.label}
+                  </span>
+                ))}
+              </div>
+            </motion.div>
+          </motion.div>
+          <div
+            className="absolute inset-0 grid"
+            style={{ gridTemplateColumns: template }}
+            onPointerLeave={() => setHovered(-1)}
+          >
+            {options.map((option, i) => (
+              <button
+                key={option.value}
+                ref={(node) => {
+                  buttons.current[i] = node;
+                }}
+                type="button"
+                role="radio"
+                aria-label={option.ariaLabel}
+                aria-checked={i === index}
+                aria-disabled={option.disabled || undefined}
+                tabIndex={i === index ? 0 : -1}
+                onClick={() => !option.disabled && select(option.value)}
+                onKeyDown={(e) => onKeyDown(e, i)}
+                onPointerEnter={() => !option.disabled && setHovered(i)}
+                className="cursor-default rounded-[6px] outline-none focus-visible:bg-[#4568FF]/[0.06] focus-visible:shadow-[inset_0_0_0_1px_#4568FF] dark:focus-visible:bg-[#93B0FF]/[0.08] dark:focus-visible:shadow-[inset_0_0_0_1px_#93B0FF]"
+              >
+                <span className="sr-only">{option.label}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/interior/tabs.tsx
+++ b/src/components/interior/tabs.tsx
@@ -171,6 +171,7 @@ export type TabsProps = {
   onValueChange?: (value: string) => void;
   activation?: TabsActivation;
   renderPanel?: (value: string) => ReactNode;
+  toolbar?: ReactNode;
   label?: string;
   panelClassName?: string;
   className?: string;
@@ -183,6 +184,7 @@ export function Tabs({
   onValueChange,
   activation = "automatic",
   renderPanel,
+  toolbar,
   label = "Tabs",
   panelClassName = "",
   className = "",
@@ -194,39 +196,42 @@ export function Tabs({
     <div
       className={`w-full overflow-hidden rounded-[12px] border border-stone-200 bg-white shadow-[0_1px_2px_rgba(28,25,23,0.06),0_4px_10px_-8px_rgba(28,25,23,0.45)] dark:border-white/[0.16] dark:bg-[#1D1D1A] dark:shadow-[0_1px_6px_rgba(0,0,0,0.45)] ${className}`}
     >
-      <div
-        {...tabs.tabListProps}
-        aria-label={label}
-        className="relative flex w-full gap-1 border-b border-stone-200 bg-stone-50 px-1 pt-1 dark:border-white/[0.16] dark:bg-[#1D1D1A]"
-      >
-        {items.map((item, index) => {
-          const selected = item.value === tabs.value;
-          return (
-            <button
-              key={item.value}
-              {...tabs.getTabProps(item, index)}
-              aria-label={item.ariaLabel}
-              className={`relative flex h-8 shrink-0 items-center justify-center rounded-t-[8px] px-3.5 text-[12.5px] outline-none transition-colors duration-150 after:pointer-events-none after:absolute after:inset-0 after:rounded-t-[8px] after:content-[''] focus-visible:after:shadow-[inset_0_0_0_1px_#4568FF] dark:focus-visible:after:shadow-[inset_0_0_0_1px_#93B0FF] ${
-                item.disabled
-                  ? "cursor-default text-stone-400 dark:text-stone-500"
-                  : selected
-                    ? "border border-b-0 border-stone-200 bg-white text-stone-800 dark:border-white/[0.16] dark:bg-[#1D1D1A] dark:text-stone-100"
-                    : "text-stone-500 hover:bg-stone-200/50 hover:text-stone-700 dark:text-stone-400 dark:hover:bg-white/[0.05] dark:hover:text-stone-200"
-              }`}
-            >
-              <span className="relative grid place-items-center leading-[1.4]">
-                <span aria-hidden className="invisible col-start-1 row-start-1 font-medium">
-                  {item.label}
+      <div className="interior-tabs-toolbar">
+        <div
+          {...tabs.tabListProps}
+          aria-label={label}
+          className="relative flex w-full gap-1 border-b border-stone-200 bg-stone-50 px-1 pt-1 dark:border-white/[0.16] dark:bg-[#1D1D1A]"
+        >
+          {items.map((item, index) => {
+            const selected = item.value === tabs.value;
+            return (
+              <button
+                key={item.value}
+                {...tabs.getTabProps(item, index)}
+                aria-label={item.ariaLabel}
+                className={`relative flex h-8 shrink-0 items-center justify-center rounded-t-[8px] px-3.5 text-[12.5px] outline-none transition-colors duration-150 after:pointer-events-none after:absolute after:inset-0 after:rounded-t-[8px] after:content-[''] focus-visible:after:shadow-[inset_0_0_0_1px_#4568FF] dark:focus-visible:after:shadow-[inset_0_0_0_1px_#93B0FF] ${
+                  item.disabled
+                    ? "cursor-default text-stone-400 dark:text-stone-500"
+                    : selected
+                      ? "border border-b-0 border-stone-200 bg-white text-stone-800 dark:border-white/[0.16] dark:bg-[#1D1D1A] dark:text-stone-100"
+                      : "text-stone-500 hover:bg-stone-200/50 hover:text-stone-700 dark:text-stone-400 dark:hover:bg-white/[0.05] dark:hover:text-stone-200"
+                }`}
+              >
+                <span className="relative grid place-items-center leading-[1.4]">
+                  <span aria-hidden className="invisible col-start-1 row-start-1 font-medium">
+                    {item.label}
+                  </span>
+                  <span
+                    className={`col-start-1 row-start-1 ${selected ? "font-medium" : ""}`}
+                  >
+                    {item.label}
+                  </span>
                 </span>
-                <span
-                  className={`col-start-1 row-start-1 ${selected ? "font-medium" : ""}`}
-                >
-                  {item.label}
-                </span>
-              </span>
-            </button>
-          );
-        })}
+              </button>
+            );
+          })}
+        </div>
+        {toolbar ? <div className="interior-tabs-action">{toolbar}</div> : null}
       </div>
 
       {renderPanel ? items.map((item) => {

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -1,4 +1,4 @@
-import { SliderDetents } from "../interior/slider-detents";
+import * as SliderPrimitive from "@radix-ui/react-slider";
 import { cn } from "../../lib/utils";
 
 type SliderProps = {
@@ -25,18 +25,23 @@ export function Slider({
   disabled
 }: SliderProps) {
   return (
-    <SliderDetents
-      value={value[0] ?? min}
+    <SliderPrimitive.Root
+      value={value}
       min={min}
       max={max}
       step={step}
-      onValueChange={(next) => onValueChange?.([next])}
-      label={thumbAriaLabel}
-      format={() => thumbAriaValueText ?? String(value[0] ?? min)}
-      showValue={false}
+      onValueChange={onValueChange}
       disabled={disabled}
-      haptic
       className={cn("ml-slider interior-slider", className)}
-    />
+    >
+      <SliderPrimitive.Track className="ml-slider-track">
+        <SliderPrimitive.Range className="ml-slider-range" />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb
+        className="ml-slider-thumb"
+        aria-label={thumbAriaLabel}
+        aria-valuetext={thumbAriaValueText}
+      />
+    </SliderPrimitive.Root>
   );
 }

--- a/src/i18n/resources.ts
+++ b/src/i18n/resources.ts
@@ -67,7 +67,7 @@ export const resources = {
         heroTitle: "说出你要的感觉，\n找到准确动效。",
         heroCopy: "描述界面、动作和质感，获得三个可预览候选。",
         openFinder: "开始描述动效",
-        finderExample: "让卡片带着重量感进入，最后稳稳收住",
+        finderExample: "例如：卡片切入后慢慢停下来",
         browseComponents: "浏览动效组件",
         openPlaygrounds: "打开参数工具",
         searchLibrary: "搜索 fade、spring、drag 或 reduced motion",
@@ -142,11 +142,11 @@ export const resources = {
         title: "描述感觉，找到准确动效。",
         copy: "写下界面、动作和质感，获得三个候选。",
         formLabel: "描述你想要的动效",
-        placeholder: "例如：让卡片带着重量感进入，最后稳稳收住",
+        placeholder: "例如：卡片先切入进来，然后慢慢停下来",
         submit: "查找候选",
         examplesLabel: "试试这些描述",
         examples: {
-          weight: "让卡片带着重量感进入，最后稳稳收住",
+          weight: "卡片先切入进来，然后慢慢停下来",
           continuity: "让同一个元素在两个页面之间连贯移动",
           sequence: "让一组列表项依次出现，节奏清楚一点"
         },
@@ -157,7 +157,7 @@ export const resources = {
           medium: "可用匹配",
           low: "探索性匹配"
         },
-        lowConfidence: "按“界面或对象 + 动作 + 感觉”补充描述，可以获得更准确的候选。例如：让卡片带着重量感进入，最后稳稳收住。",
+        lowConfidence: "按“界面或对象 + 动作 + 感觉”补充描述，可以获得更准确的候选。例如：卡片先切入进来，然后慢慢停下来。",
         matchedTerms: "匹配线索",
         candidateLabel: "候选 {{rank}}",
         select: "选择 {{name}}",
@@ -285,7 +285,7 @@ export const resources = {
         heroTitle: "Describe the feel.\nFind the right motion.",
         heroCopy: "Describe the interface, action, and feel to get three previewable candidates.",
         openFinder: "Describe your motion",
-        finderExample: "Make the card enter with a sense of weight, then settle cleanly",
+        finderExample: "For example: let the card enter, then slow to a stop",
         browseComponents: "Browse components",
         openPlaygrounds: "Open playgrounds",
         searchLibrary: "Search fade, spring, drag, or reduced motion",
@@ -360,11 +360,11 @@ export const resources = {
         title: "Describe the feel. Find the right motion.",
         copy: "Describe the interface, action, and feel to get three candidates.",
         formLabel: "Describe the motion you want",
-        placeholder: "For example: make the card enter with a sense of weight, then settle cleanly",
+        placeholder: "For example: let the card enter, then slow to a stop",
         submit: "Find candidates",
         examplesLabel: "Try an example",
         examples: {
-          weight: "Make the card enter with a sense of weight, then settle cleanly",
+          weight: "Let the card enter, then slow to a stop",
           continuity: "Move the same element smoothly between two screens",
           sequence: "Bring in a list item by item with a clear rhythm"
         },
@@ -375,7 +375,7 @@ export const resources = {
           medium: "Useful match",
           low: "Exploratory match"
         },
-        lowConfidence: "Describe the interface or object, the action, and the desired feel for tighter candidates. For example: make the card enter with a sense of weight, then settle cleanly.",
+        lowConfidence: "Describe the interface or object, the action, and the desired feel for tighter candidates. For example: let the card enter, then slow to a stop.",
         matchedTerms: "Matched cues",
         candidateLabel: "Candidate {{rank}}",
         select: "Choose {{name}}",

--- a/src/interior-theme.css
+++ b/src/interior-theme.css
@@ -195,7 +195,16 @@ a,
   width: 36px;
 }
 
-.apple-hero-finder > div,
+.apple-hero-finder > .interior-hero-search {
+  min-height: 44px;
+  display: block;
+  border: 0;
+  border-radius: 0;
+  padding: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
 .apple-search-pill .finder-search-field {
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 8px;
@@ -207,14 +216,18 @@ a,
   box-shadow: var(--interior-shadow);
 }
 
-.apple-hero-finder > div:focus-within,
+.apple-hero-finder > .interior-hero-search:focus-within {
+  border: 0;
+  outline: 0;
+  box-shadow: none;
+}
+
 .apple-search-pill .finder-search-field:focus-within {
   border-color: var(--interior-focus);
   outline: 0;
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--interior-focus) 26%, transparent), var(--interior-shadow);
 }
 
-.apple-hero-finder > div > .ml-button,
 .apple-search-pill .finder-search-field > .ml-button {
   min-width: max-content;
   min-height: 44px;
@@ -294,6 +307,15 @@ a,
   border-radius: 6px;
 }
 
+.library-device-switcher.interior-device-switcher button:hover {
+  background: transparent;
+}
+
+.interior-device-switcher,
+.interior-motion-mode {
+  align-self: center;
+}
+
 .control-switch.interior-toggle-switch,
 .ml-toggle-group.interior-parameter-segment {
   width: 100%;
@@ -306,9 +328,15 @@ a,
   min-height: 44px;
 }
 
+.ml-toggle-group.interior-parameter-segment .interior-segment-option.is-selected {
+  color: var(--apple-action-fg);
+  background: var(--apple-action-bg);
+}
+
 .ml-slider.interior-slider {
-  height: auto;
-  display: block;
+  height: 44px;
+  display: flex;
+  align-items: center;
 }
 
 .ml-slider.interior-slider [role="slider"] {
@@ -353,7 +381,8 @@ a,
 }
 
 .interior-theme-select {
-  display: inline-block;
+  width: 100%;
+  display: block;
   border: 0;
   padding: 0;
   background: transparent;
@@ -370,8 +399,8 @@ a,
 }
 
 .interior-theme-select > div {
-  inset-inline: auto 0;
-  min-width: 180px;
+  inset-inline: auto;
+  min-width: 0;
 }
 
 /* Catalog filtering and cards */
@@ -557,21 +586,65 @@ a,
 }
 
 .interior-output-tabs {
-  border-color: var(--interior-line);
-  border-radius: 12px;
-  background: var(--interior-panel);
-  box-shadow: var(--interior-shadow);
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
-.interior-output-tabs > [role="tablist"] {
-  min-height: 48px;
-  border-color: var(--interior-line);
+.interior-output-tabs > .interior-tabs-toolbar {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.interior-output-tabs > .interior-tabs-toolbar > [role="tablist"] {
+  width: fit-content;
+  min-height: 44px;
+  flex: 0 0 auto;
+  gap: 3px;
+  border: 0;
+  border-radius: 8px;
+  padding: 3px;
   background: var(--interior-well);
+}
+
+.interior-output-tabs .interior-tabs-action {
+  min-width: 0;
+  flex: 0 0 auto;
+}
+
+.interior-output-tabs .interior-tabs-action .ml-button {
+  min-height: 44px;
+  border: 0;
+  border-radius: var(--ui-radius-cta);
+  padding-inline: 16px;
+  color: var(--apple-action-fg);
+  background: var(--apple-action-bg);
+  white-space: nowrap;
+}
+
+.interior-output-tabs .interior-tabs-action .ml-button:hover {
+  background: var(--apple-action-hover);
 }
 
 .interior-output-tabs [role="tab"] {
   min-height: 44px;
+  border: 0;
+  border-radius: 6px;
+  padding-inline: 14px;
   font-size: 13px;
+}
+
+.interior-output-tabs [role="tab"][aria-selected="true"] {
+  border: 0;
+  border-radius: 6px;
+  background: var(--interior-panel);
+  box-shadow: 0 1px 2px rgba(28, 25, 23, 0.12);
 }
 
 .interior-tab-label {
@@ -582,6 +655,24 @@ a,
 
 .interior-output-panel {
   min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--interior-line);
+  border-radius: 12px;
+  background: var(--interior-panel);
+}
+
+@media (max-width: 520px) {
+  .interior-output-tabs > .interior-tabs-toolbar {
+    gap: 8px;
+  }
+
+  .interior-output-tabs [role="tab"] {
+    padding-inline: 10px;
+  }
+
+  .interior-output-tabs .interior-tabs-action .ml-button {
+    padding-inline: 12px;
+  }
 }
 
 .apple-code-output .library-code-status {
@@ -655,7 +746,6 @@ a,
     width: 100%;
   }
 
-  .apple-hero-finder > div,
   .apple-search-pill .finder-search-field {
     grid-template-columns: minmax(0, 1fr);
   }
@@ -680,7 +770,6 @@ a,
     height: 16px;
   }
 
-  .apple-hero-finder > div > .ml-button,
   .apple-search-pill .finder-search-field > .ml-button {
     width: 100%;
   }

--- a/src/interior-theme.css
+++ b/src/interior-theme.css
@@ -633,6 +633,7 @@ a,
 }
 
 .interior-output-tabs [role="tab"] {
+  min-width: 44px;
   min-height: 44px;
   border: 0;
   border-radius: 6px;

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -110,7 +110,7 @@ test("catalog announces localized result changes for category, surface, and sear
 
   const categoryTrigger = page.locator(".library-category-filter-options").getByRole("button");
   await categoryTrigger.click();
-  const categoryOptions = page.getByRole("listbox", { name: "全部条目" }).getByRole("option");
+  const categoryOptions = page.getByRole("listbox", { name: "分类" }).getByRole("option");
   expect(await categoryOptions.count()).toBeGreaterThan(1);
   const categoryName = (await categoryOptions.nth(1).locator(".truncate").innerText()).trim();
   await categoryOptions.nth(1).click();

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -4,13 +4,22 @@ test("desktop landing page renders without horizontal overflow", async ({ page }
   await page.goto("/zh/");
   await expect(page).toHaveTitle(/Motion Lexicon/);
   await expect(page.getByRole("heading", { name: /说出你要的感觉/ })).toBeVisible();
-  await expect(page.getByRole("button", { name: /开始描述动效/ })).toBeVisible();
+  await expect(page.getByRole("searchbox", { name: "描述你想要的动效" })).toBeVisible();
   await expect(page.locator(".library-card")).toHaveCount(3);
 
   const hasHorizontalOverflow = await page.evaluate(() => {
     return document.documentElement.scrollWidth > window.innerWidth;
   });
   expect(hasHorizontalOverflow).toBe(false);
+});
+
+test("landing Interior search submits directly to Finder", async ({ page }) => {
+  await page.goto("/zh/");
+  const search = page.getByRole("searchbox", { name: "描述你想要的动效" });
+  await search.fill("卡片切入后慢慢停下来");
+  await search.press("Enter");
+  await expect(page).toHaveURL(/\/zh\/finder\/\?q=/);
+  await expect(page).toHaveURL(/%E5%8D%A1%E7%89%87/);
 });
 
 test("english landing page renders english copy", async ({ page }) => {
@@ -54,6 +63,7 @@ test("recipe output opens on Prompt, exposes only Prompt and Code, and stays in 
   await expect(output.getByRole("tab")).toHaveCount(2);
   const promptTab = output.getByRole("tab", { name: "提示词", exact: true });
   const codeTab = output.getByRole("tab", { name: "代码", exact: true });
+  await expect(output.getByRole("button", { name: "复制提示词", exact: true })).toBeVisible();
   await expect(promptTab).toHaveAttribute(
     "aria-selected",
     "true"
@@ -72,6 +82,8 @@ test("recipe output opens on Prompt, exposes only Prompt and Code, and stays in 
   await promptTab.press("ArrowRight");
   await expect(codeTab).toHaveAttribute("aria-selected", "true");
   await expect(page).toHaveURL(/tab=code/);
+  await expect(output.getByRole("button", { name: "复制全部代码", exact: true })).toBeVisible();
+  await expect(output.locator(".library-code-bundle-toolbar")).toHaveCount(0);
   await expect(page.getByTestId("css-output")).toContainText("260ms");
   await expect(page.getByTestId("html-output")).toContainText('data-motion="slide-in"');
 
@@ -166,7 +178,7 @@ test("catalog category filters keep 44px touch targets", async ({ page }) => {
   expect(Math.min(...heights)).toBeGreaterThanOrEqual(44);
 
   await trigger.click();
-  const options = page.getByRole("listbox", { name: "全部条目" }).getByRole("option");
+  const options = page.getByRole("listbox", { name: "分类" }).getByRole("option");
   expect(await options.count()).toBeGreaterThan(1);
   await options.nth(1).click();
   await expect(page).toHaveURL(/category=/);
@@ -304,7 +316,7 @@ test("Apple product tokens control type, hierarchy, radii, and icon sizes", asyn
   await expect(cardIcon).toHaveCSS("height", "20px");
 
   await page.goto("/zh/entrances/slide-in/");
-  await expect(page.locator(".apple-recipe-primary-action .ml-button")).toHaveCSS(
+  await expect(page.locator(".interior-tabs-action .ml-button")).toHaveCSS(
     "border-radius",
     "999px"
   );

--- a/tests/e2e/design-system.spec.ts
+++ b/tests/e2e/design-system.spec.ts
@@ -309,8 +309,8 @@ test("dark Finder, Catalog, and recipe states render without overflow", async ({
 test("primary actions keep a neutral high-contrast treatment in both themes", async ({ page }, testInfo) => {
   test.skip(testInfo.project.name.includes("mobile"), "Theme action tokens only need one browser audit.");
 
-  await page.goto("/zh/");
-  const action = page.getByRole("button", { name: "开始描述动效", exact: true });
+  await page.goto("/zh/entrances/slide-in/");
+  const action = page.getByRole("button", { name: "复制提示词", exact: true }).first();
   await expect(action).toHaveCSS("background-color", "rgb(41, 41, 41)");
   await expect(action).toHaveCSS("color", "rgb(239, 238, 234)");
   await action.hover();
@@ -333,7 +333,7 @@ test("Interior product surfaces keep compact geometry and restrained elevation",
     {
       route: "/zh/",
       surfaces: [
-        { selector: ".apple-hero-finder > div", radius: "16px" },
+        { selector: ".apple-hero-finder .interior-hero-search > div", radius: "10px" },
         { selector: ".apple-hero-preview.library-hero-preview", radius: "16px" },
         { selector: ".apple-scene-card", radius: "16px" }
       ]
@@ -403,7 +403,7 @@ test("coarse-pointer product controls preserve 44 pixel targets", async ({ page 
     ".apple-code-output [role='tab']"
   ]) await expectMinimumTargets(page, selector);
   await page.getByRole("tab", { name: "代码" }).click();
-  await expectMinimumTargets(page, ".apple-code-output .library-code-filebar .ml-button");
+  await expectMinimumTargets(page, ".apple-code-output .interior-tabs-action .ml-button");
 
   await page.goto("/zh/sequencing/stagger/");
   for (const selector of [

--- a/tests/e2e/ui-polish.spec.ts
+++ b/tests/e2e/ui-polish.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "@playwright/test";
+
+test("recipe controls use stable components and compact geometry", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop geometry is covered once.");
+  await page.goto("/zh/entrances/slide-in/");
+
+  const mobileDevice = page.getByRole("radio", { name: "手机宽度" });
+  await mobileDevice.hover();
+  await expect(mobileDevice).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+
+  const heroSpacing = await page.evaluate(() => {
+    const breadcrumbs = document.querySelector(".apple-recipe-breadcrumbs")!.getBoundingClientRect();
+    const identity = document.querySelector(".apple-recipe-identity")!.getBoundingClientRect();
+    const hero = document.querySelector(".apple-recipe-hero")!;
+    return {
+      gap: identity.top - breadcrumbs.bottom,
+      minHeight: getComputedStyle(hero).minHeight
+    };
+  });
+  expect(heroSpacing.gap).toBeGreaterThanOrEqual(16);
+  expect(heroSpacing.gap).toBeLessThanOrEqual(40);
+  expect(heroSpacing.minHeight).toBe("0px");
+
+  const sliders = page.getByRole("slider");
+  await expect(sliders).toHaveCount(2);
+  const commonControls = page.locator(".library-parameter-panel > .controls");
+  await expect(commonControls.locator(".ml-slider-track")).toHaveCount(2);
+  await expect(commonControls.locator(".ml-slider-range")).toHaveCount(2);
+  await expect(commonControls.locator(".ml-slider-thumb")).toHaveCount(2);
+  await sliders.first().press("ArrowRight");
+  await expect(page).toHaveURL(/duration=260/);
+  await expect(page.getByTestId("prompt-output")).toContainText("260ms");
+
+  const toolbarInsets = await page.evaluate(() => {
+    const toolbar = document.querySelector(".apple-preview-toolbar.library-preview-toolbar")!.getBoundingClientRect();
+    const mode = document.querySelector(".interior-motion-mode")!.getBoundingClientRect();
+    const device = document.querySelector(".interior-device-switcher")!.getBoundingClientRect();
+    const selected = document.querySelector(".interior-motion-mode .interior-segment-thumb")!.getBoundingClientRect();
+    return {
+      height: toolbar.height,
+      top: mode.top - toolbar.top,
+      bottom: toolbar.bottom - mode.bottom,
+      controlHeightDelta: Math.abs(device.height - mode.height),
+      selectedTop: selected.top - mode.top,
+      selectedBottom: mode.bottom - selected.bottom
+    };
+  });
+  expect(toolbarInsets.height).toBeLessThanOrEqual(54);
+  expect(Math.abs(toolbarInsets.top - toolbarInsets.bottom)).toBeLessThanOrEqual(1);
+  expect(Math.min(toolbarInsets.top, toolbarInsets.bottom)).toBeGreaterThanOrEqual(4);
+  expect(toolbarInsets.controlHeightDelta).toBeLessThanOrEqual(1);
+  expect(Math.min(toolbarInsets.selectedTop, toolbarInsets.selectedBottom)).toBeGreaterThanOrEqual(2);
+
+  const outputTabs = page.locator(".interior-output-tabs");
+  const promptTab = page.getByRole("tab", { name: "提示词" });
+  await expect(outputTabs).toHaveCSS("border-top-width", "0px");
+  await expect(outputTabs).toHaveCSS("box-shadow", "none");
+  await expect(promptTab).toHaveCSS("border-top-width", "0px");
+  await expect(outputTabs.getByRole("tablist")).toHaveCSS("border-radius", "8px");
+  await expect(outputTabs.locator(".interior-tabs-toolbar > .interior-tabs-action")).toContainText("复制提示词");
+
+  const related = page.locator(".apple-related-motion .library-related-links");
+  for (const side of ["top", "right", "bottom", "left"] as const) {
+    await expect(related).toHaveCSS(`border-${side}-width`, "0px");
+  }
+});
+
+test("dense recipe choices wrap inside the shared segmented control", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "The dense inspector layout is covered once.");
+  await page.goto("/zh/easing/easing/?duration=580&view=tablet");
+
+  const easing = page.getByRole("radiogroup", { name: "曲线" });
+  await expect(easing).toHaveAttribute("data-segmented-layout", "wrapped");
+  const geometry = await easing.evaluate((element) => ({
+    clientWidth: element.clientWidth,
+    scrollWidth: element.scrollWidth,
+    rows: new Set(
+      Array.from(element.querySelectorAll<HTMLElement>("[role='radio']"))
+        .map((button) => Math.round(button.getBoundingClientRect().top))
+    ).size
+  }));
+  expect(geometry.scrollWidth).toBeLessThanOrEqual(geometry.clientWidth);
+  expect(geometry.rows).toBeGreaterThan(1);
+
+  const easeIn = easing.getByRole("radio", { name: "缓入", exact: true });
+  await easeIn.click();
+  await expect(page).toHaveURL(/ease=ease-in/);
+  await expect(easeIn).toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+  await expect(easeIn.locator(".interior-segment-option")).toHaveCSS("color", "rgb(239, 238, 234)");
+});
+
+test("resource popover grows with its inline theme menu", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop popover has enough room for a geometry check.");
+  await page.goto("/zh/");
+  await page.locator(".library-utility-trigger").click();
+
+  const dialog = page.getByRole("dialog", { name: "资源与设置" });
+  const before = await dialog.evaluate((element) => element.getBoundingClientRect().height);
+  await page.locator(".library-utility-popover .interior-theme-select > button").click();
+  const listbox = page.getByRole("listbox", { name: "主题" });
+  await expect(listbox).toBeVisible();
+
+  const geometry = await dialog.evaluate((element) => {
+    const content = element.querySelector<HTMLElement>(":scope > div")!;
+    return {
+      height: element.getBoundingClientRect().height,
+      contentClientHeight: content.clientHeight,
+      contentScrollHeight: content.scrollHeight
+    };
+  });
+  expect(geometry.height).toBeGreaterThan(before + 80);
+  expect(geometry.contentScrollHeight).toBeLessThanOrEqual(geometry.contentClientHeight + 1);
+});
+
+test("landing uses one direct Interior search shell without horizontal overflow", async ({ page }) => {
+  await page.goto("/zh/");
+  await expect(page.locator(".apple-hero-finder > .interior-hero-search")).toHaveCount(1);
+  await expect(page.locator(".apple-hero-finder > div > .ml-button")).toHaveCount(0);
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth
+  );
+  expect(overflow).toBeLessThanOrEqual(0);
+});


### PR DESCRIPTION
## What changed

- simplify the homepage motion search and tighten recipe-page spacing
- standardize device, reduced-motion, parameter, and output segmented controls
- replace the custom slider with the accessible Radix primitive
- move contextual copy actions into the Prompt and Code toolbar
- fix nested resource menu sizing and remove redundant visual framing
- add focused UI polish regression coverage

## Why

This completes the reviewed interface refinements across the landing page and recipe workspaces, with shared controls that remain compact, readable, and consistent across Chinese and English layouts.

## Verification

- npm run lint
- npm run typecheck
- npm run test
- npm run i18n:check
- npm run vocabulary:check
- npm run seo:check
- npm run motion:check
- npm run a11y:check
- npm run artifacts:check
- npm run build
- npm run bundle:check
- npm run crawl:dist
- npm run test:visual