### PR TITLE
patch development dependency security alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2227,9 +2227,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4433,7 +4433,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -92,8 +92,9 @@
     "lightningcss-linux-x64-gnu": "1.32.0"
   },
   "overrides": {
-    "brace-expansion": "5.0.8",
-    "postcss": "8.5.23"
+    "brace-expansion": "5.0.9",
+    "postcss": "8.5.23",
+    "undici": "7.29.0"
   },
   "dependencies": {
     "@radix-ui/react-slider": "^1.4.7",


### PR DESCRIPTION
## Summary

Updates two development-only transitive dependencies to their patched releases.

## Changes

- Pin `undici` to 7.29.0.
- Update `brace-expansion` to 5.0.9.

## Validation

- `npm audit --audit-level=high` — 0 vulnerabilities
- Full local quality and browser suites pass.
