### PR TITLE
feat: deepen scenario guides and navigation

### DIFF
--- a/public/pricing.txt
+++ b/public/pricing.txt
@@ -20,4 +20,4 @@
 - Vocabulary and editorial content license: CC BY 4.0
 - Generated code snippets license: 0BSD
 - Usage: The public static website and Motion Director Skill are available without an account.
-- Last updated: 2026-08-03
+- Last updated: 2026-08-04

--- a/scripts/check-bundle.ts
+++ b/scripts/check-bundle.ts
@@ -22,10 +22,11 @@ const maxChunkRawBytes = 650 * 1024;
 const maxChunkGzipBytes = 160 * 1024;
 // V2.1 carries twenty-eight real product moments, editorial hubs for all
 // twelve primitive categories, and eight lazy-loaded scenario guides. The
-// Interior interaction system keeps Motion in its own vendor chunk; this
-// remains a hard ceiling for the expanded static editorial surface.
+// Interior interaction system keeps Motion in its own vendor chunk; scenario
+// articles are isolated in their own lazy chunk and retain their own ceiling.
 const maxMotionVendorGzipBytes = 48 * 1024;
-const maxTotalJsGzipBytes = 390 * 1024;
+const maxScenarioGuideArticlesGzipBytes = 70 * 1024;
+const maxTotalJsGzipBytes = 450 * 1024;
 const maxTotalCssGzipBytes = 48 * 1024;
 let totalJsGzipBytes = 0;
 
@@ -50,6 +51,13 @@ assert(motionVendorChunk, "Interior Motion vendor chunk is missing");
 assert(
   gzipSync(readFileSync(path.join(assetsDir, motionVendorChunk))).length <= maxMotionVendorGzipBytes,
   `Motion vendor chunk exceeds ${Math.round(maxMotionVendorGzipBytes / 1024)} KiB gzip`
+);
+
+const scenarioGuideArticlesChunk = jsFiles.find((file) => file.startsWith("seo-guide.lazy-"));
+assert(scenarioGuideArticlesChunk, "Scenario guide route chunk is missing");
+assert(
+  gzipSync(readFileSync(path.join(assetsDir, scenarioGuideArticlesChunk))).length <= maxScenarioGuideArticlesGzipBytes,
+  `Scenario guide article chunk exceeds ${Math.round(maxScenarioGuideArticlesGzipBytes / 1024)} KiB gzip`
 );
 
 const totalCssGzipBytes = cssFiles.reduce((total, file) => {

--- a/scripts/check-seo.ts
+++ b/scripts/check-seo.ts
@@ -145,7 +145,12 @@ assert(
   springArticle.caseStudy.code.includes('<section class="curve-demo">') &&
     springArticle.caseStudy.code.includes("<style>") &&
     springArticle.caseStudy.code.includes("<script>") &&
-    springArticle.caseStudy.code.includes("function springTo(element, from, target, releaseVelocity = 0)") &&
+    springArticle.caseStudy.code.includes("function springTo(element, from, target, releaseVelocity = 0, onUpdate = () => {})") &&
+    springArticle.caseStudy.code.includes("return cancel;") &&
+    springArticle.caseStudy.code.includes("onUpdate(position, velocity);") &&
+    springArticle.caseStudy.code.includes('drawerRange.addEventListener("pointerdown", () => {') &&
+    springArticle.caseStudy.code.includes('drawerRange.addEventListener("change", () => settleDrawer());') &&
+    !springArticle.caseStudy.code.includes("return () => finish();") &&
     springArticle.caseStudy.code.includes(".save-status { opacity: 0; transform: translateY(6px);") &&
     springArticle.caseStudy.code.includes('.save-status[data-state="saving"], .save-status[data-state="saved"]') &&
     !springArticle.caseStudy.code.includes("HTMLElement") &&

--- a/scripts/check-seo.ts
+++ b/scripts/check-seo.ts
@@ -2,6 +2,7 @@ import { categories } from "../src/data/categories";
 import { getCategorySeoHub } from "../src/data/category-seo";
 import { motionPacks } from "../src/data/motion-packs";
 import { release } from "../src/data/release";
+import { seoGuideArticles } from "../src/data/seo-guide-articles";
 import { seoGuides } from "../src/data/seo-guides";
 import {
   aliasMetadata,
@@ -32,7 +33,126 @@ assert(aliasMetadata.length === 47, `Expected 47 aliases, found ${aliasMetadata.
 assert(motionPacks.length === 28, `Expected 28 Motion Packs, found ${motionPacks.length}`);
 assert(release.version === "2.1.0", `Expected public release 2.1.0, found ${release.version}`);
 assert(seoGuides.length === 8, `Expected 8 scenario guides, found ${seoGuides.length}`);
+assert(seoGuideArticles.length === seoGuides.length, `Expected ${seoGuides.length} long-form scenario guides, found ${seoGuideArticles.length}`);
 assert(new Set(motionPacks.map((pack) => pack.id)).size === motionPacks.length, "Motion Packs contain duplicate IDs");
+assert(new Set(seoGuideArticles.map((article) => article.guideId)).size === seoGuideArticles.length, "Long-form scenario guides contain duplicate IDs");
+
+for (const guide of seoGuides) {
+  const article = seoGuideArticles.find((candidate) => candidate.guideId === guide.id);
+  assert(article, `${guide.id} is missing its long-form scenario article`);
+  assert(article.sections.length === 5, `${guide.id} must have five editorial sections`);
+  assert(article.diagrams.length === 3, `${guide.id} must have three editorial diagrams`);
+  assert(article.checklist.length === 5, `${guide.id} must have five checklist items`);
+  assert(article.caseStudy.code.trim().length > 80, `${guide.id} is missing a substantial implementation example`);
+
+  for (const locale of locales) {
+    const body = article.sections
+      .flatMap((section) => section.paragraphs)
+      .map((paragraph) => paragraph[locale])
+      .join(" ")
+      .trim();
+    const bodyLength = locale === "zh" ? Array.from(body).length : body.split(/\s+/).filter(Boolean).length;
+    const minimumLength = locale === "zh" ? 1000 : 700;
+    assert(bodyLength >= minimumLength, `${guide.id}.${locale} long-form body is too short (${bodyLength}/${minimumLength})`);
+  }
+
+  for (const diagram of article.diagrams) {
+    assert(diagram.nodes.length >= 2, `${guide.id}.${diagram.id} needs at least two diagram nodes`);
+    assert(diagram.title.zh.trim().length > 0 && diagram.title.en.trim().length > 0, `${guide.id}.${diagram.id} needs localized titles`);
+    assert(diagram.alt.zh.trim().length > 0 && diagram.alt.en.trim().length > 0, `${guide.id}.${diagram.id} needs localized alt text`);
+  }
+}
+
+const publishFeedbackArticle = seoGuideArticles.find((article) => article.guideId === "save-submit-publish-feedback");
+assert(publishFeedbackArticle, "Save and publish scenario article is missing");
+assert(
+  publishFeedbackArticle.caseStudy.code.includes(".publish-result { opacity: 0; visibility: hidden;") &&
+    publishFeedbackArticle.caseStudy.code.includes('[data-state="complete"] .publish-button { opacity: 0; visibility: hidden;') &&
+    publishFeedbackArticle.caseStudy.code.includes('[data-state="complete"] .publish-result { opacity: 1; visibility: visible;') &&
+    publishFeedbackArticle.caseStudy.code.includes('<section class="publish-action" data-state="ready">') &&
+    publishFeedbackArticle.caseStudy.code.includes('<script>') &&
+    publishFeedbackArticle.caseStudy.code.includes('if (action.dataset.state !== "ready") return;') &&
+    publishFeedbackArticle.caseStudy.code.includes("publishButton.disabled = true;") &&
+    publishFeedbackArticle.caseStudy.code.includes("data-publish-submissions") &&
+    publishFeedbackArticle.caseStudy.code.includes("await publishRequest();") &&
+    publishFeedbackArticle.caseStudy.code.includes("publishedLink.focus();"),
+  "Publish feedback example must execute independently and accept only one request while working"
+);
+
+const springArticle = seoGuideArticles.find((article) => article.guideId === "spring-or-ease-out");
+assert(springArticle, "Spring and ease-out scenario article is missing");
+assert(
+    springArticle.caseStudy.code.includes("releaseVelocity = 0") &&
+    springArticle.caseStudy.code.includes("let velocity = releaseVelocity;") &&
+    springArticle.caseStudy.code.includes('reducedMotionQuery.addEventListener("change", onReducedMotionChange);') &&
+    springArticle.caseStudy.code.includes('reducedMotionQuery.removeEventListener("change", onReducedMotionChange);'),
+  "Spring example must preserve release velocity and react immediately to reduced-motion changes"
+);
+
+const jankArticle = seoGuideArticles.find((article) => article.guideId === "css-motion-jank");
+assert(jankArticle, "CSS motion jank scenario article is missing");
+assert(
+  jankArticle.caseStudy.code.includes(".result-card { opacity: 1; transform: translateY(0); transition:") &&
+    jankArticle.caseStudy.code.includes('.result-card[data-motion="leave"]') &&
+    jankArticle.caseStudy.code.includes(".result-card { transition-duration: 1ms; }") &&
+    !jankArticle.caseStudy.code.includes('.result-card[data-motion="ready"] {\n  transition:') &&
+    jankArticle.caseStudy.code.includes('<section class="filter-demo">') &&
+    jankArticle.caseStudy.code.includes("<script>") &&
+    jankArticle.caseStudy.code.includes("window.cancelAnimationFrame(renderFrame);") &&
+    jankArticle.caseStudy.code.includes("window.clearTimeout(leaveTimer);") &&
+    !jankArticle.caseStudy.code.includes("cancelPendingCardTransitions") &&
+    !jankArticle.caseStudy.code.includes("query: string"),
+  "Filter-card example must run independently and cancel stale visual work"
+);
+
+const continuityArticle = seoGuideArticles.find((article) => article.guideId === "card-list-filter-continuity");
+assert(continuityArticle, "Filter continuity scenario article is missing");
+assert(
+  continuityArticle.caseStudy.code.includes(".result-empty { min-height: 160px; opacity: 0; visibility: hidden;") &&
+    continuityArticle.caseStudy.code.includes('.result-list[data-empty="true"] + .result-empty { opacity: 1; visibility: visible; }'),
+  "Hidden filter empty states must leave the focus order"
+);
+
+const reducedMotionArticle = seoGuideArticles.find((article) => article.guideId === "reduced-motion");
+assert(reducedMotionArticle, "Reduced-motion scenario article is missing");
+assert(
+  reducedMotionArticle.caseStudy.code.includes("@keyframes settle-in") &&
+    reducedMotionArticle.caseStudy.code.includes("to { opacity: 1; transform: scale(1); }") &&
+    reducedMotionArticle.caseStudy.code.includes("[data-save-state] { transition: transform 120ms ease, opacity 160ms ease; }"),
+  "Reduced-motion save feedback example must define its settle-in keyframes and keep its transition on the stable state selector"
+);
+
+const deletionArticle = seoGuideArticles.find((article) => article.guideId === "form-validation-delete-permission");
+assert(deletionArticle, "High-risk interaction scenario article is missing");
+assert(
+  deletionArticle.caseStudy.code.includes('<script>') &&
+    deletionArticle.caseStudy.code.includes('row.addEventListener("transitionend", onLeaveEnd);') &&
+    deletionArticle.caseStudy.code.includes('event.target !== row || event.propertyName !== "opacity"') &&
+    deletionArticle.caseStudy.code.includes('row.removeEventListener("transitionend", onLeaveEnd)') &&
+    deletionArticle.caseStudy.code.includes("window.setTimeout(finishRemoval, 220);") &&
+    deletionArticle.caseStudy.code.includes("row.remove();") &&
+    deletionArticle.caseStudy.code.includes("await restoreProject(projectId);") &&
+    deletionArticle.caseStudy.code.includes("undoButton.disabled = false;") &&
+    deletionArticle.caseStudy.code.includes('role="status" aria-live="polite"') &&
+    deletionArticle.caseStudy.code.includes("undoButton.focus();") &&
+    deletionArticle.caseStudy.code.includes("deleteButton.focus();") &&
+    deletionArticle.caseStudy.code.includes('window.matchMedia("(prefers-reduced-motion: reduce)")') &&
+    deletionArticle.caseStudy.code.includes("} catch {"),
+  "Deletion example must handle exit cleanup, focus recovery, reduced motion, and failure accessibly"
+);
+
+assert(
+  springArticle.caseStudy.code.includes('<section class="curve-demo">') &&
+    springArticle.caseStudy.code.includes("<style>") &&
+    springArticle.caseStudy.code.includes("<script>") &&
+    springArticle.caseStudy.code.includes("function springTo(element, from, target, releaseVelocity = 0)") &&
+    springArticle.caseStudy.code.includes(".save-status { opacity: 0; transform: translateY(6px);") &&
+    springArticle.caseStudy.code.includes('.save-status[data-state="saving"], .save-status[data-state="saved"]') &&
+    !springArticle.caseStudy.code.includes("HTMLElement") &&
+    !springArticle.caseStudy.code.includes("MediaQueryListEvent") &&
+    !springArticle.caseStudy.code.includes("export function"),
+  "Spring and ease-out example must be a self-contained browser runtime with visible save-state motion"
+);
 
 const canonicalIds = new Set(canonicalMotionCatalog.map((item) => item.id));
 assert(canonicalIds.size === canonicalMotionCatalog.length, "Canonical catalog contains duplicate IDs");

--- a/scripts/crawl-dist.ts
+++ b/scripts/crawl-dist.ts
@@ -4,6 +4,7 @@ import { categories } from "../src/data/categories";
 import { glossaryTerms } from "../src/data/glossary";
 import { canonicalMotionCatalog } from "../src/data/motion-catalog";
 import { motionPacks } from "../src/data/motion-packs";
+import { seoGuideArticles } from "../src/data/seo-guide-articles";
 import { seoGuides } from "../src/data/seo-guides";
 import {
   defaultLocale,
@@ -36,6 +37,11 @@ function attributes(tag: string) {
 
 function htmlTags(html: string, name: string) {
   return Array.from(html.matchAll(new RegExp(`<${name}\\b[^>]*>`, "g")), (match) => match[0]);
+}
+
+function documentHeadTags(html: string, name: string) {
+  const head = html.match(/<head\b[^>]*>([\s\S]*?)<\/head>/i)?.[1] ?? "";
+  return htmlTags(head, name);
 }
 
 function listFiles(directory: string): string[] {
@@ -242,12 +248,36 @@ for (const routePath of sitemapRoutePaths) {
     if (routeParts[0] === "guides") {
       const guide = seoGuides.find((candidate) => candidate.id === routeParts[1]);
       if (guide) {
+        const longArticle = seoGuideArticles.find((candidate) => candidate.guideId === guide.id);
         const article = parsedSchemas.find((schema) => schema["@type"] === "TechArticle");
         const howTo = parsedSchemas.find((schema) => schema["@type"] === "HowTo");
         assert(article, `${routePath} is missing scenario guide TechArticle schema`);
         assert(howTo, `${routePath} is missing scenario guide HowTo schema`);
+        assert(longArticle, `${routePath} is missing its long-form source article`);
+        const body = longArticle.sections
+          .flatMap((section) => section.paragraphs)
+          .map((paragraph) => paragraph[locale])
+          .join(" ")
+          .trim();
+        const expectedWordCount = locale === "zh" ? Array.from(body).length : body.split(/\s+/).filter(Boolean).length;
+        assert(article.wordCount === expectedWordCount, `${routePath} TechArticle wordCount is inconsistent`);
+        assert(
+          (html.match(/<figure class="seo-guide-diagram"/g) ?? []).length === 3,
+          `${routePath} must prerender three scenario diagrams`
+        );
+        assert(html.includes("<pre><code>"), `${routePath} must prerender a scenario implementation example`);
       }
     }
+  }
+
+  if (routeParts.length === 0) {
+    const activeHomeLink = html.match(/<a\b[^>]*class="[^"]*library-primary-link[^"]*is-home[^"]*is-active[^"]*"[^>]*>/);
+    assert(
+      activeHomeLink?.[0].includes('aria-current="page"'),
+      `${routePath} home navigation is missing its active state`
+    );
+    assert(html.includes("/guides/"), `${routePath} home page is missing its scenario guide entry`);
+    assert(!html.includes("seo-guide.lazy-"), `${routePath} eagerly loads the long-form scenario guide route`);
   }
 
   if (routeParts.length === 1 && routeParts[0] === "finder") {
@@ -261,7 +291,7 @@ for (const routePath of sitemapRoutePaths) {
 
   assert(/<div id="root">[\s\S]+<\/div>/.test(html), `${routePath} is missing prerendered application HTML`);
   assert(htmlTags(html, "h1").length === 1, `${routePath} must contain exactly one H1`);
-  assert(htmlTags(html, "title").length === 1, `${routePath} must contain exactly one title`);
+  assert(documentHeadTags(html, "title").length === 1, `${routePath} must contain exactly one document title`);
   assert(
     !/>\s*(?:common|nav|landing|catalog|workspace|footer|seo)\.[a-z0-9_.-]+\s*</i.test(html),
     `${routePath} contains an unresolved translation key`
@@ -297,7 +327,7 @@ for (const routePath of noindexStaticPaths) {
     `${routePath} is outside the sitemap and must carry noindex metadata`
   );
   assert(htmlTags(html, "h1").length === 1, `${routePath} must have exactly one H1`);
-  assert(htmlTags(html, "title").length === 1, `${routePath} must have exactly one title`);
+  assert(documentHeadTags(html, "title").length === 1, `${routePath} must have exactly one document title`);
 }
 
 for (const locale of locales) {

--- a/src/apple-redesign.css
+++ b/src/apple-redesign.css
@@ -759,8 +759,40 @@ summary {
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.05);
 }
 
+/* The five English labels need the same breathing room as the action cluster. */
+@media (max-width: 1280px) {
+  .library-header-compact .library-primary-nav {
+    display: none;
+  }
+}
+
 .library-header-compact .library-header-actions {
   gap: 0.35rem;
+}
+
+.library-header-compact .library-director-link {
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: var(--ui-radius-nav);
+  padding: 0 0.65rem;
+  color: var(--apple-secondary);
+  font-size: var(--type-xs);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.library-header-compact .library-director-link:hover,
+.library-header-compact .library-director-link.is-active {
+  color: var(--apple-ink);
+  background: color-mix(in srgb, var(--apple-ink) 6%, transparent);
+}
+
+@media (max-width: 1280px) {
+  .library-header-compact .library-director-link {
+    display: none;
+  }
 }
 
 .library-header-compact .library-github-link,
@@ -1734,6 +1766,15 @@ summary {
   line-height: 1.7;
 }
 
+.seo-guide-page > header .seo-guide-standfirst {
+  max-width: 68ch;
+  border-left: 2px solid var(--apple-ink);
+  margin-top: 8px;
+  padding-left: 14px;
+  color: var(--apple-ink);
+  font-weight: 500;
+}
+
 .seo-guide-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1756,6 +1797,12 @@ summary {
   color: var(--apple-tertiary);
   font-family: var(--mono);
   font-size: 10px;
+}
+
+.seo-guide-grid article > small {
+  color: var(--apple-tertiary);
+  font-size: var(--type-xs);
+  line-height: 1.45;
 }
 
 .seo-guide-grid h2,
@@ -1870,6 +1917,223 @@ summary {
   font-weight: 600;
 }
 
+.seo-guide-article {
+  display: grid;
+  gap: 34px;
+  margin-top: 34px;
+}
+
+.seo-guide-article > section {
+  display: grid;
+  gap: 14px;
+  padding-top: 28px;
+  border-top: 1px solid var(--apple-line);
+}
+
+.seo-guide-article h2 {
+  font-size: var(--type-title);
+  letter-spacing: -0.025em;
+  line-height: 1.24;
+}
+
+.seo-guide-article p {
+  max-width: 68ch;
+  font-size: var(--type-md);
+  line-height: 1.82;
+}
+
+.seo-guide-article-copy {
+  display: grid;
+  gap: 12px;
+}
+
+.seo-guide-checklist,
+.seo-guide-case-study {
+  display: grid;
+  gap: 12px;
+  min-width: 0;
+  border: 1px solid var(--apple-line);
+  border-radius: var(--ui-radius-card);
+  padding: 18px;
+  background: var(--apple-surface);
+}
+
+.seo-guide-checklist > header,
+.seo-guide-case-study > header {
+  display: grid;
+  gap: 5px;
+}
+
+.seo-guide-checklist h2,
+.seo-guide-case-study h2 {
+  font-size: var(--type-md);
+  letter-spacing: var(--tracking-ui);
+}
+
+.seo-guide-checklist header p,
+.seo-guide-case-study header p {
+  font-size: var(--type-sm);
+  line-height: 1.65;
+}
+
+.seo-guide-checklist ul {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.seo-guide-checklist li {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  gap: 8px;
+  color: var(--apple-secondary);
+  font-size: var(--type-sm);
+  line-height: 1.6;
+}
+
+.seo-guide-checklist li > span {
+  display: grid;
+  gap: 3px;
+}
+
+.seo-guide-checklist li strong {
+  color: var(--apple-ink);
+  font-weight: 600;
+}
+
+.seo-guide-checklist li small {
+  color: var(--apple-secondary);
+  font-size: var(--type-xs);
+  line-height: 1.55;
+}
+
+.seo-guide-checklist li::before {
+  width: 15px;
+  height: 15px;
+  box-sizing: border-box;
+  border: 1.5px solid var(--apple-ink);
+  border-radius: 50%;
+  content: "";
+}
+
+.seo-guide-case-study pre {
+  box-sizing: border-box;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  border-radius: var(--ui-radius-nav);
+  margin: 0;
+  padding: 14px;
+  color: var(--apple-ink);
+  background: var(--apple-surface-soft);
+  font: 12px/1.65 var(--mono);
+  tab-size: 2;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.seo-guide-diagram {
+  display: grid;
+  overflow: hidden;
+  border: 1px solid var(--apple-line);
+  border-radius: var(--ui-radius-card);
+  margin: 4px 0 2px;
+  background: var(--apple-surface);
+}
+
+.seo-guide-diagram svg {
+  width: 100%;
+  height: auto;
+  padding: 16px;
+  background:
+    linear-gradient(var(--apple-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--apple-line) 1px, transparent 1px),
+    var(--apple-surface-soft);
+  background-size: 30px 30px;
+}
+
+.seo-guide-diagram-mobile {
+  display: none;
+}
+
+.seo-guide-diagram-arrow {
+  fill: var(--apple-secondary);
+}
+
+.seo-guide-diagram-connector {
+  fill: none;
+  stroke: var(--apple-secondary);
+  stroke-width: 3;
+  stroke-linecap: round;
+}
+
+.seo-guide-diagram-connector-label {
+  fill: var(--apple-secondary);
+  font: 500 18px var(--sans);
+}
+
+.seo-guide-diagram-node rect {
+  fill: var(--apple-surface);
+  stroke: var(--apple-line-strong);
+  stroke-width: 2;
+}
+
+.seo-guide-diagram-node.is-ink rect {
+  fill: var(--apple-ink);
+  stroke: var(--apple-ink);
+}
+
+.seo-guide-diagram-node.is-accent rect {
+  fill: color-mix(in srgb, var(--ml-focus) 12%, var(--apple-surface));
+  stroke: var(--ml-focus);
+}
+
+.seo-guide-diagram-node.is-success rect {
+  fill: color-mix(in srgb, var(--ml-success) 13%, var(--apple-surface));
+  stroke: var(--ml-success);
+}
+
+.seo-guide-diagram-node.is-warning rect {
+  fill: color-mix(in srgb, var(--ml-warning) 13%, var(--apple-surface));
+  stroke: var(--ml-warning);
+}
+
+.seo-guide-diagram-node-label {
+  fill: var(--apple-ink);
+  font: 600 25px var(--sans);
+}
+
+.seo-guide-diagram-node-detail {
+  fill: var(--apple-secondary);
+  font: 400 18px var(--sans);
+}
+
+.seo-guide-diagram-node.is-ink :is(.seo-guide-diagram-node-label, .seo-guide-diagram-node-detail) {
+  fill: var(--apple-surface);
+}
+
+.seo-guide-diagram figcaption {
+  display: grid;
+  gap: 5px;
+  border-top: 1px solid var(--apple-line);
+  padding: 14px 16px 15px;
+}
+
+.seo-guide-diagram figcaption strong {
+  color: var(--apple-ink);
+  font-size: var(--type-sm);
+  font-weight: 600;
+}
+
+.seo-guide-diagram figcaption span {
+  color: var(--apple-secondary);
+  font-size: var(--type-xs);
+  line-height: 1.6;
+}
+
 .seo-guide-links > div,
 .seo-guide-related > div {
   display: grid;
@@ -1964,6 +2228,105 @@ summary {
   .seo-guide-related > div,
   .method-page > section > div:not(.method-actions) {
     grid-template-columns: minmax(0, 1fr);
+  }
+
+  .seo-guide-diagram svg {
+    display: none;
+  }
+
+  .seo-guide-diagram-mobile {
+    display: grid;
+    gap: 10px;
+    padding: 12px;
+    background:
+      linear-gradient(var(--apple-line) 1px, transparent 1px),
+      linear-gradient(90deg, var(--apple-line) 1px, transparent 1px),
+      var(--apple-surface-soft);
+    background-size: 24px 24px;
+  }
+
+  .seo-guide-diagram-mobile-nodes {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 8px;
+  }
+
+  .seo-guide-diagram-mobile-node {
+    min-width: 0;
+    display: grid;
+    gap: 4px;
+    border: 1px solid var(--apple-line-strong);
+    border-radius: var(--ui-radius-nav);
+    padding: 11px;
+    background: var(--apple-surface);
+  }
+
+  .seo-guide-diagram-mobile-node.is-ink {
+    border-color: var(--apple-ink);
+    color: var(--apple-surface);
+    background: var(--apple-ink);
+  }
+
+  .seo-guide-diagram-mobile-node.is-accent {
+    border-color: var(--ml-focus);
+    background: color-mix(in srgb, var(--ml-focus) 12%, var(--apple-surface));
+  }
+
+  .seo-guide-diagram-mobile-node.is-success {
+    border-color: var(--ml-success);
+    background: color-mix(in srgb, var(--ml-success) 13%, var(--apple-surface));
+  }
+
+  .seo-guide-diagram-mobile-node.is-warning {
+    border-color: var(--ml-warning);
+    background: color-mix(in srgb, var(--ml-warning) 13%, var(--apple-surface));
+  }
+
+  .seo-guide-diagram-mobile-node strong {
+    color: currentColor;
+    font-size: var(--type-sm);
+    font-weight: 650;
+    line-height: 1.35;
+    overflow-wrap: anywhere;
+  }
+
+  .seo-guide-diagram-mobile-node span {
+    color: var(--apple-secondary);
+    font-size: var(--type-xs);
+    line-height: 1.5;
+    overflow-wrap: anywhere;
+  }
+
+  .seo-guide-diagram-mobile-node.is-ink span {
+    color: color-mix(in srgb, var(--apple-surface) 76%, transparent);
+  }
+
+  .seo-guide-diagram-mobile-flow {
+    display: grid;
+    gap: 5px;
+  }
+
+  .seo-guide-diagram-mobile-flow span {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 5px;
+    min-width: 0;
+    border-top: 1px solid var(--apple-line);
+    padding-top: 8px;
+    color: var(--apple-secondary);
+    font-size: var(--type-xs);
+    line-height: 1.45;
+  }
+
+  .seo-guide-diagram-mobile-flow i {
+    color: var(--apple-ink);
+    font-style: normal;
+  }
+
+  .seo-guide-diagram-mobile-flow small {
+    color: var(--apple-tertiary);
+    font-size: inherit;
   }
 }
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -29,20 +29,22 @@ export function Header({ locale }: HeaderProps) {
   const { t } = useTranslation();
   const location = useLocation();
   const [resourcesOpen, setResourcesOpen] = useState(false);
-  const pathSegments = location.pathname.split("/").filter(Boolean);
-  const isCatalog = /\/catalog\/?$/.test(location.pathname);
+  const routeSegment = location.pathname.split("/")[2];
+  const isHomeRoute = /^\/(?:zh|en)\/$/.test(location.pathname);
   const isPacksRoute = /\/packs(?:\/|$)/.test(location.pathname);
   const isFinderRoute = /\/finder\/?$/.test(location.pathname);
+  const isGuidesRoute = /\/guides(?:\/|$)/.test(location.pathname);
+  const isMethodRoute = /\/method\/?$/.test(location.pathname);
   const isVocabulary = /\/vocabulary\/?$/.test(location.pathname);
   const isDirectorRoute = /\/(?:director|lab\/motion-blueprints)\/?$/.test(location.pathname);
-  const routeSegment = pathSegments[1];
-  const isPrimitivesRoute = isCatalog
-    || isVocabulary
-    || (pathSegments.length > 1 && !["finder", "guides", "method", "packs", "director", "lab"].includes(routeSegment ?? ""));
+  const isPrimitivesRoute = /\/catalog\/?$/.test(location.pathname)
+    || !["", "finder", "guides", "method", "packs", "director", "lab", "vocabulary"].includes(routeSegment ?? "");
   const finderLabel = locale === "zh" ? "找动效" : "Find motion";
+  const homeLabel = locale === "zh" ? "首页" : "Home";
   const packsLabel = locale === "zh" ? "产品瞬间" : "Product moments";
   const primitivesLabel = locale === "zh" ? "动效基础" : "Motion primitives";
-  const directorLabel = locale === "zh" ? "Motion Director" : "Motion Director";
+  const guidesLabel = locale === "zh" ? "场景指南" : "Scenario guides";
+  const directorLabel = "Motion Director";
   const resourcesLabel = locale === "zh" ? "资源与设置" : "Resources and settings";
   const settingsLabel = locale === "zh" ? "显示设置" : "Display settings";
   const vocabularyLabel = locale === "zh" ? "动画词汇" : "Vocabulary";
@@ -54,12 +56,27 @@ export function Header({ locale }: HeaderProps) {
   return (
     <header className="library-header library-header-compact">
       <div className="library-header-inner">
-        <Link className="library-brand" to="/$locale/" params={{ locale }} aria-label={t("common.brand")}>
+        <Link
+          className="library-brand"
+          to="/$locale/"
+          params={{ locale }}
+          activeOptions={{ exact: true }}
+          aria-label={t("common.brand")}
+        >
           <BrandMark className="library-brand-mark" />
           <span>{t("common.brand")}</span>
         </Link>
 
         <nav className="library-primary-nav" aria-label={t("nav.primaryLabel")}>
+          <Link
+            to="/$locale/"
+            params={{ locale }}
+            activeOptions={{ exact: true }}
+            className={`library-primary-link is-home${isHomeRoute ? " is-active" : ""}`}
+            aria-current={isHomeRoute ? "page" : undefined}
+          >
+            {homeLabel}
+          </Link>
           <Link
             to="/$locale/finder/"
             params={{ locale }}
@@ -86,16 +103,25 @@ export function Header({ locale }: HeaderProps) {
             {primitivesLabel}
           </Link>
           <Link
-            to="/$locale/director/"
+            to="/$locale/guides/"
             params={{ locale }}
-            className={`library-primary-link is-director${isDirectorRoute ? " is-active" : ""}`}
-            aria-current={isDirectorRoute ? "page" : undefined}
+            className={`library-primary-link is-guides${isGuidesRoute ? " is-active" : ""}`}
+            aria-current={isGuidesRoute ? "page" : undefined}
           >
-            {directorLabel}
+            {guidesLabel}
           </Link>
         </nav>
 
         <div className="library-header-actions">
+          <Link
+            className={`library-director-link${isDirectorRoute ? " is-active" : ""}`}
+            to="/$locale/director/"
+            params={{ locale }}
+            aria-current={isDirectorRoute ? "page" : undefined}
+          >
+            <MotionDirectorGlyph aria-hidden="true" size={14} />
+            <span>{directorLabel}</span>
+          </Link>
           <a
             className="icon-link library-github-link"
             href={repositoryUrl}
@@ -124,14 +150,17 @@ export function Header({ locale }: HeaderProps) {
               )}
               >
               <nav aria-label={t("nav.mobileLabel")}>
-                <Link to="/$locale/finder/" params={{ locale }}>
+                <Link to="/$locale/" params={{ locale }} activeOptions={{ exact: true }} className={isHomeRoute ? "is-active" : undefined} aria-current={isHomeRoute ? "page" : undefined}>
+                  {homeLabel}
+                </Link>
+                <Link to="/$locale/finder/" params={{ locale }} className={isFinderRoute ? "is-active" : undefined} aria-current={isFinderRoute ? "page" : undefined}>
                   {finderLabel}
                 </Link>
-                <Link to="/$locale/director/" params={{ locale }} className={isDirectorRoute ? "is-active" : undefined}>
+                <Link to="/$locale/director/" params={{ locale }} className={isDirectorRoute ? "is-active" : undefined} aria-current={isDirectorRoute ? "page" : undefined}>
                   <MotionDirectorGlyph aria-hidden="true" size={16} />
                   <span>{directorLabel}</span>
                 </Link>
-                <Link to="/$locale/packs/" params={{ locale }} className={isPacksRoute ? "is-active" : undefined}>
+                <Link to="/$locale/packs/" params={{ locale }} className={isPacksRoute ? "is-active" : undefined} aria-current={isPacksRoute ? "page" : undefined}>
                   <ProductMomentGlyph aria-hidden="true" size={16} />
                   <span>{packsLabel}</span>
                 </Link>
@@ -140,6 +169,7 @@ export function Header({ locale }: HeaderProps) {
                   params={{ locale }}
                   search={{ surface: "components" }}
                   className={isPrimitivesRoute ? "is-active" : undefined}
+                  aria-current={isPrimitivesRoute ? "page" : undefined}
                 >
                   <MotionPrimitiveGlyph aria-hidden="true" size={16} />
                   <span>{primitivesLabel}</span>
@@ -148,15 +178,16 @@ export function Header({ locale }: HeaderProps) {
                   to="/$locale/vocabulary/"
                   params={{ locale }}
                   className={isVocabulary ? "is-active" : undefined}
+                  aria-current={isVocabulary ? "page" : undefined}
                 >
                   <MotionVocabularyGlyph aria-hidden="true" size={16} />
                   <span>{vocabularyLabel}</span>
                 </Link>
-                <Link to="/$locale/guides/" params={{ locale }}>
+                <Link to="/$locale/guides/" params={{ locale }} className={isGuidesRoute ? "is-active" : undefined} aria-current={isGuidesRoute ? "page" : undefined}>
                   <BookOpen aria-hidden="true" size={16} />
-                  <span>{locale === "zh" ? "场景指南" : "Scenario guides"}</span>
+                  <span>{guidesLabel}</span>
                 </Link>
-                <Link to="/$locale/method/" params={{ locale }}>
+                <Link to="/$locale/method/" params={{ locale }} className={isMethodRoute ? "is-active" : undefined} aria-current={isMethodRoute ? "page" : undefined}>
                   <BookOpen aria-hidden="true" size={16} />
                   <span>{locale === "zh" ? "方法与来源" : "Method and sources"}</span>
                 </Link>

--- a/src/components/SeoGuideDiagram.tsx
+++ b/src/components/SeoGuideDiagram.tsx
@@ -1,0 +1,172 @@
+import type { SeoGuideArticleDiagram } from "../data/seo-guide-articles-b";
+import type { Locale } from "../data/types";
+
+function textLength(value: string, locale: Locale) {
+  if (locale === "en") return value.length;
+  return Array.from(value).reduce((total, character) => total + (/^[A-Za-z0-9._-]$/.test(character) ? 0.6 : 1), 0);
+}
+
+function splitLongToken(token: string, limit: number, locale: Locale) {
+  if (textLength(token, locale) <= limit) return [token];
+
+  const chunks: string[] = [];
+  let current = "";
+  for (const character of Array.from(token)) {
+    if (current && textLength(`${current}${character}`, locale) > limit) {
+      chunks.push(current);
+      current = character;
+    } else {
+      current += character;
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+function nodeTextLines(value: string, locale: Locale) {
+  const limit = locale === "zh" ? 8 : 13;
+  const tokens = locale === "zh"
+    ? value.match(/[A-Za-z0-9][A-Za-z0-9._-]*|[^\s]/g) ?? []
+    : value.split(/\s+/).filter(Boolean);
+  const words = tokens.flatMap((token) => splitLongToken(token, limit, locale));
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    const next = locale === "zh" ? `${current}${word}` : `${current}${current ? " " : ""}${word}`;
+    if (current && textLength(next, locale) > limit) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = next;
+    }
+  }
+
+  if (current) lines.push(current);
+  return lines;
+}
+
+function connectionPoint(
+  source: SeoGuideArticleDiagram["nodes"][number],
+  target: SeoGuideArticleDiagram["nodes"][number]
+) {
+  const sourceCenterX = source.x + source.width / 2;
+  const sourceCenterY = source.y + source.height / 2;
+  const targetCenterX = target.x + target.width / 2;
+  const targetCenterY = target.y + target.height / 2;
+  const horizontal = Math.abs(targetCenterX - sourceCenterX) >= Math.abs(targetCenterY - sourceCenterY);
+
+  if (horizontal) {
+    return {
+      x1: targetCenterX > sourceCenterX ? source.x + source.width : source.x,
+      y1: sourceCenterY,
+      x2: targetCenterX > sourceCenterX ? target.x : target.x + target.width,
+      y2: targetCenterY
+    };
+  }
+
+  return {
+    x1: sourceCenterX,
+    y1: targetCenterY > sourceCenterY ? source.y + source.height : source.y,
+    x2: targetCenterX,
+    y2: targetCenterY > sourceCenterY ? target.y : target.y + target.height
+  };
+}
+
+export function SeoGuideDiagram({ diagram, locale }: { diagram: SeoGuideArticleDiagram; locale: Locale }) {
+  const diagramId = `guide-diagram-${diagram.id}-${locale}`;
+  const nodesById = new Map(diagram.nodes.map((node) => [node.id, node]));
+
+  return (
+    <figure className="seo-guide-diagram">
+      <svg viewBox={diagram.viewBox} role="img" aria-labelledby={diagramId}>
+        <title id={diagramId}>{diagram.alt[locale]}</title>
+        <defs>
+          <marker id={`${diagramId}-arrow`} markerWidth="12" markerHeight="12" refX="9" refY="4.5" orient="auto" markerUnits="strokeWidth">
+            <path d="M0,0 L0,9 L10,4.5 z" className="seo-guide-diagram-arrow" />
+          </marker>
+        </defs>
+        {diagram.connectors.map((connector) => {
+          const source = nodesById.get(connector.from);
+          const target = nodesById.get(connector.to);
+          if (!source || !target) return null;
+          const line = connectionPoint(source, target);
+          const labelX = (line.x1 + line.x2) / 2;
+          const labelY = (line.y1 + line.y2) / 2;
+
+          return (
+            <g key={`${connector.from}-${connector.to}`}>
+              <path
+                className="seo-guide-diagram-connector"
+                d={`M ${line.x1} ${line.y1} L ${line.x2} ${line.y2}`}
+                markerEnd={`url(#${diagramId}-arrow)`}
+              />
+              {connector.label ? (
+                <text className="seo-guide-diagram-connector-label" x={labelX} y={labelY - 12} textAnchor="middle">
+                  {connector.label[locale]}
+                </text>
+              ) : null}
+            </g>
+          );
+        })}
+        {diagram.nodes.map((node) => {
+          const labelLines = nodeTextLines(node.label[locale], locale);
+          const detailLines = nodeTextLines(node.detail[locale], locale);
+          const availableHeight = Math.max(node.height - 22, 48);
+          const labelLineHeight = Math.max(
+            14,
+            Math.min(22, Math.floor(availableHeight / (labelLines.length + detailLines.length * 0.8)))
+          );
+          const detailLineHeight = Math.max(11, Math.round(labelLineHeight * 0.8));
+          const labelFontSize = Math.max(14, Math.round(labelLineHeight * 0.9));
+          const detailFontSize = Math.max(11, Math.round(detailLineHeight * 0.9));
+          const labelStart = 12 + labelFontSize;
+          const detailStart = labelStart + (labelLines.length - 1) * labelLineHeight + 6 + detailFontSize;
+
+          return (
+            <g className={`seo-guide-diagram-node is-${node.tone}`} key={node.id} transform={`translate(${node.x} ${node.y})`}>
+              <rect width={node.width} height={node.height} rx="18" />
+              <text className="seo-guide-diagram-node-label" x="24" y={labelStart} style={{ fontSize: `${labelFontSize}px` }} aria-label={node.label[locale]}>
+                {labelLines.map((line, index) => <tspan key={`${line}-${index}`} x="24" dy={index === 0 ? 0 : labelLineHeight}>{line}</tspan>)}
+              </text>
+              <text className="seo-guide-diagram-node-detail" x="24" y={detailStart} style={{ fontSize: `${detailFontSize}px` }} aria-label={node.detail[locale]}>
+                {detailLines.map((line, index) => <tspan key={`${line}-${index}`} x="24" dy={index === 0 ? 0 : detailLineHeight}>{line}</tspan>)}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+      <div className="seo-guide-diagram-mobile" aria-hidden="true">
+        <div className="seo-guide-diagram-mobile-nodes">
+          {diagram.nodes.map((node) => (
+            <div className={`seo-guide-diagram-mobile-node is-${node.tone}`} key={node.id}>
+              <strong>{node.label[locale]}</strong>
+              <span>{node.detail[locale]}</span>
+            </div>
+          ))}
+        </div>
+        {diagram.connectors.length > 0 ? (
+          <div className="seo-guide-diagram-mobile-flow">
+            {diagram.connectors.map((connector) => {
+              const source = nodesById.get(connector.from);
+              const target = nodesById.get(connector.to);
+              if (!source || !target) return null;
+              return (
+                <span key={`${connector.from}-${connector.to}`}>
+                  {source.label[locale]}
+                  <i aria-hidden="true">→</i>
+                  {target.label[locale]}
+                  {connector.label ? <small>{connector.label[locale]}</small> : null}
+                </span>
+              );
+            })}
+          </div>
+        ) : null}
+      </div>
+      <figcaption>
+        <strong>{diagram.title[locale]}</strong>
+        <span>{diagram.alt[locale]}</span>
+      </figcaption>
+    </figure>
+  );
+}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -49,6 +49,7 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     const storedTheme = getStoredTheme();
     setThemeState(storedTheme);
     applyTheme(storedTheme);
+    document.documentElement.dataset.clientReady = "true";
     setHasMounted(true);
   }, []);
 

--- a/src/data/release.ts
+++ b/src/data/release.ts
@@ -6,6 +6,6 @@
 export const release = {
   version: "2.1.0",
   publishedAt: "2026-08-03T19:40:25.000Z",
-  updatedAt: "2026-08-03T19:40:25.000Z",
-  updatedDate: "2026-08-03"
+  updatedAt: "2026-08-04T04:12:00.000Z",
+  updatedDate: "2026-08-04"
 } as const;

--- a/src/data/seo-guide-articles-a.ts
+++ b/src/data/seo-guide-articles-a.ts
@@ -1,0 +1,470 @@
+import type { SeoGuideId } from "./seo-guide-ids";
+
+/**
+ * Long-form editorial source for scenario guides 01–04.
+ * The shape deliberately matches seo-guide-articles-b.ts so one renderer can
+ * render every guide. Diagram coordinates use a 960 × 540 canvas.
+ */
+export type SeoGuideArticleText = {
+  zh: string;
+  en: string;
+};
+
+export type SeoGuideArticleSection = {
+  id: string;
+  title: SeoGuideArticleText;
+  paragraphs: readonly [SeoGuideArticleText, SeoGuideArticleText, ...SeoGuideArticleText[]];
+};
+
+export type SeoGuideArticleChecklistItem = {
+  id: string;
+  label: SeoGuideArticleText;
+  detail: SeoGuideArticleText;
+};
+
+export type SeoGuideArticleCase = {
+  title: SeoGuideArticleText;
+  context: SeoGuideArticleText;
+  code: string;
+  explanation: SeoGuideArticleText;
+};
+
+export type SeoGuideArticleDiagramNode = {
+  id: string;
+  label: SeoGuideArticleText;
+  detail: SeoGuideArticleText;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  tone: "ink" | "accent" | "success" | "warning" | "surface";
+};
+
+export type SeoGuideArticleDiagramConnector = {
+  from: string;
+  to: string;
+  label?: SeoGuideArticleText;
+};
+
+export type SeoGuideArticleDiagram = {
+  id: string;
+  title: SeoGuideArticleText;
+  alt: SeoGuideArticleText;
+  viewBox: "0 0 960 540";
+  nodes: readonly SeoGuideArticleDiagramNode[];
+  connectors: readonly SeoGuideArticleDiagramConnector[];
+};
+
+export type SeoGuideLongArticle = {
+  guideId: Extract<
+    SeoGuideId,
+    | "save-submit-publish-feedback"
+    | "card-list-filter-continuity"
+    | "css-motion-jank"
+    | "spring-or-ease-out"
+  >;
+  standfirst: SeoGuideArticleText;
+  sections: readonly [
+    SeoGuideArticleSection,
+    SeoGuideArticleSection,
+    SeoGuideArticleSection,
+    SeoGuideArticleSection,
+    SeoGuideArticleSection
+  ];
+  checklistTitle: SeoGuideArticleText;
+  checklist: readonly [
+    SeoGuideArticleChecklistItem,
+    SeoGuideArticleChecklistItem,
+    SeoGuideArticleChecklistItem,
+    SeoGuideArticleChecklistItem,
+    SeoGuideArticleChecklistItem
+  ];
+  caseStudy: SeoGuideArticleCase;
+  diagrams: readonly [SeoGuideArticleDiagram, SeoGuideArticleDiagram, SeoGuideArticleDiagram];
+};
+
+const text = (zh: string, en: string): SeoGuideArticleText => ({ zh, en });
+
+const node = (
+  id: string,
+  zh: string,
+  en: string,
+  zhDetail: string,
+  enDetail: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  tone: SeoGuideArticleDiagramNode["tone"]
+): SeoGuideArticleDiagramNode => ({
+  id,
+  label: text(zh, en),
+  detail: text(zhDetail, enDetail),
+  x,
+  y,
+  width,
+  height,
+  tone
+});
+
+export const seoGuideArticlesA = [
+  {
+    guideId: "save-submit-publish-feedback",
+    standfirst: text(
+      "保存、提交和发布表面上都像一个按钮，实际承载着用户对结果、风险和等待的判断。完整反馈会让人清楚地知道：输入已经收到，系统正在处理，结果落在何处，出错时还能怎样继续。",
+      "Save, submit, and publish can look like one button, yet each carries a judgment about result, risk, and waiting. Complete feedback makes four things clear: input was received, the system is working, the result lands somewhere visible, and there is a path forward when work fails."
+    ),
+    sections: [
+      {
+        id: "waiting",
+        title: text("先分清三种等待", "Classify the three kinds of waiting"),
+        paragraphs: [
+          text(
+            "一次保存可能在 150ms 内完成，用户只需要知道按下已经被接收；一次提交可能需要校验和网络往返；发布、上传和支付则常常跨过数秒。三种等待的界面语言不同。瞬时操作适合短促的按下反馈和状态替换；短等待需要把按钮从“可点”转成“进行中”；长等待要给出进度、可离开页面的说明，或至少告诉用户结果会在何处出现。把所有操作都处理成旋转图标，会把这些差异抹平。",
+            "A save can finish in 150 ms, where acknowledgement is enough. A submit can include validation and a network round trip. Publish, upload, and payment often last several seconds. Each duration needs its own interface language. Instant work benefits from a brief press response and state swap; short waits need a button that clearly enters progress; long waits need progress, permission to leave, or a clear place where the result will appear. One generic spinner flattens important differences."
+          ),
+          text(
+            "动效时长应当跟着系统事实走。按钮的按压反馈可以在 80–140ms 内结束，让输入与画面贴在一起；真正开始请求后，再把文案切成“保存中”或“正在发布”。如果请求已经结束，成功状态不必额外停留太久，通常 600–1200ms 足够让人确认，然后让界面回到可继续工作的状态。等待的核心是节奏：用户需要一条连续、可追踪的因果链。",
+            "Motion duration should follow system facts. A button press can settle in 80–140 ms so input and response feel connected; when the request begins, switch the label to Saving or Publishing. Once work finishes, success usually needs only 600–1200 ms for confirmation before the interface returns to useful work. Waiting is a matter of rhythm: people need one continuous causal chain rather than a series of unrelated effects."
+          )
+        ]
+      },
+      {
+        id: "proximity",
+        title: text("让状态留在动作发生处", "Resolve the state where the action happened"),
+        paragraphs: [
+          text(
+            "用户点击“保存”后，最自然的视线仍停在编辑器底部、表单末尾或工具栏里。成功提示优先在这一带出现：按钮文案变为“已保存”、旁边出现简短的状态、字段边界回到稳定颜色。全局 Toast 适合补充信息，例如“所有更改已同步”，却不应承担唯一的确认职责。提示离得越远，用户越要在页面上重新寻找刚刚发生的事。",
+            "After someone clicks Save, attention remains near the editor footer, the end of a form, or the toolbar. Resolve success there first: change the button to Saved, add a short adjacent status, and return the field boundary to a settled color. A global toast can add context, such as All changes synced, yet should not be the only confirmation. The farther feedback sits from the action, the more people must search for what just happened."
+          ),
+          text(
+            "原位置反馈也让失败更容易理解。网络错误可以让按钮恢复可点，同时保留“重试”入口；字段校验可以把焦点带回具体输入，用户可直接在原处修正；发布失败则应保留草稿和失败原因。这里的连续性比华丽更重要：同一个对象从可用、进行中到结果的变化，能让用户看见系统在处理自己的请求。crossfade、轻微透明度变化和稳定的布局足以承载这一层意义。",
+            "In-place feedback also makes failure easier to understand. A network error can restore the button while keeping Retry nearby; field validation can return focus to the exact input instead of sending someone to the top of the page; a failed publish should retain the draft and expose the reason. Continuity matters more than spectacle: one object moving from available to working to resolved lets people see the system handling their request. A crossfade, slight opacity change, and stable layout are enough to carry that meaning."
+          )
+        ]
+      },
+      {
+        id: "failure",
+        title: text("把失败和重复操作纳入流程", "Include failure and duplicate actions in the flow"),
+        paragraphs: [
+          text(
+            "反馈流程从来不只有成功路径。用户可能连续点击、请求超时、权限在提交时变化，或者离线后恢复网络。每一种情况都需要一个可预期的界面落点。进行中的主按钮应禁用重复提交，旁边保留取消或返回的路径；超时不要无声地把按钮变回原样，应该说明请求是否仍在处理；权限变化要提示新状态，并避免用户误以为内容已经成功发布。把这些边缘状态列在设计稿里，开发时就更容易写出一致的状态机。",
+            "A feedback flow never has only a success path. People may click repeatedly, hit a timeout, lose permission during submission, or recover from offline work. Each case needs a predictable landing place in the UI. Disable duplicate submission on the primary action while keeping a path to cancel or return; do not silently restore a button after a timeout—explain whether work may still be running; surface a permission change so people do not assume content was published. Listing these edge states in the design makes a consistent state machine much easier to build."
+          ),
+          text(
+            "可撤销操作值得单独安排。删除、归档和取消邀请常常会先从列表中离开，再在原位置附近给出“撤销”。这个动作可以有一小段离开动效，却要保留稳定的占位或计数变化，避免列表突然塌陷让用户以为点错了别处。撤销窗口结束后再完成最终移除。这样既能给人回头的机会，也能让列表的空间关系保持清楚。",
+            "Reversible actions deserve their own treatment. Delete, archive, and cancel invite can leave a list first, then expose Undo near the original location. The exit can have a short motion, while a stable placeholder or count change prevents the list from collapsing so abruptly that people doubt what they clicked. Final removal happens after the undo window. This gives people a way back while keeping the list’s spatial relationship clear."
+          )
+        ]
+      },
+      {
+        id: "next-step",
+        title: text("发布后的页面也要接住用户", "Let the page receive the user after publish"),
+        paragraphs: [
+          text(
+            "发布结束后，界面常常只显示“成功”，然后把用户留在一个已经失去下一步的页面。更完整的设计会明确接下来能做什么：打开已发布页面、复制链接、继续编辑、查看审核状态，或回到内容列表。动效可以帮助把注意力从发布按钮带到下一步入口，例如让结果卡片在原区域出现，让复制链接按钮随后可见。动作顺序要短，目标要近，用户才能顺着流程走下去。",
+            "After publishing, interfaces often stop at Success and leave people on a page with no obvious next move. A complete design shows what follows: open the published page, copy the link, continue editing, check review status, or return to the content list. Motion can shift attention from the Publish button to that next action: reveal a result card in the same region, then make Copy link available. Keep the sequence short and the destination close so people can continue without reorienting."
+          ),
+          text(
+            "真实产品瞬间比单一原子动效更有价值，原因就在这里。一个“发布成功”瞬间往往包含按下反馈、按钮状态、进度、结果卡片和下一步入口；它们共享同一套节奏和层级。先用 Pack 看完整状态流，再回到 press feedback、crossfade 和 duration 调整局部细节，会比从零拼几个漂亮动画更可靠。动效在这里服务的是信任感：用户能看懂，也能继续行动。",
+            "This is why a real product moment is more useful than a lone atomic animation. A publish success moment often includes press feedback, button state, progress, a result card, and a next action; they share one rhythm and hierarchy. Start with a Pack to see the full state flow, then return to press feedback, crossfade, and duration to tune local details. That is more reliable than assembling a few attractive animations from scratch. Motion serves trust here: people can understand it and continue."
+          )
+        ]
+      },
+      {
+        id: "contract",
+        title: text("把反馈写成可验收的状态契约", "Write feedback as a testable state contract"),
+        paragraphs: [
+          text(
+            "每个流程都值得拥有一张状态表：idle、working、complete、failed、undoable 分别显示什么文字、哪些控件可用、焦点在哪里、是否允许离开页面。动效附着在状态转换上，而不替代状态本身。这样做能让产品、设计和开发讨论同一件事，也让测试能够检查成功、失败、重试和撤销是否真实成立。数据状态是事实，动画只是让事实更容易被看见。",
+            "Every flow benefits from a state table: what idle, working, complete, failed, and undoable show; which controls are available; where focus sits; and whether leaving the page is allowed. Motion attaches to state transitions rather than replacing state itself. This keeps product, design, and engineering discussing the same thing and lets tests check whether success, failure, retry, and undo truly work. Data state is the fact; animation simply makes the fact easier to see."
+          ),
+          text(
+            "这份契约也需要覆盖减弱动效。默认路径可以让按钮轻微缩放、结果卡片淡入；低动态路径保留同样的“保存中”“已保存”、同样的按钮禁用和同样的下一步入口，只缩短或取消装饰性位移。无论用户使用键盘、触屏，还是开启系统减少动效偏好，核心反馈链都应该完整。把这一点作为发布前检查，动效才会真正成为产品可靠性的一部分。",
+            "The contract also needs reduced motion. The default path can give a button slight scale and fade in a result card; the low-motion path keeps the same Saving and Saved copy, disabled button, and next action while shortening or removing decorative travel. Whether people use keyboard, touch, or a system reduced-motion preference, the core feedback chain should remain complete. Treat this as a pre-release check and motion becomes part of product reliability."
+          )
+        ]
+      }
+    ],
+    checklistTitle: text("保存、提交与发布验收清单", "Save, submit, and publish checklist"),
+    checklist: [
+      { id: "acknowledge", label: text("点击后立刻有输入已被接收的信号", "Acknowledge input immediately after click"), detail: text("按压、文案或状态色应在约 140ms 内发生变化。", "Press, copy, or state color changes within roughly 140 ms.") },
+      { id: "working", label: text("进行中状态阻止重复提交", "Working state prevents duplicate submission"), detail: text("保留必要的取消、返回或说明路径。", "Keep any necessary cancel, return, or explanatory path.") },
+      { id: "proximity", label: text("结果和失败靠近原动作", "Results and failures remain close to the action"), detail: text("按钮、局部状态和全局通知各自承担清楚职责。", "Button, local state, and global notice each carry a clear responsibility.") },
+      { id: "recovery", label: text("超时、失败和撤销都有明确落点", "Timeout, failure, and undo each have a clear landing place"), detail: text("草稿、错误原因和重试入口可被用户找到。", "Draft, error reason, and retry path remain findable.") },
+      { id: "next", label: text("完成后能继续下一步", "Completion leads to a next step"), detail: text("发布后提供打开、复制、继续编辑或返回列表等路径。", "After publish, offer open, copy, continue editing, or return-to-list paths.") }
+    ],
+    caseStudy: {
+      title: text("案例：文章发布在同一块界面内完成交接", "Case: article publishing hands off within one region"),
+      context: text("发布按钮先进入进行中状态，成功后替换为结果卡片和打开文章入口。", "The publish button first enters progress, then resolves into a result card with an Open article action."),
+      code: `<section class="publish-action" data-state="ready">
+  <button class="publish-button" type="button" data-publish aria-describedby="publish-status">Publish article</button>
+  <p id="publish-status" role="status" aria-live="polite" data-publish-status>Ready to publish.</p>
+  <p>Requests sent: <output data-publish-submissions>0</output></p>
+  <div class="publish-result" data-publish-result aria-hidden="true" inert>
+    <strong>Article published.</strong>
+    <a href="#published-article">Open published article</a>
+  </div>
+</section>
+
+<style>
+.publish-action { display: grid; gap: 12px; max-width: 28rem; }
+.publish-button, .publish-result { transition: opacity 180ms ease-out, transform 180ms ease-out; }
+.publish-result { opacity: 0; visibility: hidden; transform: translateY(6px); pointer-events: none; }
+.publish-action[data-state="working"] .publish-button { opacity: .72; cursor: progress; }
+.publish-action[data-state="complete"] .publish-button { opacity: 0; visibility: hidden; transform: scale(.98); pointer-events: none; }
+.publish-action[data-state="complete"] .publish-result { opacity: 1; visibility: visible; transform: translateY(0); pointer-events: auto; }
+@media (prefers-reduced-motion: reduce) {
+  .publish-button, .publish-result { transition-duration: 1ms; }
+}
+</style>
+
+<script>
+const action = document.querySelector(".publish-action");
+const publishButton = action.querySelector("[data-publish]");
+const status = action.querySelector("[data-publish-status]");
+const publishResult = action.querySelector("[data-publish-result]");
+const publishedLink = publishResult.querySelector("a");
+const requestCount = action.querySelector("[data-publish-submissions]");
+let submissions = 0;
+
+function publishRequest() {
+  return new Promise((resolve) => window.setTimeout(resolve, 160));
+}
+
+async function publishArticle() {
+  if (action.dataset.state !== "ready") return;
+
+  action.dataset.state = "working";
+  publishButton.disabled = true;
+  status.textContent = "Publishing article.";
+  submissions += 1;
+  requestCount.textContent = String(submissions);
+
+  try {
+    await publishRequest();
+    action.dataset.state = "complete";
+    publishResult.inert = false;
+    publishResult.setAttribute("aria-hidden", "false");
+    status.textContent = "Article published. You can open it now.";
+    publishedLink.focus();
+  } catch {
+    action.dataset.state = "ready";
+    publishButton.disabled = false;
+    status.textContent = "Publishing failed. Try again.";
+  }
+}
+
+publishButton.addEventListener("click", publishArticle);
+</script>`,
+      explanation: text("状态写在父元素的 data-state 上，按钮和结果卡片共享同一个事实，不需要依赖延时器猜测请求何时结束。结果出现前和旧按钮完成后都用 visibility 退出焦点顺序，完成状态只暴露可继续操作的结果；透明度和轻微位移负责交接，减弱动效偏好下立即完成交接。", "State lives on the parent data-state, so button and result card share one fact instead of using a timer to guess when the request ends. Visibility keeps both the pending result and the completed action out of the focus order, exposing only the next usable result; opacity and short travel handle the handoff, and reduced motion resolves it immediately.")
+    },
+    diagrams: [
+      {
+        id: "publish-state-flow",
+        title: text("图解一：一次发布的状态流", "Diagram 1: a publish state flow"),
+        alt: text("可发布、发布中、已发布和需要处理四个状态，其中发布中分别通向成功和失败。", "Ready, publishing, published, and needs-attention states, with publishing branching to success and failure."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("idle", "可发布", "Ready", "按钮可用，说明风险", "Action available with risk context", 50, 205, 175, 110, "surface"),
+          node("working", "发布中", "Publishing", "禁用重复提交，显示进度", "Prevent duplicates and show progress", 285, 205, 175, 110, "accent"),
+          node("success", "已发布", "Published", "展示链接与下一步", "Expose link and next action", 610, 95, 175, 110, "success"),
+          node("failure", "需要处理", "Needs attention", "保留草稿与重试入口", "Keep draft and retry path", 610, 335, 175, 110, "warning")
+        ],
+        connectors: [
+          { from: "idle", to: "working", label: text("点击", "Click") },
+          { from: "working", to: "success", label: text("请求完成", "Request resolves") },
+          { from: "working", to: "failure", label: text("请求失败", "Request fails") },
+          { from: "failure", to: "idle", label: text("修改或重试", "Edit or retry") }
+        ]
+      },
+      {
+        id: "feedback-proximity-map",
+        title: text("图解二：反馈离操作多近", "Diagram 2: feedback proximity"),
+        alt: text("发布按钮、同一区域的结果卡片和全局通知三层从近到远排列。", "Publish button, local result card, and global notice arranged from nearest to farthest."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("button", "按钮状态", "Button state", "第一确认层", "First confirmation layer", 80, 215, 200, 110, "ink"),
+          node("local", "结果卡片", "Result card", "链接、撤销、失败原因", "Link, undo, or failure reason", 380, 215, 200, 110, "accent"),
+          node("global", "全局通知", "Global notice", "同步、跨页面提示", "Sync or cross-page context", 680, 215, 200, 110, "surface")
+        ],
+        connectors: [
+          { from: "button", to: "local", label: text("同一视线", "Same line of sight") },
+          { from: "local", to: "global", label: text("补充上下文", "Add context") }
+        ]
+      },
+      {
+        id: "feedback-timeline",
+        title: text("图解三：从按下到结果的节奏", "Diagram 3: rhythm from press to result"),
+        alt: text("时间线从按下、输入已接收、请求期间到完成后的下一步。", "A timeline from press and acknowledgement through request duration to the next action after completion."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("zero", "0ms", "0 ms", "按下", "Pressed", 45, 205, 170, 110, "ink"),
+          node("ack", "120ms", "120 ms", "输入已接收", "Input acknowledged", 265, 205, 170, 110, "accent"),
+          node("wait", "请求期间", "During request", "发布中或进度", "Publishing or progress", 485, 205, 170, 110, "surface"),
+          node("settle", "完成后 800ms", "800 ms after result", "结果与下一步", "Result and next action", 705, 205, 170, 110, "success")
+        ],
+        connectors: [
+          { from: "zero", to: "ack" },
+          { from: "ack", to: "wait" },
+          { from: "wait", to: "settle" }
+        ]
+      }
+    ]
+  },
+  {
+    guideId: "card-list-filter-continuity",
+    standfirst: text(
+      "卡片、列表和筛选里的变化经常同时发生：项目进入、离开、重排、刷新和收缩。用户需要一条能追踪的因果链，知道自己操作的是谁、它去了哪里，以及为什么周围内容也随之变化。",
+      "Cards, lists, and filters often change at once: items arrive, leave, reorder, refresh, and contract. People need a trackable causal chain that tells them what they acted on, where it went, and why surrounding content changed too."
+    ),
+    sections: [
+      {
+        id: "identity",
+        title: text("先让用户认得出同一个对象", "Let people recognise the same object first"),
+        paragraphs: [
+          text(
+            "连续性的起点是对象身份。一个卡片被选择、拖拽或筛选后，它的标题、缩略图、边界和相对位置应该尽量延续。即使尺寸要变化，也要让关键识别线索留在画面里。比如任务卡从看板进入详情页时，标题和主色块可以在新布局中继续出现；筛选后只剩三条结果时，保留激活的筛选条件和数量，用户便能把收缩后的列表与刚才的选择联系起来。",
+            "Continuity starts with object identity. When a card is selected, dragged, or filtered, its title, thumbnail, boundary, and relative position should persist where possible. Even when size changes, keep main recognition cues on screen. When a task card opens into detail, its title and primary color can continue in the new layout; when filtering leaves three results, keep the active filter and count visible so people can connect the reduced list to the choice they just made."
+          ),
+          text(
+            "身份线索也能帮助处理内容更新。来自实时协作、轮询刷新或后台同步的新项目，不要和用户刚操作的项目混成一团。新项目可以从列表边缘轻量进入，并用短暂的“新增”标记说明来源；被更新的项目可以只变化相关字段，避免整张卡片反复闪动。用户会把每一次变化归因到自己的动作、别人的动作或系统刷新，界面提供的线索越清楚，认知负担越低。",
+            "Identity cues also help with updates. New items from collaboration, polling, or background sync should not blend into the item a person just touched. A new item can enter lightly from the list edge with a brief New marker that explains its source; an updated item can change only the relevant field instead of flashing the whole card. People attribute every change to their own action, someone else’s action, or a system refresh. Clearer cues reduce that burden."
+          )
+        ]
+      },
+      {
+        id: "timeline",
+        title: text("进入、移动和离开共用一条时间线", "Let entrance, movement, and exit share one timeline"),
+        paragraphs: [
+          text(
+            "列表变化很容易显得乱，因为进入、离开和位置移动同时发生。处理的关键在于给它们一个共同的节奏。先让要离开的项目降低存在感，再让保留项目平移到新位置，最后让新增项目出现。它们并不需要逐帧串行，只要开始和结束有清楚的先后关系即可。对于十条以内的列表，120–220ms 往往能完成一次干净的重排；项目更多时，优先缩短单项延迟，避免最后一个项目很久以后才落位。",
+            "List changes can feel chaotic because entrance, exit, and movement happen together. The key is a shared rhythm. Let departing items reduce their presence, move retained items to their new places, then reveal incoming items. They do not need frame-by-frame serialization; their starts and ends simply need a clear order. For lists under ten items, 120–220 ms often completes a clean reorder. With more items, shorten per-item delay so the final item does not settle much later than the first."
+          ),
+          text(
+            "视觉上的移动应当真实反映数据变化。排序后卡片最好沿着它们实际要去的位置移动；如果采用 crossfade，保留旧位置和新位置的重叠时间，让眼睛有机会建立对应关系。列表容器本身保持稳定高度也很重要。大面积的高度跳动会让用户以为页面重新加载了，而非理解为内容发生了筛选。对小屏幕来说，连续性还意味着滚动位置可控：用户刚刚触碰的区域应尽可能留在视口附近。",
+            "Visual movement should reflect the data change. After sorting, cards should travel toward the places they truly occupy; if using crossfade, overlap old and new positions long enough for the eye to establish correspondence. Keeping the container’s height stable matters too. Large height jumps can look like a page reload rather than a filtered result. On small screens, continuity also means controlling scroll position: keep the area a person just touched near the viewport whenever possible."
+          )
+        ]
+      },
+      {
+        id: "filters",
+        title: text("筛选要保留条件、数量和空状态", "Keep criteria, counts, and empty states through filtering"),
+        paragraphs: [
+          text(
+            "筛选的动效承担解释责任。用户选择“已完成”或输入关键词后，列表会减少、排序会变化、统计数字也会更新。激活的筛选 chip、搜索词和结果数量应该先于或同时于列表变化出现，这样用户先知道规则，再看到结果。若只让卡片瞬间消失，页面会像发生了故障；若条件、数量和卡片同步更新，用户能理解这是一次受控的收缩。",
+            "Filter motion carries an explanatory responsibility. When someone chooses Completed or enters a query, the list shrinks, ordering can change, and counts update. Show the active filter chip, query, and result count before or alongside the list change, so people see the rule before the result. If cards simply vanish, the page can resemble a fault; when criteria, count, and cards update together, the contraction reads as controlled."
+          ),
+          text(
+            "空状态同样属于连续性。零结果也是列表的一种结果，它应接住刚才的筛选条件：显示“没有匹配‘预算’的项目”，提供清除筛选或换一个条件的入口。空状态进入时，一次淡入加上稳定的占位就足够。若筛选结果很快来回变化，避免每次都播放完整出入场；在输入框连续输入时，可以用更短的过渡，等用户停止输入后再让最终结果稳定下来。",
+            "An empty state belongs to continuity as well. Zero results are not the end of the list; the state should receive the active criteria: say No projects match budget and offer Clear filters or another path. Its entrance does not need a large bounce—one fade with a stable placeholder is enough. When results change rapidly, avoid replaying a full entrance and exit every time. During continuous typing, use shorter transitions and let the final result settle once input pauses."
+          )
+        ]
+      },
+      {
+        id: "source",
+        title: text("刷新、排序和拖拽各自有不同信号", "Give refresh, sorting, and dragging distinct signals"),
+        paragraphs: [
+          text(
+            "三种变化看起来都在移动卡片，实际含义完全不同。刷新告诉用户系统得到了新数据；排序表达一个新的比较规则；拖拽确认用户亲手改变了顺序。刷新适合轻量提示和局部更新，排序适合展示当前排序规则与整体重排，拖拽则需要拾取态、占位和落点。把它们做成同一种“卡片飞来飞去”，会让用户失去对原因的判断。",
+            "Refresh, sorting, and dragging all move cards, yet they mean different things. Refresh says the system received new data; sorting expresses a new comparison rule; dragging confirms that a person directly changed order. Refresh benefits from a light cue and local update, sorting from showing the active rule and a whole-list reorder, and dragging from pickup, placeholder, and drop states. Treating all three as cards flying around removes the user’s ability to understand why change occurred."
+          ),
+          text(
+            "实现时可以把“变化来源”作为状态的一部分。列表容器记录当前是 filter、sort、refresh 还是 drag；每种状态只触发自己需要的视觉规则。这样也利于测试：筛选时检查结果数量和焦点，排序时检查对象的最终顺序，拖拽时检查键盘与触屏路径。动效不再是覆盖在数据之上的装饰层，它成为状态变化的可见输出，和业务逻辑一起被验收。",
+            "In implementation, make the source of change part of state. Let the list container know whether the current change is filter, sort, refresh, or drag, and let each mode trigger only its necessary visual rule. This also improves testing: verify result count and focus during filtering, final order during sorting, and keyboard and touch paths during dragging. Motion becomes visible output of state change, validated alongside business logic rather than treated as decoration floating above it."
+          )
+        ]
+      },
+      {
+        id: "review",
+        title: text("把连续性写进列表组件的验收", "Make continuity part of list-component acceptance"),
+        paragraphs: [
+          text(
+            "列表组件可以把连续性写成一组明确规则：对象身份如何保留、容器高度在何种条件下变化、筛选条件和数量何时更新、移动距离和总时长的上限是多少、空状态承接哪些动作。这样新页面引用组件时，不会每次重新猜测动画该怎么做。设计评审关注的是用户是否能追踪，工程评审关注的是最终数据顺序和焦点，两个角度围绕的是同一份契约。",
+            "A list component can turn continuity into explicit rules: how object identity persists, when container height may change, when criteria and counts update, the limit for travel and total duration, and which actions an empty state receives. New pages can then use the component without repeatedly guessing how animation should work. Design review asks whether people can track the change; engineering review checks final data order and focus. Both perspectives revolve around the same contract."
+          ),
+          text(
+            "验收时要用真实规模的数据。三张卡片的漂亮位移，放到五十条搜索结果上可能变成拖延。测试一次连续输入、一次多条件筛选、一次排序和一次移动端滚动中的更新；同时开启减少动效偏好，确认规则、数量和焦点仍然清楚。好的连续性并不要求每个对象都演一段完整动画，它要求每次变化都有来处、有结果、有可以继续操作的空间。",
+            "Review with realistic data scale. A beautiful move across three cards can turn into delay across fifty search results. Test continuous typing, multi-condition filtering, sorting, and an update while mobile scrolling; then enable reduced motion and confirm that rules, counts, and focus remain clear. Good continuity does not require every object to perform a full animation. It requires every change to have an origin, a result, and room for the next action."
+          )
+        ]
+      }
+    ],
+    checklistTitle: text("列表连续性验收清单", "List continuity checklist"),
+    checklist: [
+      { id: "identity", label: text("被操作对象保留可辨认线索", "The acted-on object retains recognisable cues"), detail: text("标题、缩略图、色块或相对位置在新状态中继续出现。", "Title, thumbnail, color block, or relative position continues in the new state.") },
+      { id: "rule", label: text("筛选规则和结果数量同步可见", "Filter rule and result count are visible together"), detail: text("先让人知道规则，再让列表收缩或重排。", "Show the rule before the list contracts or reorders.") },
+      { id: "timing", label: text("离开、移动和进入共享短节奏", "Exit, movement, and entrance share a short rhythm"), detail: text("项目多时控制总时长，避免延迟排队。", "Cap total duration for larger sets and avoid delay queues.") },
+      { id: "empty", label: text("空状态解释条件并给出下一步", "Empty state explains criteria and offers a next step"), detail: text("保留搜索词或筛选条件，并提供清除或替换入口。", "Retain query or criteria and offer clear or replacement actions.") },
+      { id: "source", label: text("刷新、排序与拖拽可被区分", "Refresh, sort, and drag are distinguishable"), detail: text("每种来源使用自己的状态与验收路径。", "Each source uses its own state and acceptance path.") }
+    ],
+    caseStudy: {
+      title: text("案例：项目筛选先更新数量，再收缩卡片", "Case: project filtering updates count before cards contract"),
+      context: text("筛选条件和命中数量放在列表上方，保留项平移，离开项只降低透明度。", "Active criteria and match count sit above the list; retained items move while departing items only fade."),
+      code: `.result-list { display: grid; gap: 12px; }
+.result-card { transition: transform 180ms ease-out, opacity 140ms ease-out; }
+.result-card[data-visibility="leaving"] { opacity: 0; transform: scale(.985); pointer-events: none; }
+.result-meta[data-updating="true"] { color: var(--motion-ink); }
+.result-empty { min-height: 160px; opacity: 0; visibility: hidden; transition: opacity 140ms ease-out; }
+.result-list[data-empty="true"] + .result-empty { opacity: 1; visibility: visible; }
+@media (prefers-reduced-motion: reduce) { .result-card, .result-empty { transition-duration: 1ms; } }`,
+      explanation: text("离开项目不使用大位移，保留项目的真实位置移动更容易被看清。命中数量通过 data-updating 先变化，建立“规则已经生效”的线索；空状态预留高度，列表收缩后页面不会突然塌陷。", "Departing items avoid large travel so the real movement of retained items is easier to read. The match count changes first through data-updating, establishing that the rule has taken effect; the empty state reserves height so the page does not suddenly collapse.")
+    },
+    diagrams: [
+      {
+        id: "card-identity-map",
+        title: text("图解一：卡片身份在状态间延续", "Diagram 1: card identity persists across states"),
+        alt: text("同一张带标题和色块的卡片经历默认、选中、筛选后和详情四个位置。", "One card with a title and color block appears in default, selected, filtered, and detail positions."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("default", "默认卡片", "Default card", "标题、缩略图、位置", "Title, thumbnail, position", 55, 215, 185, 105, "surface"),
+          node("selected", "已选中", "Selected", "边界与焦点增强", "Boundary and focus strengthen", 285, 215, 185, 105, "accent"),
+          node("filtered", "筛选后", "After filter", "保留身份与新顺序", "Identity remains in new order", 515, 215, 185, 105, "ink"),
+          node("detail", "详情状态", "Detail state", "同一标题继续出现", "The same title continues", 745, 215, 185, 105, "success")
+        ],
+        connectors: [
+          { from: "default", to: "selected", label: text("选择", "Select") },
+          { from: "selected", to: "filtered", label: text("筛选", "Filter") },
+          { from: "selected", to: "detail", label: text("打开", "Open") }
+        ]
+      },
+      {
+        id: "list-change-timeline",
+        title: text("图解二：列表更新的三段节奏", "Diagram 2: three beats of a list update"),
+        alt: text("从 0 到 220 毫秒依次展示离开、重排和进入，三段有部分重叠。", "From 0 to 220 milliseconds, exit, reorder, and entrance appear in partially overlapping beats."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("exit", "0–100ms", "0–100 ms", "离开项降低存在感", "Departing items reduce presence", 70, 205, 230, 110, "warning"),
+          node("move", "60–180ms", "60–180 ms", "保留项移向真实位置", "Retained items travel to real positions", 365, 205, 230, 110, "accent"),
+          node("enter", "120–220ms", "120–220 ms", "新增项轻量进入", "New items enter lightly", 660, 205, 230, 110, "success")
+        ],
+        connectors: [
+          { from: "exit", to: "move" },
+          { from: "move", to: "enter" }
+        ]
+      },
+      {
+        id: "filter-explanation-flow",
+        title: text("图解三：筛选如何解释结果", "Diagram 3: how a filter explains its result"),
+        alt: text("筛选条件先影响结果数量，再分支到保留卡片或空状态，空状态提供清除入口。", "Criteria first affects result count, then branches to retained cards or empty state; the empty state offers Clear."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("criteria", "筛选条件", "Criteria", "已完成 · 本周", "Completed · This week", 60, 215, 180, 105, "accent"),
+          node("count", "结果数量", "Result count", "规则已生效", "Rule has taken effect", 305, 215, 180, 105, "ink"),
+          node("results", "保留卡片", "Retained cards", "移动到新位置", "Move to new positions", 610, 100, 180, 105, "success"),
+          node("empty", "空状态", "Empty state", "解释条件与下一步", "Explain criteria and next step", 610, 340, 180, 105, "surface")
+        ],
+        connectors: [
+          { from: "criteria", to: "count" },
+          { from: "count", to: "results", label: text("有结果", "Matches") },
+          { from: "count", to: "empty", label: text("零结果", "Zero matches") },
+          { from: "empty", to: "criteria", label: text("清除", "Clear") }
+        ]
+      }
+    ]
+  }
+] as const satisfies readonly SeoGuideLongArticle[];
+
+export function getSeoGuideArticleA(id?: string | null): SeoGuideLongArticle | undefined {
+  return seoGuideArticlesA.find((article) => article.guideId === id);
+}

--- a/src/data/seo-guide-articles-b.ts
+++ b/src/data/seo-guide-articles-b.ts
@@ -1,0 +1,779 @@
+import type { SeoGuideId } from "./seo-guide-ids";
+
+/**
+ * Long-form editorial source for scenario guides 05–08.
+ * The renderer can turn `diagrams` directly into SVG cards: coordinates use a
+ * 960 × 540 canvas and connectors join node ids.
+ */
+export type SeoGuideArticleText = {
+  zh: string;
+  en: string;
+};
+
+export type SeoGuideArticleSection = {
+  id: string;
+  title: SeoGuideArticleText;
+  paragraphs: readonly [SeoGuideArticleText, SeoGuideArticleText, ...SeoGuideArticleText[]];
+};
+
+export type SeoGuideArticleChecklistItem = {
+  id: string;
+  label: SeoGuideArticleText;
+  detail: SeoGuideArticleText;
+};
+
+export type SeoGuideArticleCase = {
+  title: SeoGuideArticleText;
+  context: SeoGuideArticleText;
+  code: string;
+  explanation: SeoGuideArticleText;
+};
+
+export type SeoGuideArticleDiagramNode = {
+  id: string;
+  label: SeoGuideArticleText;
+  detail: SeoGuideArticleText;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  tone: "ink" | "accent" | "success" | "warning" | "surface";
+};
+
+export type SeoGuideArticleDiagramConnector = {
+  from: string;
+  to: string;
+  label?: SeoGuideArticleText;
+};
+
+export type SeoGuideArticleDiagram = {
+  id: string;
+  title: SeoGuideArticleText;
+  alt: SeoGuideArticleText;
+  viewBox: "0 0 960 540";
+  nodes: readonly SeoGuideArticleDiagramNode[];
+  connectors: readonly SeoGuideArticleDiagramConnector[];
+};
+
+export type SeoGuideLongArticle = {
+  guideId: SeoGuideId;
+  standfirst: SeoGuideArticleText;
+  sections: readonly [
+    SeoGuideArticleSection,
+    SeoGuideArticleSection,
+    SeoGuideArticleSection,
+    SeoGuideArticleSection,
+    SeoGuideArticleSection
+  ];
+  checklistTitle: SeoGuideArticleText;
+  checklist: readonly [
+    SeoGuideArticleChecklistItem,
+    SeoGuideArticleChecklistItem,
+    SeoGuideArticleChecklistItem,
+    SeoGuideArticleChecklistItem,
+    SeoGuideArticleChecklistItem
+  ];
+  caseStudy: SeoGuideArticleCase;
+  diagrams: readonly [SeoGuideArticleDiagram, SeoGuideArticleDiagram, SeoGuideArticleDiagram];
+};
+
+const text = (zh: string, en: string): SeoGuideArticleText => ({ zh, en });
+
+const node = (
+  id: string,
+  zh: string,
+  en: string,
+  zhDetail: string,
+  enDetail: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  tone: SeoGuideArticleDiagramNode["tone"]
+): SeoGuideArticleDiagramNode => ({
+  id,
+  label: text(zh, en),
+  detail: text(zhDetail, enDetail),
+  x,
+  y,
+  width,
+  height,
+  tone
+});
+
+const deletionInteractionRuntimeExample = `<section class="delete-demo">
+  <ul data-project-list>
+    <li class="project-row" data-project-row data-project-id="alpha" data-state="ready">
+      <span>Project Alpha</span>
+      <button type="button" data-delete>Delete</button>
+    </li>
+  </ul>
+  <div data-project-undo hidden>
+    <span>Project deleted.</span>
+    <button type="button" data-undo>Undo</button>
+  </div>
+  <p role="status" aria-live="polite" data-delete-status>Project Alpha is available.</p>
+</section>
+
+<style>
+.delete-demo { display: grid; gap: 12px; max-width: 28rem; }
+.project-row { display: flex; justify-content: space-between; gap: 12px; align-items: center; }
+@media (prefers-reduced-motion: no-preference) {
+  .project-row { transition: opacity 180ms ease, transform 180ms ease; }
+  .project-row[data-state="leaving"] { opacity: 0; transform: translateX(8px); }
+}
+</style>
+
+<script>
+const row = document.querySelector("[data-project-row]");
+const list = document.querySelector("[data-project-list]");
+const deleteButton = row.querySelector("[data-delete]");
+const undoRegion = document.querySelector("[data-project-undo]");
+const undoButton = undoRegion.querySelector("[data-undo]");
+const status = document.querySelector("[data-delete-status]");
+const projectId = row.dataset.projectId;
+const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+let leaveTimer = 0;
+let onLeaveEnd = null;
+
+function waitForServer() {
+  return new Promise((resolve) => window.setTimeout(resolve, 160));
+}
+
+async function deleteProject(id) {
+  await waitForServer();
+}
+
+async function restoreProject(id) {
+  await waitForServer();
+}
+
+function clearLeaving() {
+  window.clearTimeout(leaveTimer);
+  leaveTimer = 0;
+  if (onLeaveEnd) row.removeEventListener("transitionend", onLeaveEnd);
+  onLeaveEnd = null;
+}
+
+function removeAfterExit() {
+  const finishRemoval = () => {
+    clearLeaving();
+    if (row.isConnected) row.remove();
+  };
+
+  if (reducedMotion.matches) {
+    finishRemoval();
+    return;
+  }
+
+  onLeaveEnd = (event) => {
+    if (event.target !== row || event.propertyName !== "opacity") return;
+    finishRemoval();
+  };
+  row.addEventListener("transitionend", onLeaveEnd);
+  leaveTimer = window.setTimeout(finishRemoval, 220);
+}
+
+async function removeProject() {
+  if (deleteButton.disabled) return;
+
+  row.dataset.state = "deleting";
+  deleteButton.disabled = true;
+  status.textContent = "Deleting Project Alpha.";
+
+  try {
+    await deleteProject(projectId);
+    row.dataset.state = "leaving";
+    undoRegion.hidden = false;
+    undoButton.disabled = false;
+    status.textContent = "Project deleted. Undo is available.";
+    undoButton.focus();
+    removeAfterExit();
+  } catch {
+    row.dataset.state = "ready";
+    deleteButton.disabled = false;
+    status.textContent = "Project deletion failed. Try again.";
+    deleteButton.focus();
+  }
+}
+
+async function restoreProjectRow() {
+  if (undoButton.disabled) return;
+
+  clearLeaving();
+  undoButton.disabled = true;
+  status.textContent = "Restoring Project Alpha.";
+
+  try {
+    await restoreProject(projectId);
+    if (!row.isConnected) list.append(row);
+    row.dataset.state = "ready";
+    deleteButton.disabled = false;
+    undoButton.disabled = false;
+    undoRegion.hidden = true;
+    status.textContent = "Project restored.";
+    deleteButton.focus();
+  } catch {
+    undoButton.disabled = false;
+    status.textContent = "Project restoration failed. Try again.";
+    undoButton.focus();
+  }
+}
+
+deleteButton.addEventListener("click", removeProject);
+undoButton.addEventListener("click", restoreProjectRow);
+</script>`;
+
+export const seoGuideArticlesB = [
+  {
+    guideId: "reduced-motion",
+    standfirst: text(
+      "减弱动效的目标是让用户更容易读懂界面：保留因果、焦点和完成结果，再把大幅移动、持续循环和意外跳动降到合适强度。它是一条完整交互路径，需要和默认路径一起设计、一起验收。",
+      "Reduced motion makes an interface easier to read: retain cause, focus, and completed outcomes, then lower large travel, continuous loops, and surprising movement to an appropriate intensity. It is a complete interaction path that deserves the same design and review as the default path."
+    ),
+    sections: [
+      {
+        id: "meaning",
+        title: text("先定义必须保留的意义", "Define the meaning that must remain"),
+        paragraphs: [
+          text(
+            "很多团队把减弱动效理解成把所有 transition 设为零。这样虽然减少了移动，却常常顺带拿走了界面的解释能力：用户点击保存后，不再知道请求是否已经收到；切换工作区后，焦点突然换了位置；删除一项后，列表少了一行，却没有告诉人发生了什么。减弱动效真正要保护的是信息，而不是某一段 CSS 的时长。先写下每个动作需要传递的答案：是谁触发的、系统正在处理什么、结果落在哪里、接下来还能做什么。",
+            "Many teams treat reduced motion as setting every transition to zero. That lowers movement, yet it can also remove the interface’s explanation: after Save, people no longer know whether the request was received; after switching workspaces, focus appears somewhere new; after deletion, a row disappears without explaining the change. Reduced motion protects information rather than the duration of one CSS rule. Start by writing the answers every action must communicate: who triggered it, what the system is processing, where the result lands, and what can happen next."
+          ),
+          text(
+            "把这份答案转成状态表，会比从动画属性开始更可靠。以文件上传为例，默认路径可以有进度填充、短暂旋转和新文件行的进入；低动态路径仍要有“上传中”“已完成”、文件名、可用状态和失败后的重试入口。用户得到的是同一份结果，只是路径不再依赖大范围位移。状态文字、颜色、边框、图标、焦点和层级都能承担信号，其中至少两个应在每个关键状态同时出现，避免只依赖一种感官线索。",
+            "Turn those answers into a state table before choosing properties. A file upload can use progress fill, a short spinner, and an entering file row on the default path; the low-motion path still needs Uploading, Complete, the filename, availability, and a retry action after failure. The outcome stays the same while the route no longer depends on broad travel. State copy, color, boundaries, icons, focus, and hierarchy can all carry the signal. Use at least two of them at each critical state so no single sensory cue bears the whole meaning."
+          )
+        ]
+      },
+      {
+        id: "inventory",
+        title: text("盘点移动，再选择替代表达", "Inventory movement, then choose replacements"),
+        paragraphs: [
+          text(
+            "审查页面时，把动作按感知负担分成四类：跨屏或跨容器的位移、尺寸快速变化、持续循环、由滚动或手势驱动的跟随。第一类最容易造成空间失衡，适合缩短距离、改为原位淡化或用稳定边界标出变化；第二类可以保留极小的缩放，但应避免从很小尺寸突然放大；第三类常可停在一个可读的静态状态；第四类要保留用户手势和内容位置，让控制感一直在用户手里。分类让方案具有一致性，页面也更容易维护。",
+            "During review, group movement by perceptual load: travel across a screen or container, rapid size changes, continuous loops, and movement driven by scroll or direct manipulation. The first category can lose spatial balance, so shorten distance, fade in place, or use a stable boundary to mark the change. The second can retain very small scale changes while avoiding a sudden expansion from a tiny size. The third often settles into a readable static state. The fourth should preserve the person’s gesture and content position so control remains in their hands. Grouping creates consistency and makes the page easier to maintain."
+          ),
+          text(
+            "替代方案需要匹配原动作的职责。一个抽屉原先从右侧滑入，是为了说明它来自哪里并暂时覆盖主内容；低动态版本可以直接显示抽屉、保持触发按钮的 pressed 状态，并把键盘焦点移到抽屉标题。一个成功 toast 原先从底部升起，是为了让结果被看见；低动态版本可在触发按钮附近更新“已保存”，再在状态区保留一条静态确认。这样做不会让低动态界面变得沉默，它只是把解释从移动转移到更稳定的视觉和语义线索上。",
+            "A replacement should match the job of the original motion. A drawer may slide in from the right to explain its origin and its temporary coverage of main content; the low-motion version can reveal it directly, preserve the trigger’s pressed state, and move keyboard focus to the drawer title. A success toast may rise from the bottom to make a result noticeable; the low-motion version can update Saved beside the trigger and retain a static confirmation in the status area. The interface remains expressive because explanation moves from travel to stable visual and semantic cues."
+          )
+        ]
+      },
+      {
+        id: "implementation",
+        title: text("把偏好写进组件契约", "Put the preference into the component contract"),
+        paragraphs: [
+          text(
+            "`prefers-reduced-motion` 应该在组件层定义，而不是等到页面末尾再用一条全局覆盖规则收尾。组件契约要说明默认状态、低动态状态、两条路径共同保留的文案和 aria 状态，以及用户在运行时修改系统偏好时如何更新。对可重复使用的 Pack，这份契约还应明确哪些值允许主题或产品覆盖，例如入口距离、是否显示装饰性旋转、成功状态停留多久。把规则放在数据与组件附近，才能避免新页面悄悄回到只会移动的旧习惯。",
+            "Define `prefers-reduced-motion` at the component level instead of adding one global override at the end of a page. The component contract should state the default state, the low-motion state, the copy and aria states shared by both paths, and the response when a person changes the system preference at runtime. For reusable Packs, it should also identify values a theme or product may override: entrance distance, whether decorative rotation appears, and how long a success state stays visible. Keeping rules close to data and components prevents new pages from drifting back to a movement-only habit."
+          ),
+          text(
+            "实现时优先使用同一个状态源。按钮从“保存”变为“保存中”再变为“已保存”，默认版本可以在状态变化周围加入 transform 和 opacity；低动态版本沿用相同的 `data-state`、相同的文字和相同的可访问性通知，只替换视觉过渡。这样测试覆盖的是一个业务流程，而不是两套互不相干的组件。也要尊重手动设置：如果产品提供“减少动效”开关，它的优先级、存储方式和与系统偏好的关系应被写清楚，避免用户每次访问都要重新选择。",
+            "Use one state source in implementation. A button moves from Save to Saving to Saved; the default version can add transform and opacity around those state changes, while the low-motion version keeps the same `data-state`, copy, and accessibility announcement and replaces only the visual transition. Tests then cover one business flow rather than two unrelated components. Respect manual settings as well: if the product offers a Reduce motion control, document its priority, storage, and relationship to the system preference so people do not have to choose again on every visit."
+          )
+        ]
+      },
+      {
+        id: "interaction",
+        title: text("让焦点、滚动和输入保持连续", "Keep focus, scroll, and input continuous"),
+        paragraphs: [
+          text(
+            "低动态模式常常暴露出默认路径里被动画掩盖的问题。弹窗出现得更直接时，焦点是否已经进入弹窗？列表不再滑动时，新增项是否仍然在阅读位置附近？筛选结果立刻替换时，屏幕阅读器能否知道结果数量发生了变化？这些问题决定交互是否完整。每当移除一段视觉运动，都要补查焦点管理、滚动位置、状态区域和键盘返回路径。减弱动效能够成为一面镜子，帮助团队发现原先依赖视觉缓冲掩盖的断点。",
+            "Low-motion mode often exposes issues that the default path hides with animation. When a dialog appears directly, has focus already entered it? When a list no longer slides, does a new item still appear near the reading position? When filtered results replace immediately, can a screen reader learn that the count changed? These questions determine whether the interaction is complete. Whenever visual movement is removed, recheck focus management, scroll position, status regions, and the keyboard return path. Reduced motion becomes a useful mirror for breaks previously hidden by visual buffering."
+          ),
+          text(
+            "同样的原则适用于触摸和拖拽。减少动效并不意味着禁用直接操控；用户拖动滑块、排序任务或拖拽时间线时，内容仍应跟随手势，只是惯性、回弹和装饰性残影可以更克制。要确保松手后的结果在同一位置被确认，并让撤销或恢复入口稳定可见。对于自动播放的轮播、背景浮动和闪烁加载骨架，默认关闭或改为手动触发通常更合适，因为这些动作没有用户输入作为锚点。",
+            "The same principle applies to touch and drag. Reducing motion does not disable direct manipulation; when someone drags a slider, sorts tasks, or scrubs a timeline, content should still follow the gesture while inertia, bounce, and decorative trails become more restrained. Confirm the result in the same place after release and keep undo or recovery actions steadily visible. Autoplay carousels, background floating, and flashing loading skeletons are usually better disabled by default or changed to manual replay because they lack a user action as an anchor."
+          )
+        ]
+      },
+      {
+        id: "review",
+        title: text("把减弱动效作为发布标准验收", "Review reduced motion as a shipping criterion"),
+        paragraphs: [
+          text(
+            "验收不应只在浏览器开发工具里勾选一次偏好。把系统偏好切换、产品内开关、键盘操作、触屏操作和窄屏布局放在同一张测试清单中。测试者需要能够回答：我是否看得出提交已经开始？我是否知道失败发生在哪里？我是否还能撤销？我是否能在没有连续运动的情况下理解列表、工作区和层级变化？把回答记录下来，下一次同类组件就能直接复用。",
+            "Review should go beyond toggling a browser preference once. Put system-preference changes, an in-product control, keyboard operation, touch operation, and narrow layouts on the same test checklist. A reviewer should be able to answer: Can I tell that submission started? Do I know where failure happened? Can I still undo? Can I understand list, workspace, and hierarchy changes without continuous movement? Record the answers so the next component of the same class can reuse them."
+          ),
+          text(
+            "最后再衡量节奏。减弱动效不等于所有东西同时瞬移：一组信息仍可按语义顺序出现，状态仍可在极短时间内交接，焦点仍可被引导。关键是任何时间差都服务于阅读顺序，而不是制造戏剧性。把装饰性时间归零或降到极短，把任务完成、错误定位和内容更新的时间保留在可感知范围。这样无论用户选择哪条路径，产品都保持同一套逻辑和同一份尊重。",
+            "Measure rhythm last. Reduced motion does not require every element to appear at the exact same instant: information can still arrive in semantic order, states can hand off over a very short interval, and focus can still be guided. Each delay should serve reading order rather than drama. Reduce decorative time to zero or near zero while keeping task completion, error location, and content updates perceptible. Both paths then preserve the same logic and the same respect for the person using the product."
+          )
+        ]
+      }
+    ],
+    checklistTitle: text("减弱动效发布清单", "Reduced-motion shipping checklist"),
+    checklist: [
+      { id: "signals", label: text("每个关键状态至少保留两种信号", "Retain at least two signals for every critical state"), detail: text("组合文案、图标、边界、颜色和焦点，不把结果交给单一动画。", "Combine copy, icon, boundary, color, and focus instead of assigning the result to one animation.") },
+      { id: "preference", label: text("系统偏好与产品开关都能即时生效", "System preference and product control update immediately"), detail: text("运行时修改偏好后，当前组件应切换到对应状态。", "When the preference changes at runtime, the current component should switch to the matching treatment.") },
+      { id: "focus", label: text("直接出现的层级仍有正确焦点", "Directly appearing layers still receive correct focus"), detail: text("抽屉、弹窗和展开内容需要可预测的键盘路径。", "Drawers, dialogs, and disclosure content need a predictable keyboard path.") },
+      { id: "input", label: text("直接操控仍然跟随手势", "Direct manipulation still follows the gesture"), detail: text("保留拖拽、滑动和排序的因果关系，收敛惯性与装饰性轨迹。", "Keep the causal link in drag, swipe, and reorder while reducing inertia and decorative trails.") },
+      { id: "review", label: text("默认路径与低动态路径都通过同一业务验收", "Default and low-motion paths pass the same business review"), detail: text("成功、失败、撤销和恢复都要被独立检查。", "Success, failure, undo, and recovery all receive independent checks.") }
+    ],
+    caseStudy: {
+      title: text("案例：保存确认在两条路径中保持同一结果", "Case: one save confirmation, two paths, one outcome"),
+      context: text("编辑器点击保存后，需要立刻确认输入、展示进行中状态，并在完成后更新页面状态。", "An editor needs to acknowledge Save immediately, show progress, and update page state on completion."),
+      code: `[data-save-state="saving"] { opacity: .72; }\n[data-save-state="saved"] { color: var(--success); }\n\n@keyframes settle-in {\n  from { opacity: 0; transform: scale(.88); }\n  70% { transform: scale(1.04); }\n  to { opacity: 1; transform: scale(1); }\n}\n\n@media (prefers-reduced-motion: no-preference) {\n  [data-save-state] { transition: transform 120ms ease, opacity 160ms ease; }\n  [data-save-state="saving"] { transform: scale(.98); }\n  [data-save-state="saved"] .save-icon { animation: settle-in 180ms cubic-bezier(.23, 1, .32, 1); }\n}`,
+      explanation: text("业务状态、按钮文案和 status 区域在两条路径中完全一致。媒体查询只增加默认路径的缩放与图标进入，因此低动态版本仍能表达“收到、处理中、已完成”。", "Business state, button copy, and the status region stay identical on both paths. The media query adds scale and icon entrance only to the default path, so the low-motion version still communicates received, processing, and complete.")
+    },
+    diagrams: [
+      {
+        id: "signal-preservation",
+        title: text("图解一：从移动信号转为稳定信号", "Diagram 1: move from travel signals to stable signals"),
+        alt: text("保存动作从点击、处理中到已保存，低动态路径保留文案、图标和状态色。", "A save action moves from press to processing to saved; the low-motion path retains copy, icon, and status color."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("press", "点击保存", "Press Save", "输入已收到", "Input received", 70, 205, 190, 110, "ink"),
+          node("processing", "保存中", "Saving", "文案 + 状态图标", "Copy + status icon", 385, 205, 190, 110, "accent"),
+          node("saved", "已保存", "Saved", "结果 + 时间标记", "Result + time marker", 700, 205, 190, 110, "success")
+        ],
+        connectors: [
+          { from: "press", to: "processing", label: text("保留状态变化", "Retain state change") },
+          { from: "processing", to: "saved", label: text("减少装饰性位移", "Reduce decorative travel") }
+        ]
+      },
+      {
+        id: "motion-inventory",
+        title: text("图解二：动作盘点与替代策略", "Diagram 2: motion inventory and replacement strategy"),
+        alt: text("四类动作分别对应短距离、稳定边界、静态状态和保留手势的替代策略。", "Four motion classes map to short travel, stable boundaries, static states, and preserved gestures."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("travel", "跨容器位移", "Cross-container travel", "缩短距离", "Shorten distance", 70, 100, 290, 95, "warning"),
+          node("scale", "快速缩放", "Rapid scale", "保留边界", "Keep boundary", 600, 100, 290, 95, "surface"),
+          node("loop", "持续循环", "Continuous loop", "停在静态状态", "Settle to static state", 70, 345, 290, 95, "surface"),
+          node("gesture", "手势跟随", "Gesture following", "保留直接操控", "Preserve manipulation", 600, 345, 290, 95, "accent")
+        ],
+        connectors: []
+      },
+      {
+        id: "review-loop",
+        title: text("图解三：低动态验收循环", "Diagram 3: low-motion review loop"),
+        alt: text("状态表、默认路径、低动态路径、键盘和触屏验收形成循环。", "A state table, default path, low-motion path, keyboard, and touch review form a loop."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("states", "状态表", "State table", "必须保留的信息", "Meaning to retain", 385, 55, 190, 90, "ink"),
+          node("default", "默认路径", "Default path", "视觉节奏", "Visual rhythm", 650, 220, 190, 90, "accent"),
+          node("reduced", "低动态路径", "Low-motion path", "稳定线索", "Stable cues", 385, 385, 190, 90, "success"),
+          node("input", "键盘与触屏", "Keyboard and touch", "焦点与手势", "Focus and gesture", 120, 220, 190, 90, "surface")
+        ],
+        connectors: [
+          { from: "states", to: "default" },
+          { from: "default", to: "reduced" },
+          { from: "reduced", to: "input" },
+          { from: "input", to: "states" }
+        ]
+      }
+    ]
+  },
+  {
+    guideId: "form-validation-delete-permission",
+    standfirst: text(
+      "表单校验、删除确认和权限变更都在处理边界。动效要把风险、影响范围、进行中状态和恢复路径安排在用户做决定的位置，让人能看见后果，也能继续完成任务。",
+      "Form validation, deletion confirmation, and permission changes all handle boundaries. Motion should place risk, scope, progress, and recovery where people make the decision, so consequences remain visible and work can continue."
+    ),
+    sections: [
+      {
+        id: "risk-map",
+        title: text("先画出风险和可恢复性的地图", "Map risk and reversibility first"),
+        paragraphs: [
+          text(
+            "把高风险交互都做成同一种弹窗，往往会让重要程度变得模糊。表单中的邮箱格式错误需要快速、贴近输入的帮助；移除团队成员需要说明对象、影响和是否可以恢复；把链接从“受邀成员”改为“任何人可访问”需要让人看见范围扩大到了哪里。先按后果而不是控件类型分组：可立即修正、可撤销、需要明确承诺、会影响他人的设置。每一组决定反馈的位置、速度和文字强度。",
+            "Making every high-risk interaction the same modal often blurs importance. An invalid email needs fast help beside the field; removing a team member needs the object, impact, and recovery option; changing a link from invited members to anyone needs to show where access expands. Group by consequence rather than control type: immediately correctable, reversible, explicitly committed, and settings that affect other people. Each group determines the location, pace, and language of feedback."
+          ),
+          text(
+            "风险地图也能阻止过度表演。轻微的输入错误不需要整张页面震动，真正的删除确认也不该只靠红色和一次闪烁。界面应把注意力导向下一步：字段错误让焦点和帮助文本回到具体输入；删除确认让目标名称、影响数量和撤销策略同时可读；权限变更让旧规则、新规则和受影响对象并列出现。动效的节奏随风险提高而更有停顿，信息的证据也随风险提高而更完整。",
+            "A risk map also prevents over-performance. A small input error does not need the whole page to shake, and a genuine deletion confirmation should not rely on red alone and one flash. Direct attention to the next step: field errors return focus and help text to the input; deletion confirmation makes the target name, impact count, and undo policy readable together; permission changes place old rule, new rule, and affected objects side by side. As risk rises, motion earns a clearer pause and information earns fuller evidence."
+          )
+        ]
+      },
+      {
+        id: "validation",
+        title: text("表单校验贴着输入发生", "Make validation happen beside the input"),
+        paragraphs: [
+          text(
+            "好的行内校验从用户行为开始，而不是从错误状态开始。用户输入、离开字段、点击提交，三个时机需要不同策略。输入过程中优先给格式和要求的前瞻提示；离开字段时可以确认完整性；提交时再集中处理遗漏项，并把焦点带到第一个需要处理的地方。这样用户不会在每敲一个字符时被打断，也不会在提交后面对一串没有顺序的红字。每条提示都应说明问题、修正方式和修正后的预期。",
+            "Good inline validation begins with user behavior rather than the error state. Typing, leaving a field, and submitting require different strategies. While typing, offer anticipatory format and requirement guidance; on blur, confirm completeness; on submit, gather missing items and move focus to the first one that needs action. People are then neither interrupted on every character nor left with an unordered wall of red copy after submission. Each message should state the problem, the correction, and the expected result."
+          ),
+          text(
+            "动效只需帮助定位。字段边界可以在 120 到 180 毫秒内改变，错误图标和说明可在原位置显现，输入光标保持可编辑。一次极短的横向提醒适合提交后的单个错误，连续晃动会让错误本身变得比修正方案更抢眼。多个错误同时出现时，用清晰的文档顺序、错误摘要和逐项焦点导航代替逐个动画。低动态路径保留边界、说明和焦点，把额外位移移除。",
+            "Motion only needs to help locate the issue. A field boundary can change over 120 to 180 milliseconds, an error icon and explanation can appear in place, and the input remains editable. One very short horizontal cue can suit a single post-submit error; repeated shaking makes the error more prominent than the correction. When several errors appear together, use clear document order, an error summary, and stepwise focus navigation instead of animating every field. The low-motion path keeps boundary, explanation, and focus while removing extra travel."
+          )
+        ]
+      },
+      {
+        id: "deletion",
+        title: text("删除需要对象、承诺和恢复", "Deletion needs object, commitment, and recovery"),
+        paragraphs: [
+          text(
+            "删除流程的第一责任是确认对象。确认层里应出现项目名称、相关数量、不可恢复的内容和保留内容；当对象的名称相近时，还可补充头像、缩略图或路径。用户按下删除后，原列表里的项目可以进入处理中状态，避免看起来像点击无效。服务器确认后，再让项目离开列表，并在原位置或邻近位置留下撤销入口。整个过程讲的是同一件事，不同区域的状态要同步，而不是各自播放一段漂亮动画。",
+            "The first responsibility of a deletion flow is confirming the object. The confirmation layer should show the item name, related count, irreversible content, and content that remains; similar names can be disambiguated with an avatar, thumbnail, or path. After Delete is pressed, the original list item can enter a processing state so the click never looks ignored. After the server confirms, let the item leave the list and retain an Undo action in or near the original position. The flow describes one event, so states across regions should stay synchronized rather than each playing an attractive animation."
+          ),
+          text(
+            "按住确认适合代价高、误触概率高的操作，因为它把承诺变成一段可见的时间。进度填充要始终贴着手指或指针的来源，松开后立即取消，不要留下模糊的半完成状态。它不能取代文本说明：用户仍要知道删掉的是谁、能否恢复、多久后彻底清除。对于可撤销的归档或移除，撤销窗口应该稳定地停留足够久，并在窗口关闭前让用户完成其他任务；不要用短暂浮层逼迫用户立刻做决定。",
+            "Hold-to-confirm suits actions with high cost and a high chance of accidental activation because it turns commitment into visible time. Progress fill should stay attached to the finger or pointer origin and cancel immediately on release, leaving no ambiguous half-complete state. It does not replace textual explanation: people still need to know what is removed, whether recovery is possible, and when permanent removal happens. For reversible archive or remove actions, the undo window should remain stable long enough for people to continue other work; a fleeting overlay should not force an immediate decision."
+          )
+        ]
+      },
+      {
+        id: "permissions",
+        title: text("权限变化要展示范围，而非只更新标签", "Show permission scope instead of updating one label"),
+        paragraphs: [
+          text(
+            "权限设置的困难来自不可见的受影响对象。把“仅受邀成员”改为“拥有链接的任何人”时，界面需要同时说明访问者、可见内容、链接行为和保存后的结果。选择控件附近可以立即更新解释文案，确认保存时则把最终规则放到页面状态区，并更新成员或共享列表中的相关标记。用户看到的是一条可追踪的规则变化，而不是一个孤立的下拉框选择。",
+            "Permission settings are difficult because affected objects are often invisible. When a rule changes from invited members only to anyone with the link, the interface needs to explain visitors, visible content, link behavior, and the result after saving. Copy near the choice can update immediately; on confirmation, place the final rule in the page status area and update related markers in members or sharing lists. People see a traceable rule change rather than an isolated dropdown choice."
+          ),
+          text(
+            "权限的视觉层级应当和影响范围一致。只影响当前文档的角色调整可以在原处确认；影响整个工作区、公开链接或外部邀请的选择，应当获得更明确的总结和可回退路径。颜色可以帮助区分状态，完整句子负责说明谁会受到影响。对于实时协作产品，还要处理并发：当其他管理员同时修改规则时，页面需要说明本地选择是否仍有效、保存会覆盖什么、以及怎样重新载入最新状态。动效在这里负责让冲突和更新被看见，绝不掩盖它们。",
+            "Permission hierarchy should match scope. A role adjustment that affects one document can confirm in place; a choice affecting a workspace, public link, or external invitations deserves a clearer summary and a route back. Color helps distinguish states while complete sentences explain who is affected. Collaborative products must also handle concurrency: if another administrator changes the rule, explain whether the local choice remains valid, what saving would overwrite, and how to reload the latest state. Motion makes conflict and update visible; it should never hide either one."
+          )
+        ]
+      },
+      {
+        id: "review",
+        title: text("用失败路径验收边界交互", "Review boundary interactions through failure paths"),
+        paragraphs: [
+          text(
+            "真正的验收从失败开始。让校验接口返回延迟和错误，观察用户是否知道当前字段仍可编辑；让删除请求失败，确认对象没有提前消失且错误落在原操作附近；让权限保存发生冲突，检查页面是否保留了用户选择并给出明确下一步。再加入网络离线、键盘操作、窄屏和低动态偏好。每一种异常都验证同一个原则：风险越高，界面越要把原因、当前状态和恢复动作留在同一上下文里。",
+            "Real review begins with failure. Return delay and error from validation services and observe whether people know the field is still editable; fail a deletion request and confirm the object has not vanished early and the error lands near the original action; create a permission-save conflict and check that the page retains the person’s choice and offers a clear next step. Add offline networking, keyboard operation, narrow screens, and low-motion preference. Every exception tests one principle: as risk rises, the interface keeps cause, current state, and recovery action in the same context."
+          ),
+          text(
+            "团队也应记录哪些反馈是“承诺前”、哪些是“承诺中”、哪些是“承诺后”。承诺前的提示帮助理解后果；承诺中的反馈防止重复操作；承诺后的结果负责恢复任务节奏。这个分层能让设计、产品和工程对同一个交互使用相同语言，并减少把警告、加载和成功信息堆在一个组件里的冲动。当一个页面的边界操作都能被这样描述，动效规范就已经接近可复用的产品规则。",
+            "Teams should record which feedback happens before commitment, during commitment, and after commitment. Before-commitment guidance explains consequences; during-commitment feedback prevents duplicate work; after-commitment result restores task rhythm. This framing gives design, product, and engineering a shared language and reduces the urge to pile warning, loading, and success into one component. When every boundary interaction on a page can be described this way, the motion spec is close to a reusable product rule."
+          )
+        ]
+      }
+    ],
+    checklistTitle: text("高风险交互发布清单", "High-risk interaction shipping checklist"),
+    checklist: [
+      { id: "object", label: text("确认层明确对象与影响", "Confirmation names the object and impact"), detail: text("名称、数量、范围和可恢复性同时可读。", "Name, count, scope, and recoverability are readable together.") },
+      { id: "field", label: text("错误贴着字段并保留编辑焦点", "Errors stay beside the field and retain editing focus"), detail: text("提示解释问题、修正方式和预期结果。", "The message explains the issue, correction, and expected result.") },
+      { id: "pending", label: text("处理中状态阻止重复承诺", "Processing state prevents duplicate commitment"), detail: text("按钮、原对象和状态区同步说明进行中。", "Button, original object, and status region communicate progress together.") },
+      { id: "recovery", label: text("失败和撤销入口留在原上下文", "Failure and undo stay in the original context"), detail: text("用户无需重新寻找对象或回忆刚才做了什么。", "People do not have to relocate the object or remember what they just did.") },
+      { id: "scope", label: text("权限变化展示受影响范围", "Permission changes show affected scope"), detail: text("旧规则、新规则和受影响成员或内容可被比较。", "Old rule, new rule, and affected people or content can be compared.") }
+    ],
+    caseStudy: {
+      title: text("案例：删除项目后保留可恢复的任务节奏", "Case: preserve task rhythm after deleting a project"),
+      context: text("项目列表中的删除动作需要确认对象、等待服务器、更新列表并给出撤销机会。", "A project-list deletion must confirm the object, await the server, update the list, and offer an undo opportunity."),
+      code: deletionInteractionRuntimeExample,
+      explanation: text("列表项只有在服务端确认后才离开。两条路径都保留状态文字和撤销入口；默认路径额外加入极短的离开反馈，低动态路径直接更新结果。", "The list row leaves only after server confirmation. Both paths retain status copy and Undo; the default path adds a very short exit cue while the low-motion path updates the result directly.")
+    },
+    diagrams: [
+      {
+        id: "risk-map",
+        title: text("图解一：按后果安排反馈", "Diagram 1: assign feedback by consequence"),
+        alt: text("四种后果从可立即修正到影响他人，分别对应字段提示、撤销、明确确认和范围摘要。", "Four consequences range from immediate correction to affecting others, mapping to field help, undo, explicit confirmation, and scope summary."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("correct", "可立即修正", "Immediately correctable", "字段提示", "Field help", 55, 220, 190, 100, "surface"),
+          node("undo", "可撤销", "Reversible", "原位撤销", "Undo in place", 275, 220, 190, 100, "accent"),
+          node("commit", "需要承诺", "Requires commitment", "对象 + 后果", "Object + consequence", 495, 220, 190, 100, "warning"),
+          node("others", "影响他人", "Affects others", "范围摘要", "Scope summary", 715, 220, 190, 100, "ink")
+        ],
+        connectors: [
+          { from: "correct", to: "undo", label: text("风险上升", "Risk rises") },
+          { from: "undo", to: "commit" },
+          { from: "commit", to: "others" }
+        ]
+      },
+      {
+        id: "commitment-timeline",
+        title: text("图解二：承诺前、中、后的反馈", "Diagram 2: feedback before, during, and after commitment"),
+        alt: text("删除动作依次展示后果说明、处理中状态和删除结果与撤销入口。", "A deletion shows consequence guidance, processing state, then result and undo."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("before", "承诺前", "Before commitment", "名称、影响、选择", "Name, impact, choice", 80, 205, 210, 110, "warning"),
+          node("during", "承诺中", "During commitment", "处理中、防重复", "Processing, prevent repeats", 375, 205, 210, 110, "accent"),
+          node("after", "承诺后", "After commitment", "结果、撤销、继续", "Result, undo, continue", 670, 205, 210, 110, "success")
+        ],
+        connectors: [{ from: "before", to: "during" }, { from: "during", to: "after" }]
+      },
+      {
+        id: "permission-scope",
+        title: text("图解三：权限变化的范围证据", "Diagram 3: evidence for a permission scope change"),
+        alt: text("旧规则、新规则、受影响对象和保存结果组成可比较的权限变化说明。", "Old rule, new rule, affected objects, and saved result create a comparable permission-change explanation."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("old", "旧规则", "Old rule", "仅受邀成员", "Invited members only", 80, 90, 300, 105, "surface"),
+          node("new", "新规则", "New rule", "拥有链接的任何人", "Anyone with the link", 580, 90, 300, 105, "warning"),
+          node("affected", "受影响对象", "Affected objects", "成员、链接、可见内容", "Members, links, visible content", 330, 250, 300, 105, "ink"),
+          node("saved", "保存结果", "Saved result", "状态区中的最终规则", "Final rule in status area", 330, 400, 300, 80, "success")
+        ],
+        connectors: [{ from: "old", to: "affected" }, { from: "new", to: "affected" }, { from: "affected", to: "saved" }]
+      }
+    ]
+  },
+  {
+    guideId: "from-brief-to-spec",
+    standfirst: text(
+      "一句“自然一点”可以成为讨论的起点，不能成为交付标准。可实现的动效规格把感觉翻译为对象、状态、触发、空间、时间、可打断性和低动态规则，让设计判断能被开发、测试和后续迭代共同使用。",
+      "A line such as “make it feel more natural” can start a conversation; it cannot be a delivery standard. A buildable motion spec translates feeling into object, state, trigger, space, time, interruptibility, and low-motion rules so design judgment can be shared by implementation, testing, and later iteration."
+    ),
+    sections: [
+      {
+        id: "brief",
+        title: text("把形容词变成可观察的事件", "Turn adjectives into observable events"),
+        paragraphs: [
+          text(
+            "“高级”“有重量”“丝滑”描述的是感受，却没有说明界面里发生了什么。规格工作的第一步是追问可观察的事件：谁触发了变化，哪个对象改变，用户在变化前后分别能看见什么，结果需要被理解多久。比如“卡片出来时有一个动作再慢慢停下来”，可以拆成卡片从触发器附近进入、先快速到达、末段减速、最终边界与标题保持清晰。这样团队讨论的是状态和节奏，不会停留在每个人心里不同的审美词。",
+            "Words such as polished, weighty, and smooth describe feeling without describing what happens in an interface. The first step of a spec is to ask for observable events: who triggers the change, which object changes, what people can see before and after, and how long the result needs to be understood. “A card arrives with an action and gradually stops” can become a card entering near its trigger, arriving quickly, decelerating near the end, and retaining a clear boundary and title. The team then discusses states and rhythm instead of private interpretations of aesthetic words."
+          ),
+          text(
+            "用前后状态命名也能识别缺失信息。一个发布按钮常常至少有草稿、发布中、已发布、发布失败四种状态；如果需求只写“点击后播一个成功动画”，它遗漏了等待、失败和重复点击。把状态列成表后，每一行都有可见文案、允许操作、无障碍通知和视觉线索。规格因此从一个效果说明变成一份小型行为契约，开发可以据此搭建状态机，测试也能据此设计断言。",
+            "Naming before and after states also reveals missing information. A publish button commonly has at least Draft, Publishing, Published, and Publish failed; a request that says only “play a success animation after click” misses waiting, failure, and repeat activation. Once states sit in a table, each row has visible copy, allowed actions, accessibility announcement, and visual cue. The spec becomes a compact behavior contract: engineering can build a state machine from it and testing can write assertions from it."
+          )
+        ]
+      },
+      {
+        id: "state",
+        title: text("先写状态图，再写关键节拍", "Write the state graph before key beats"),
+        paragraphs: [
+          text(
+            "状态图回答“允许从哪里到哪里”，节拍表回答“在什么时间让什么被看见”。两者分开能避免一个常见问题：看起来很顺的时间线无法处理用户中途点击、网络变慢或请求失败。先画出合法转换，例如 Draft → Publishing → Published，Publishing 也可以回到 Failed；再为每条转换写关键节拍，例如 0ms 锁定按钮并确认输入、80ms 显示处理中、服务端返回后切换最终状态。节拍只描述需要被感知的节点，避免把每一帧都写进文档。",
+            "A state graph answers which transitions are allowed; a beat plan answers what becomes visible when. Keeping them separate prevents a common failure: a lovely timeline that cannot handle a second click, a slow network, or a failed request. Draw legal transitions first, such as Draft to Publishing to Published, with Publishing also able to move to Failed. Then write key beats for each transition: at 0ms lock the button and acknowledge input, at 80ms show processing, and after the server returns switch the final state. Beats describe perceptible nodes rather than documenting every frame."
+          ),
+          text(
+            "节拍的数量应随信息复杂度增加，而非随装饰欲增加。保存确认可能只需要“按下—处理中—已保存”三个节点；审批请求需要额外展示审批人队列，因为用户要理解系统正在等待谁。对于多个元素，明确谁先变化、谁跟随、谁保持静止。静止经常是重要的设计选择：它给用户提供锚点，让新增内容、结果数字或状态标签有地方可以被比较。一个好的规格会写出应当保持不动的内容。",
+            "The number of beats should increase with information complexity, not decorative ambition. Save confirmation may need only Pressed, Saving, and Saved; an approval request needs the approver queue because people must understand whom the system is awaiting. For several elements, state who changes first, who follows, and who stays still. Stillness is often an important design choice: it gives an anchor against which a new row, result number, or status label can be compared. A good spec explicitly names what should remain still."
+          )
+        ]
+      },
+      {
+        id: "space-time",
+        title: text("用空间和时间描述感觉", "Describe feeling through space and time"),
+        paragraphs: [
+          text(
+            "空间规格至少包括来源、目的地、距离和层级。来源告诉用户变化为何发生在这里；目的地告诉用户结果属于哪里；距离决定动作是否会抢走注意力；层级决定覆盖、推开还是并列。把“从左边滑进来”换成“从当前筛选器下方进入结果区域，位移不超过 16px，结果计数保持原位”，开发就能判断使用 transform、插入新行还是替换现有内容，设计也能判断动作是否仍遵循界面结构。",
+            "A spatial spec includes origin, destination, distance, and hierarchy. Origin tells people why change occurs here; destination tells them where the result belongs; distance determines whether motion steals attention; hierarchy decides whether content overlays, pushes, or sits beside other content. Replace “slide in from the left” with “enter the result region beneath the active filter, travel no more than 16px, and keep the result count in place.” Engineering can then choose transform, inserting a row, or replacing existing content, while design can judge whether the action still follows interface structure."
+          ),
+          text(
+            "时间规格要同时写时长和关系。单个数值如 240ms 只能说明一段变化有多长，不能说明按钮和状态标签是否同步、列表是否在结果落定后再出现、失败是否应打断进行中提示。写成“按钮反馈 120ms；状态文案在 80ms 后出现；成功结果在请求完成时切换；后续记录延迟 60ms”会更清晰。再补上曲线的职责：ease-out 用于明确落点，spring 用于连续输入或可中断对象。曲线名称只是实现选择，用户感知到的是抵达、停顿和衔接。",
+            "A time spec needs both duration and relationships. A lone value such as 240ms says how long one change lasts, while saying nothing about whether a button and status label synchronize, whether a list appears after the result settles, or whether failure interrupts processing. “Button feedback: 120ms; status copy appears after 80ms; success switches when the request completes; follow-up record delays 60ms” is clearer. Add the job of the curve: ease-out supports a definite arrival, while spring supports continuous input or interruptible objects. Curve names are implementation choices; people perceive arrival, pause, and continuity."
+          )
+        ]
+      },
+      {
+        id: "failure",
+        title: text("把中断、失败和低动态写进同一份规格", "Put interruption, failure, and low motion in the same spec"),
+        paragraphs: [
+          text(
+            "动效规格常在成功路径结束，这会让真正上线后的边界情况临时拼凑。每个进行中状态都要回答：用户再次点击会怎样，离开页面会怎样，网络超时会怎样，返回的数据过期会怎样。对于可取消请求，取消后的视觉状态应回到一个明确起点；对于不可取消请求，按钮和文案要说明正在完成什么。失败状态必须保留原始输入或可恢复上下文，避免用户既看见失败又失去之前填的内容。",
+            "Motion specs often end at the success path, forcing edge cases to be improvised after launch. Every in-progress state should answer: What happens on another click? On leaving the page? On timeout? When returned data is stale? For cancelable work, the visual state should return to a clear starting point; for noncancelable work, button and copy should explain what is completing. A failure state must retain the original input or recoverable context so people do not see failure and lose their previous work at the same time."
+          ),
+          text(
+            "低动态规则同样属于状态定义。写“减少动效”不够，需要说明哪些信号保留、哪些位移缩短、哪些循环停止、焦点如何管理。对发布流程而言，低动态版本仍然保留按钮状态、发布结果和记录插入，只移除沿路径移动和装饰性旋转。把这条规则写进每个关键转换，研发就不会把它视为发布前的附加修补。它也会让默认路径更清楚，因为团队被迫说明每一段动画实际在传递什么。",
+            "Low-motion rules also belong in state definitions. “Reduce motion” is too vague; state which signals remain, which travel shortens, which loops stop, and how focus is managed. In a publishing flow, the low-motion version still retains button state, publishing result, and record insertion while removing travel along a path and decorative rotation. Put that rule on every key transition so it never becomes a last-minute patch. It also clarifies the default path because the team must state what every animation actually communicates."
+          )
+        ]
+      },
+      {
+        id: "handoff",
+        title: text("让规格成为可交接、可测试的资产", "Make the spec an asset for handoff and testing"),
+        paragraphs: [
+          text(
+            "一份可交接的规格应让没有参与讨论的人也能复现判断。开头写场景、目标用户和成功标准；中间给出状态图、节拍、空间关系和参数范围；结尾列出失败、撤销、低动态和验收方法。附上一个静态图或可交互原型会帮助沟通，但图本身无法替代文字，因为测试需要知道何时断言、开发需要知道数据何时更新、内容设计需要知道文案如何变化。文字、图解和代码片段共同构成一个可追溯的决定。",
+            "A handoff-ready spec lets someone who missed the conversation reproduce the judgment. Start with scenario, audience, and success criteria; give state graph, beats, spatial relationships, and parameter ranges in the middle; close with failure, undo, low-motion behavior, and review methods. A static diagram or interactive prototype helps communication, yet an image cannot replace words: tests need to know when to assert, engineering needs to know when data updates, and content design needs to know how copy changes. Text, diagram, and code fragment together create a traceable decision."
+          ),
+          text(
+            "验收语句要可观察。与其写“感觉顺滑”，可以写“点击发布后 120ms 内出现进行中状态；完成后按钮、状态标记和时间线记录在同一轮状态更新中变为已发布；低动态模式没有超过 1px 的装饰性位移；失败时标题、正文和重试入口仍保留”。这样的标准既允许设计保有判断空间，也能让自动化测试和人工评审围绕同一组事实工作。规格因此会反哺内容库：每一份经过验证的场景都可能成为新的 Product Moment。",
+            "Acceptance statements should be observable. Instead of “feel smooth,” write: “Within 120ms of Publish, show an in-progress state; when complete, button, status marker, and timeline record become Published in the same state update; low-motion mode uses no decorative travel over 1px; on failure, title, body copy, and retry remain.” Such standards preserve room for design judgment while giving automation and human review the same facts. The spec then feeds the content library: every verified scenario can become a future Product Moment."
+          )
+        ]
+      }
+    ],
+    checklistTitle: text("动效规格交接清单", "Motion-spec handoff checklist"),
+    checklist: [
+      { id: "goal", label: text("写清场景、用户与要理解的结果", "State scenario, audience, and result to understand"), detail: text("先让动效服务任务，再讨论视觉性格。", "Let motion serve the task before discussing visual character.") },
+      { id: "states", label: text("列出前后状态与合法转换", "List before/after states and legal transitions"), detail: text("包含等待、失败、撤销和重复输入。", "Include waiting, failure, undo, and repeat input.") },
+      { id: "beats", label: text("写出关键节拍与同步关系", "Write key beats and synchronization"), detail: text("说明谁先变化、谁保持静止、何时更新数据。", "State who changes first, who stays still, and when data updates.") },
+      { id: "space", label: text("标注来源、目的地、距离与层级", "Mark origin, destination, distance, and hierarchy"), detail: text("让空间关系能直接映射到实现方式。", "Make spatial relationships map directly to implementation.") },
+      { id: "review", label: text("给出低动态和可观察验收语句", "Provide low-motion rules and observable acceptance"), detail: text("交接后任何人都能验证结果。", "Anyone can verify the result after handoff.") }
+    ],
+    caseStudy: {
+      title: text("案例：把“卡片出来再慢慢停下来”写成规格", "Case: turn “the card arrives and gradually stops” into a spec"),
+      context: text("筛选结果出现时，产品希望新卡片有进入感，同时不抢走用户对结果数量的阅读。", "When filtered results appear, the product wants the new card to feel introduced without stealing attention from the result count."),
+      code: `Trigger: filter value changes after input settles\nStates: previous results → updating → filtered results\nSpace: new cards enter from the result region, translateY(12px) maximum\nBeats: 0ms update count; 40ms reveal first visible row; 60ms stagger only the next two rows\nCurve: cubic-bezier(.23, 1, .32, 1)\nReduced motion: update count and rows in place; no travel; preserve live-region announcement`,
+      explanation: text("规格把“慢慢停下来”落实为 12px 上限、明确曲线、有限的三行节拍和原位低动态路径。结果数量保持原位，因此用户始终有稳定锚点。", "The spec turns “gradually stops” into a 12px cap, named curve, limited three-row beat plan, and in-place low-motion path. The result count stays fixed, giving people a stable anchor throughout.")
+    },
+    diagrams: [
+      {
+        id: "brief-to-event",
+        title: text("图解一：从感受词到可观察事件", "Diagram 1: from feeling words to observable events"),
+        alt: text("“自然一点”经过对象、状态、空间和时间四个问题，形成可实现的规格。", "“Make it feel natural” passes through object, state, space, and time questions to become a buildable spec."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("brief", "自然一点", "Make it natural", "感受词", "Feeling word", 55, 215, 180, 100, "warning"),
+          node("object", "哪个对象", "Which object", "卡片、按钮、记录", "Card, button, record", 285, 215, 180, 100, "surface"),
+          node("states", "哪些状态", "Which states", "前后与失败", "Before, after, failure", 515, 215, 180, 100, "accent"),
+          node("spec", "动效规格", "Motion spec", "空间、时间、低动态", "Space, time, low motion", 745, 215, 180, 100, "success")
+        ],
+        connectors: [{ from: "brief", to: "object" }, { from: "object", to: "states" }, { from: "states", to: "spec" }]
+      },
+      {
+        id: "state-and-beats",
+        title: text("图解二：状态图与节拍表分工", "Diagram 2: state graph and beat plan have distinct jobs"),
+        alt: text("状态图显示草稿、发布中、已发布和失败；节拍表显示输入确认、进行中和结果出现的时间。", "A state graph shows draft, publishing, published, and failed; a beat plan shows input acknowledgement, processing, and result timing."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("draft", "草稿", "Draft", "可编辑", "Editable", 90, 210, 150, 90, "surface"),
+          node("publishing", "发布中", "Publishing", "锁定重复提交", "Prevent repeats", 335, 210, 170, 90, "accent"),
+          node("published", "已发布", "Published", "结果落定", "Result settled", 690, 110, 170, 90, "success"),
+          node("failed", "发布失败", "Publish failed", "保留重试", "Keep retry", 690, 330, 170, 90, "warning")
+        ],
+        connectors: [{ from: "draft", to: "publishing", label: text("0ms", "0ms") }, { from: "publishing", to: "published", label: text("请求完成", "Request complete") }, { from: "publishing", to: "failed", label: text("失败", "Failure") }]
+      },
+      {
+        id: "handoff-asset",
+        title: text("图解三：可交接规格的组成", "Diagram 3: parts of a handoff-ready spec"),
+        alt: text("场景、状态、空间与时间、失败与低动态、验收五部分组成可交接的动效规格。", "Scenario, states, space and time, failure and low motion, and review form a handoff-ready motion spec."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("scenario", "场景与目标", "Scenario and goal", "为什么需要变化", "Why change is needed", 375, 60, 210, 85, "ink"),
+          node("behavior", "状态与节拍", "States and beats", "允许的转换", "Allowed transitions", 665, 190, 210, 85, "accent"),
+          node("space", "空间与时间", "Space and time", "来源、距离、关系", "Origin, distance, relation", 555, 375, 210, 85, "surface"),
+          node("edges", "失败与低动态", "Failure and low motion", "中断与恢复", "Interrupt and recover", 195, 375, 210, 85, "warning"),
+          node("review", "验收", "Review", "可观察断言", "Observable assertions", 85, 190, 210, 85, "success")
+        ],
+        connectors: [{ from: "scenario", to: "behavior" }, { from: "behavior", to: "space" }, { from: "space", to: "edges" }, { from: "edges", to: "review" }, { from: "review", to: "scenario" }]
+      }
+    ]
+  },
+  {
+    guideId: "pack-or-primitive",
+    standfirst: text(
+      "Product Moment 和 Motion Primitive 是两种平级的设计入口。前者交付一段真实产品交互，后者交付一个可复用行为和它的边界。选择起点取决于问题的完整度、现有界面的约束和你需要保留多少设计控制力。",
+      "Product Moments and Motion Primitives are two peer design entry points. The former delivers a real product interaction; the latter delivers a reusable behavior and its boundaries. Choose a starting point from the completeness of the problem, existing interface constraints, and how much design control you need to retain."
+    ),
+    sections: [
+      {
+        id: "two-levels",
+        title: text("理解两种入口各自解决什么", "Understand what each entry point solves"),
+        paragraphs: [
+          text(
+            "Motion Primitive 解决一个清楚的行为问题，例如淡入、滑入、交错、缓动、按压反馈或减弱动效。它适合团队已经知道对象、状态和界面结构，只需要为某个局部变化选择合适规则的时刻。Primitive 的价值在于边界清楚：它告诉你什么时候适合用、参数如何调整、会和哪些相近动作混淆、如何在低动态模式下保持意义。它让局部决定可被复用，也让设计系统拥有共同语言。",
+            "A Motion Primitive solves one clear behavior problem: fade, slide, stagger, easing, press feedback, or reduced motion. It suits moments when a team already knows the object, state, and interface structure and needs a rule for one local change. Its value is clear boundaries: when it fits, how to tune parameters, which neighboring behaviors it can be confused with, and how low-motion mode retains meaning. It makes local decisions reusable and gives a design system a shared language."
+          ),
+          text(
+            "Product Moment 解决一个完整场景，例如保存确认、删除确认、筛选结果、权限变更或审批请求。它把触发器、等待、结果、关联对象和恢复路径组织成一段可运行的交互。Moment 的价值在于让人先看到整体：保存不只是一条 press feedback，还是按钮、状态标记、内容状态和可能的失败提示共同构成的结果。它适合需求已经带有多个状态和多个参与对象，团队希望快速拥有一个经过推敲的骨架。",
+            "A Product Moment solves a complete scenario: save confirmation, deletion confirmation, filtered results, permission change, or approval request. It organizes trigger, waiting, result, related objects, and recovery into one working interaction. Its value is seeing the whole: saving is more than press feedback; it is the joint result of button, status marker, content state, and possible failure guidance. It suits requirements with several states and actors when a team wants a considered skeleton quickly."
+          )
+        ]
+      },
+      {
+        id: "choose",
+        title: text("按问题完整度选择起点", "Choose the starting point by problem completeness"),
+        paragraphs: [
+          text(
+            "先问问题能否用一句状态转换说清。若答案是“按钮变为已保存”“一张卡片从当前位置进入”“数字在原位更新”，从 Primitive 开始通常更有效，因为你需要的主要是一个局部规则。若答案包含“用户提交后等待服务端、页面顶部状态改变、列表新增记录、失败后能重试”，它已经是一个 Moment。此时从完整场景开始能帮助团队发现遗漏的状态，再回到其中的基础动效做细调。",
+            "Ask whether the problem can be explained as one state transition. If the answer is “the button becomes Saved,” “a card enters from its current context,” or “a number updates in place,” start with a Primitive because the main need is a local rule. If the answer includes “after submission, wait for the server, change top-of-page status, add a list record, and allow retry after failure,” it is already a Moment. Starting from the complete scenario helps reveal missing states, then you can refine the primitives inside it."
+          ),
+          text(
+            "再问是否已有可靠的产品结构。一个成熟的设置页可能已经有清楚的字段、保存栏和状态区，团队只需为错误或确认加上局部反馈；一个新工作流则往往缺少状态区、恢复路径和信息层级，直接选择 Pack 会更快得到可讨论的整体。选择 Pack 并不意味着照搬视觉。把它当作交互的状态模板，保留业务对象、品牌语言和现有导航结构；选择 Primitive 也不意味着只做一个孤立效果，它仍要回到页面里验证焦点、空间关系和可访问性。",
+            "Then ask whether a reliable product structure already exists. A mature settings page may already have clear fields, save bar, and status area, so the team only needs local error or confirmation feedback. A new workflow often lacks status area, recovery path, and information hierarchy, making a Pack a faster whole to discuss. Choosing a Pack does not mean copying its visual style. Treat it as an interaction state template while retaining business objects, brand language, and existing navigation. Choosing a Primitive does not mean creating an isolated effect; it still returns to the page to validate focus, spatial relationship, and accessibility."
+          )
+        ]
+      },
+      {
+        id: "adapt",
+        title: text("从 Pack 拆出基础规则，再把规则装回界面", "Extract primitives from a Pack, then fit them back into the interface"),
+        paragraphs: [
+          text(
+            "采用 Pack 的高效方式是先保留它的状态序列，再逐项检查其中的基础动作。以保存确认举例：输入反馈告诉用户点击已收到，状态文本切换告诉用户正在保存或已保存，短暂的加载循环只在等待期间出现，顶部状态标记和文档内容在完成时同步更新。团队可以保留这条因果链，同时把 press 的力度、文本切换的速度、状态标记的位置换成自己的设计系统。Pack 提供的是结构，Primitive 提供的是每个结构节点的精确控制。",
+            "An efficient way to adopt a Pack is to retain its state sequence and inspect the primitive actions inside it. Take save confirmation: input feedback says the click was received, state-copy change says Saving or Saved, a brief loading loop appears only while waiting, and top status marker and document content update together on completion. A team can keep that causal chain while changing press strength, copy-switch speed, and status-marker position to fit its own design system. The Pack provides structure; Primitives provide precise control at each structural node."
+          ),
+          text(
+            "反向使用也很重要。当团队从一个 Primitive 开始，例如只想给筛选后的卡片增加淡入，应该顺手问：结果数量是否也要更新？旧卡片如何离开？用户是否需要知道筛选条件仍然生效？如果回答引入了多个对象和连续状态，就值得打开 Filter results 这样的 Moment 作为检查表。这个来回过程让组件库和产品瞬间互相供给：基础规则避免 Pack 变成黑盒，真实场景避免 Primitive 漂在脱离业务的演示里。",
+            "The reverse use matters as well. When a team starts from one Primitive, such as adding a fade to filtered cards, ask immediately: Should result count update too? How do old cards leave? Does the person need to know the filter remains active? If answers introduce several objects and sequential states, open a Moment such as Filter results as a checklist. This back-and-forth lets the libraries feed each other: basic rules keep Packs from becoming black boxes, while real scenarios keep Primitives from floating in a demo detached from product work."
+          )
+        ]
+      },
+      {
+        id: "control",
+        title: text("用控制范围决定定制深度", "Use control scope to decide customization depth"),
+        paragraphs: [
+          text(
+            "定制可以分成三层。第一层是换内容：名称、颜色、文案、数据与品牌语气改变，交互状态保持；第二层是换规则：时长、曲线、出现顺序、撤销窗口与低动态策略改变；第三层是换结构：触发器、参与对象、状态图和恢复路径改变。第一层通常直接采用 Pack 最省力，第二层需要回到关联 Primitives 做精调，第三层更适合从场景规格重新开始。提前说清处在哪一层，能避免“只改一点”最后变成重写整套交互。",
+            "Customization has three levels. First, change content: names, color, copy, data, and brand voice change while interaction states remain. Second, change rules: duration, curve, reveal order, undo window, and low-motion strategy change. Third, change structure: trigger, actors, state graph, and recovery path change. The first level usually adopts a Pack efficiently, the second returns to related Primitives for tuning, and the third is better served by a new scene spec. Naming the level early prevents “just a small change” from turning into a full interaction rewrite."
+          ),
+          text(
+            "控制范围还包括技术边界。若产品只能使用原生 HTML、CSS 和少量 JavaScript，应选择能在这些约束内稳定运行的 Pack，并确认代码的状态源和事件绑定容易迁移；若组件本身是现有设计系统的一部分，Primitive 的 CSS 变量、参数范围和无障碍规则可能更适合直接嵌入。无论从哪里开始，最终都要保留可复制的实现说明、浏览器兼容性判断和 `prefers-reduced-motion` 路径。可移植性本身就是设计质量的一部分。",
+            "Control scope also includes technical boundaries. When a product can use only native HTML, CSS, and a small amount of JavaScript, choose a Pack that runs reliably within those constraints and confirm its state source and event bindings migrate cleanly. When a component belongs to an existing design system, a Primitive’s CSS variables, parameter ranges, and accessibility rules may embed more directly. Whatever the starting point, retain copy-ready implementation guidance, browser-compatibility judgment, and a `prefers-reduced-motion` path. Portability itself is part of design quality."
+          )
+        ]
+      },
+      {
+        id: "workflow",
+        title: text("建立两条目录之间的工作流", "Build a workflow between the two directories"),
+        paragraphs: [
+          text(
+            "实际工作中可以采用一个简单循环：先用一句话描述产品场景；判断它是局部行为还是完整流程；从对应目录打开一个参考；把参考中的状态、参数和限制写入当前项目；在真实界面里预览；把经过验证的改动回馈为新的 Pack 候选或 Primitive 说明。这个循环让内容库持续贴近真实问题，也避免团队把目录当成一次性灵感板。每次复用都留下新的判断证据。",
+            "In practice, use a simple loop: describe the product scene in one sentence; decide whether it is a local behavior or a complete flow; open a reference from the matching directory; bring its states, parameters, and boundaries into the current project; preview in the real interface; feed the verified change back as a Pack candidate or Primitive note. The loop keeps the library close to real problems and prevents it from becoming a one-time inspiration board. Every reuse leaves new evidence for future judgment."
+          ),
+          text(
+            "评审时同时看两件事：这段交互是否帮助用户理解当前任务，这条基础规则是否还能在别处复用。前一个问题保护产品语义，后一个问题保护系统质量。若一个 Pack 被多次拆出同样的基础动作，那个动作应当获得更完整的 Primitive 文档；若多个 Primitive 总是被同一种业务场景组合，那个场景应当晋升为 Pack。这样网站的信息架构会随真实使用演化，用户也会逐渐看到一套既有审美又能落地的动效语言。",
+            "During review, look at two things together: Does this interaction help people understand the current task, and can this basic rule be reused elsewhere? The first protects product semantics; the second protects system quality. If a Pack repeatedly yields the same basic action, that action deserves fuller Primitive documentation. If several Primitives repeatedly combine in one business scenario, that scenario deserves promotion to a Pack. The site’s information architecture then evolves with real use, and people gradually encounter a motion language with both taste and practical delivery."
+          )
+        ]
+      }
+    ],
+    checklistTitle: text("选择入口清单", "Entry-point selection checklist"),
+    checklist: [
+      { id: "scope", label: text("用一句话判断问题范围", "Use one sentence to judge problem scope"), detail: text("单一状态变化优先看 Primitive；多状态流程优先看 Pack。", "A single state change points to a Primitive; a multi-state flow points to a Pack.") },
+      { id: "structure", label: text("检查现有页面是否已有可靠结构", "Check whether the page already has reliable structure"), detail: text("已有状态区和导航时更容易嵌入基础规则。", "Existing status areas and navigation make a Primitive easier to embed.") },
+      { id: "custom", label: text("明确内容、规则或结构哪一层需要改", "Name whether content, rules, or structure changes"), detail: text("不同层级对应不同的复用起点与改造成本。", "Each level maps to a different reuse point and adaptation cost.") },
+      { id: "bridge", label: text("从 Pack 追溯关联基础动效", "Trace a Pack back to its related Primitives"), detail: text("保留整体状态链，同时获得局部参数控制。", "Keep the overall state chain while gaining local parameter control.") },
+      { id: "contribute", label: text("把重复出现的真实模式回馈目录", "Feed recurring real patterns back into the directories"), detail: text("反复组合的 Primitive 可形成 Pack，反复拆出的动作可扩展 Primitive。", "Repeated Primitive combinations can form a Pack; repeatedly extracted actions can expand a Primitive.") }
+    ],
+    caseStudy: {
+      title: text("案例：筛选结果该从 Pack 还是 Primitive 开始", "Case: should filtered results start from a Pack or a Primitive?"),
+      context: text("团队最初只想让筛选后的卡片淡入，随后发现用户还要追踪筛选条件、命中数量、旧内容离开和新内容到达。", "The team initially wants filtered cards to fade in, then discovers people also need to track criteria, result count, old content leaving, and new content arriving."),
+      code: `Scenario: status filter changes in a resource library\nStart: Filter results Pack\nKeep: active filter, result count, stable list container, empty state\nTune primitives: crossfade for replacement; stagger for first three new rows; duration 160–220ms\nReduced motion: update count and rows in place, retain live-region result announcement`,
+      explanation: text("需求包含多个对象和连续状态，因此从 Filter results Pack 开始更完整。团队随后只调整其中的 crossfade、stagger 和 duration，而无需重新发明筛选语义。", "The requirement contains several objects and sequential states, so Filter results Pack provides the more complete start. The team then tunes crossfade, stagger, and duration without reinventing filtering semantics.")
+    },
+    diagrams: [
+      {
+        id: "two-entry-points",
+        title: text("图解一：两条平级入口", "Diagram 1: two peer entry points"),
+        alt: text("产品场景可以进入 Product Moment 或 Motion Primitive，两条路径都回到真实界面验证。", "A product scene can enter through a Product Moment or Motion Primitive; both paths return to validation in the real interface."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("scene", "产品场景", "Product scene", "一句真实需求", "One real request", 365, 55, 230, 90, "ink"),
+          node("pack", "Product Moment", "Product Moment", "完整状态流程", "Complete state flow", 120, 230, 260, 105, "accent"),
+          node("primitive", "Motion Primitive", "Motion Primitive", "一个行为与边界", "One behavior and boundary", 580, 230, 260, 105, "surface"),
+          node("interface", "真实界面验证", "Validate in product", "任务、性能、低动态", "Task, speed, low motion", 365, 415, 230, 80, "success")
+        ],
+        connectors: [{ from: "scene", to: "pack" }, { from: "scene", to: "primitive" }, { from: "pack", to: "interface" }, { from: "primitive", to: "interface" }]
+      },
+      {
+        id: "selection-matrix",
+        title: text("图解二：按问题完整度选择", "Diagram 2: choose by problem completeness"),
+        alt: text("单一局部行为指向 Motion Primitive，多对象多状态流程指向 Product Moment。", "One local behavior points to a Motion Primitive; a multi-actor, multi-state flow points to a Product Moment."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("local", "单一对象", "One object", "按钮、卡片、数字", "Button, card, number", 85, 100, 250, 95, "surface"),
+          node("primitive", "Motion Primitive", "Motion Primitive", "局部规则", "Local rule", 85, 345, 250, 95, "accent"),
+          node("flow", "多个对象与状态", "Multiple actors and states", "等待、结果、恢复", "Wait, result, recovery", 625, 100, 250, 95, "ink"),
+          node("pack", "Product Moment", "Product Moment", "完整交互骨架", "Complete interaction skeleton", 625, 345, 250, 95, "success")
+        ],
+        connectors: [{ from: "local", to: "primitive", label: text("局部变化", "Local change") }, { from: "flow", to: "pack", label: text("完整流程", "Complete flow") }]
+      },
+      {
+        id: "feedback-loop",
+        title: text("图解三：内容库随真实使用演化", "Diagram 3: the library evolves with real use"),
+        alt: text("真实项目验证后，重复组合的基础动效升级为产品瞬间，重复拆出的动作升级为基础动效文档。", "After real-project validation, repeated primitive combinations become Product Moments and repeated extracted actions gain Primitive documentation."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("project", "真实项目", "Real project", "场景与约束", "Scene and constraints", 385, 55, 190, 90, "ink"),
+          node("moment", "产品瞬间", "Product Moment", "验证完整流程", "Validate complete flow", 650, 220, 190, 90, "success"),
+          node("primitive", "基础动效", "Motion Primitive", "提炼局部规则", "Extract local rule", 385, 385, 190, 90, "accent"),
+          node("evidence", "复用证据", "Reuse evidence", "反馈与评审", "Feedback and review", 120, 220, 190, 90, "surface")
+        ],
+        connectors: [{ from: "project", to: "moment" }, { from: "moment", to: "primitive" }, { from: "primitive", to: "evidence" }, { from: "evidence", to: "project" }]
+      }
+    ]
+  }
+] as const satisfies readonly SeoGuideLongArticle[];
+
+export const seoGuideArticlesBById = new Map(
+  seoGuideArticlesB.map((article) => [article.guideId, article])
+);

--- a/src/data/seo-guide-articles-c.ts
+++ b/src/data/seo-guide-articles-c.ts
@@ -147,11 +147,12 @@ const drawerToggle = document.querySelector("[data-drawer-toggle]");
 const saveButton = document.querySelector("[data-save]");
 const saveStatus = document.querySelector("[data-save-status]");
 let drawerPosition = -240;
-let releaseVelocity = 0;
+let drawerVelocity = 0;
+let drawerTarget = -240;
 let lastInputTime = performance.now();
 let cancelDrawerSpring = () => {};
 
-function springTo(element, from, target, releaseVelocity = 0) {
+function springTo(element, from, target, releaseVelocity = 0, onUpdate = () => {}) {
   let position = from;
   let velocity = releaseVelocity;
   let previous = performance.now();
@@ -159,6 +160,15 @@ function springTo(element, from, target, releaseVelocity = 0) {
   let finished = false;
   const stiffness = 340;
   const damping = 34;
+  const update = (nextPosition, nextVelocity) => {
+    position = nextPosition;
+    velocity = nextVelocity;
+    element.style.transform = "translateX(" + position + "px)";
+    onUpdate(position, velocity);
+  };
+  const cleanup = () => {
+    reducedMotionQuery.removeEventListener("change", onReducedMotionChange);
+  };
   function onReducedMotionChange(event) {
     if (event.matches) finish();
   }
@@ -166,8 +176,15 @@ function springTo(element, from, target, releaseVelocity = 0) {
     if (finished) return;
     finished = true;
     window.cancelAnimationFrame(frame);
-    element.style.transform = "translateX(" + target + "px)";
-    reducedMotionQuery.removeEventListener("change", onReducedMotionChange);
+    update(target, 0);
+    cleanup();
+  };
+  const cancel = () => {
+    if (finished) return;
+    finished = true;
+    window.cancelAnimationFrame(frame);
+    onUpdate(position, velocity);
+    cleanup();
   };
 
   if (reducedMotionQuery.matches) {
@@ -182,7 +199,7 @@ function springTo(element, from, target, releaseVelocity = 0) {
     previous = now;
     velocity += (-stiffness * (position - target) - damping * velocity) * dt;
     position += velocity * dt;
-    element.style.transform = "translateX(" + position + "px)";
+    update(position, velocity);
     if (Math.abs(velocity) < 0.1 && Math.abs(position - target) < 0.1) {
       finish();
       return;
@@ -191,35 +208,44 @@ function springTo(element, from, target, releaseVelocity = 0) {
   };
 
   frame = window.requestAnimationFrame(tick);
-  return () => finish();
+  return cancel;
 }
 
-function setDrawerPosition(position) {
+function setDrawerPosition(position, velocity = 0) {
   drawerPosition = Math.max(-240, Math.min(0, position));
+  drawerVelocity = velocity;
   drawer.style.transform = "translateX(" + drawerPosition + "px)";
+  drawerRange.value = String(Math.round(drawerPosition));
 }
 
 function settleDrawer(target = drawerPosition > -120 ? 0 : -240) {
   cancelDrawerSpring();
-  drawerRange.value = String(target);
+  drawerTarget = target;
   drawerToggle.textContent = target === 0 ? "Close drawer" : "Open drawer";
-  cancelDrawerSpring = springTo(drawer, drawerPosition, target, releaseVelocity);
-  drawerPosition = target;
+  cancelDrawerSpring = springTo(drawer, drawerPosition, target, drawerVelocity, (position, velocity) => {
+    drawerPosition = position;
+    drawerVelocity = velocity;
+    drawerRange.value = String(Math.round(Math.max(-240, Math.min(0, position))));
+  });
 }
 
 drawerRange.addEventListener("input", () => {
   cancelDrawerSpring();
   const now = performance.now();
   const nextPosition = Number(drawerRange.value);
-  releaseVelocity = (nextPosition - drawerPosition) / Math.max((now - lastInputTime) / 1000, 0.016);
+  const nextVelocity = (nextPosition - drawerPosition) / Math.max((now - lastInputTime) / 1000, 0.016);
   lastInputTime = now;
-  setDrawerPosition(nextPosition);
+  drawerTarget = nextPosition > -120 ? 0 : -240;
+  drawerToggle.textContent = drawerTarget === 0 ? "Close drawer" : "Open drawer";
+  setDrawerPosition(nextPosition, nextVelocity);
 });
-drawerRange.addEventListener("change", settleDrawer);
+drawerRange.addEventListener("pointerdown", () => {
+  cancelDrawerSpring();
+  lastInputTime = performance.now();
+});
+drawerRange.addEventListener("change", () => settleDrawer());
 drawerToggle.addEventListener("click", () => {
-  const target = drawerPosition === 0 ? -240 : 0;
-  releaseVelocity = target === 0 ? 420 : -420;
-  settleDrawer(target);
+  settleDrawer(drawerTarget === 0 ? -240 : 0);
 });
 
 async function saveSettings() {
@@ -516,7 +542,7 @@ export const seoGuideArticlesC = [
     ],
     caseStudy: {
       title: text("案例：抽屉用 spring 接住拖拽，保存提示用 ease-out 交接", "Case: a drawer uses spring after drag while save feedback uses ease-out"),
-      context: text("抽屉在拖拽松手后要延续当前速度并收束到开合位置；保存提示只需要在原操作附近迅速清楚地抵达完成状态。", "After drag release, a drawer needs to retain current velocity and settle to open or closed; save feedback only needs a fast, clear completed state near the original action."),
+      context: text("抽屉在拖拽松手后延续当前速度并收束到开合位置；保存提示在原操作附近快速抵达完成状态。", "After drag release, a drawer retains velocity and settles open or closed; save feedback reaches a clear completed state near the original action."),
       code: springAndEaseRuntimeExample,
       explanation: text("`springTo` 接收松手瞬间的 releaseVelocity，并把它作为积分器初始速度，因此新的拖拽、反向操作或路由离开都能立即接管旧动画。系统减弱动效偏好通过 change 事件立即落在目标位置，并在完成与取消时清理监听；保存提示使用短时 ease-out，文案和状态仍由同一业务状态驱动，方便用户读到完成结果后继续操作。", "`springTo` receives releaseVelocity from the instant of release and uses it as the integrator’s initial velocity, so a new drag, reversal, or route exit can take over immediately. A reduced-motion preference change lands at the target through its change event, with listeners cleaned up on completion and cancellation; save feedback uses a short ease-out while copy and state remain driven by the same business state, letting people read completion and continue their work.")
     },

--- a/src/data/seo-guide-articles-c.ts
+++ b/src/data/seo-guide-articles-c.ts
@@ -1,0 +1,586 @@
+import type {
+  SeoGuideArticleDiagramNode,
+  SeoGuideArticleText,
+  SeoGuideLongArticle
+} from "./seo-guide-articles-b";
+import type { SeoGuideId } from "./seo-guide-ids";
+
+/**
+ * Long-form editorial source for scenario guides 03–04.
+ * It follows the shared renderer contract from seo-guide-articles-b.ts. Each
+ * diagram uses a 960 × 540 canvas; connectors reference node ids directly.
+ */
+type SeoGuideArticleC = Omit<SeoGuideLongArticle, "guideId"> & {
+  guideId: Extract<SeoGuideId, "css-motion-jank" | "spring-or-ease-out">;
+};
+
+const text = (zh: string, en: string): SeoGuideArticleText => ({ zh, en });
+
+const node = (
+  id: string,
+  zh: string,
+  en: string,
+  zhDetail: string,
+  enDetail: string,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  tone: SeoGuideArticleDiagramNode["tone"]
+): SeoGuideArticleDiagramNode => ({
+  id,
+  label: text(zh, en),
+  detail: text(zhDetail, enDetail),
+  x,
+  y,
+  width,
+  height,
+  tone
+});
+
+const jankRuntimeExample = `<section class="filter-demo">
+  <label>
+    Filter projects
+    <input type="search" data-filter-input placeholder="Type a project name">
+  </label>
+  <p role="status" aria-live="polite" data-result-count></p>
+  <ul class="result-list" data-result-list></ul>
+</section>
+
+<style>
+.filter-demo { display: grid; gap: 12px; max-width: 32rem; }
+.result-list { display: grid; gap: 8px; padding: 0; list-style: none; }
+.result-card { opacity: 1; transform: translateY(0); transition: opacity 160ms ease-out, transform 160ms ease-out; }
+.result-card[data-motion="enter"] { opacity: 0; transform: translateY(8px); }
+.result-card[data-motion="leave"] { opacity: 0; pointer-events: none; transform: scale(.985); }
+@media (prefers-reduced-motion: reduce) {
+  .result-card { transition-duration: 1ms; }
+}
+</style>
+
+<script>
+const input = document.querySelector("[data-filter-input]");
+const resultList = document.querySelector("[data-result-list]");
+const resultCount = document.querySelector("[data-result-count]");
+const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+const projects = ["Alpha dashboard", "Beta settings", "Gamma archive", "Delta reports"];
+let renderFrame = 0;
+let leaveTimer = 0;
+
+function matchingProjects(query) {
+  const normalizedQuery = query.trim().toLowerCase();
+  return projects.filter((project) => project.toLowerCase().includes(normalizedQuery));
+}
+
+function updateResultCount(results) {
+  resultCount.textContent = results.length + " project" + (results.length === 1 ? "" : "s") + " shown.";
+}
+
+function createResultCard(project) {
+  const item = document.createElement("li");
+  item.className = "result-card";
+  item.dataset.motion = "enter";
+  item.textContent = project;
+  return item;
+}
+
+function commitResults(results) {
+  resultList.replaceChildren(...results.map(createResultCard));
+  renderFrame = window.requestAnimationFrame(() => {
+    resultList.querySelectorAll("[data-motion='enter']").forEach((card) => {
+      card.removeAttribute("data-motion");
+    });
+  });
+}
+
+function applyLatestQuery(query) {
+  window.cancelAnimationFrame(renderFrame);
+  window.clearTimeout(leaveTimer);
+  const results = matchingProjects(query);
+  updateResultCount(results);
+  const currentCards = Array.from(resultList.children);
+
+  if (reducedMotion.matches || currentCards.length === 0) {
+    commitResults(results);
+    return;
+  }
+
+  currentCards.forEach((card) => {
+    card.dataset.motion = "leave";
+  });
+  leaveTimer = window.setTimeout(() => commitResults(results), 160);
+}
+
+input.addEventListener("input", () => applyLatestQuery(input.value));
+applyLatestQuery("");
+</script>`;
+
+const springAndEaseRuntimeExample = `<section class="curve-demo">
+  <label>
+    Drawer position
+    <input type="range" min="-240" max="0" value="-240" data-drawer-range>
+  </label>
+  <button type="button" data-drawer-toggle>Open drawer</button>
+  <div class="drawer-stage">
+    <aside class="drawer" data-drawer aria-label="Settings drawer">Settings stay attached to the drag position.</aside>
+  </div>
+  <button type="button" data-save>Save settings</button>
+  <p class="save-status" data-save-status data-state="idle" role="status" aria-live="polite">Ready to save.</p>
+</section>
+
+<style>
+.curve-demo { display: grid; gap: 12px; max-width: 32rem; }
+.drawer-stage { overflow: hidden; min-height: 4rem; border: 1px solid currentColor; }
+.drawer { width: 14rem; min-height: 4rem; padding: 12px; background: Canvas; }
+.save-status { opacity: 0; transform: translateY(6px); transition: opacity 160ms ease-out, transform 160ms ease-out; }
+.save-status[data-state="saving"], .save-status[data-state="saved"] { opacity: 1; transform: translateY(0); }
+@media (prefers-reduced-motion: reduce) {
+  .save-status { transition-duration: 1ms; }
+}
+</style>
+
+<script>
+const reducedMotionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+const drawer = document.querySelector("[data-drawer]");
+const drawerRange = document.querySelector("[data-drawer-range]");
+const drawerToggle = document.querySelector("[data-drawer-toggle]");
+const saveButton = document.querySelector("[data-save]");
+const saveStatus = document.querySelector("[data-save-status]");
+let drawerPosition = -240;
+let releaseVelocity = 0;
+let lastInputTime = performance.now();
+let cancelDrawerSpring = () => {};
+
+function springTo(element, from, target, releaseVelocity = 0) {
+  let position = from;
+  let velocity = releaseVelocity;
+  let previous = performance.now();
+  let frame = 0;
+  let finished = false;
+  const stiffness = 340;
+  const damping = 34;
+  function onReducedMotionChange(event) {
+    if (event.matches) finish();
+  }
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    window.cancelAnimationFrame(frame);
+    element.style.transform = "translateX(" + target + "px)";
+    reducedMotionQuery.removeEventListener("change", onReducedMotionChange);
+  };
+
+  if (reducedMotionQuery.matches) {
+    finish();
+    return () => {};
+  }
+
+  reducedMotionQuery.addEventListener("change", onReducedMotionChange);
+  const tick = (now) => {
+    if (finished) return;
+    const dt = Math.min((now - previous) / 1000, 0.032);
+    previous = now;
+    velocity += (-stiffness * (position - target) - damping * velocity) * dt;
+    position += velocity * dt;
+    element.style.transform = "translateX(" + position + "px)";
+    if (Math.abs(velocity) < 0.1 && Math.abs(position - target) < 0.1) {
+      finish();
+      return;
+    }
+    frame = window.requestAnimationFrame(tick);
+  };
+
+  frame = window.requestAnimationFrame(tick);
+  return () => finish();
+}
+
+function setDrawerPosition(position) {
+  drawerPosition = Math.max(-240, Math.min(0, position));
+  drawer.style.transform = "translateX(" + drawerPosition + "px)";
+}
+
+function settleDrawer(target = drawerPosition > -120 ? 0 : -240) {
+  cancelDrawerSpring();
+  drawerRange.value = String(target);
+  drawerToggle.textContent = target === 0 ? "Close drawer" : "Open drawer";
+  cancelDrawerSpring = springTo(drawer, drawerPosition, target, releaseVelocity);
+  drawerPosition = target;
+}
+
+drawerRange.addEventListener("input", () => {
+  cancelDrawerSpring();
+  const now = performance.now();
+  const nextPosition = Number(drawerRange.value);
+  releaseVelocity = (nextPosition - drawerPosition) / Math.max((now - lastInputTime) / 1000, 0.016);
+  lastInputTime = now;
+  setDrawerPosition(nextPosition);
+});
+drawerRange.addEventListener("change", settleDrawer);
+drawerToggle.addEventListener("click", () => {
+  const target = drawerPosition === 0 ? -240 : 0;
+  releaseVelocity = target === 0 ? 420 : -420;
+  settleDrawer(target);
+});
+
+async function saveSettings() {
+  if (saveButton.disabled) return;
+  saveButton.disabled = true;
+  saveStatus.dataset.state = "saving";
+  saveStatus.textContent = "Saving settings.";
+  await new Promise((resolve) => window.setTimeout(resolve, 160));
+  saveStatus.dataset.state = "saved";
+  saveStatus.textContent = "Settings saved.";
+  saveButton.disabled = false;
+}
+
+saveButton.addEventListener("click", saveSettings);
+setDrawerPosition(drawerPosition);
+</script>`;
+
+export const seoGuideArticlesC = [
+  {
+    guideId: "css-motion-jank",
+    standfirst: text(
+      "CSS 动效卡顿需要回到用户正在完成的任务：找出哪一次输入、哪一帧和哪一段渲染工作打断了反馈链，再用可复现的证据收窄属性、脚本和视觉层的成本。",
+      "CSS motion jank becomes tractable when it returns to the task a person is trying to complete: identify the input, frame, and rendering work that breaks the feedback chain, then use repeatable evidence to narrow the cost of properties, scripting, and visual layers."
+    ),
+    sections: [
+      {
+        id: "reproduce-the-moment",
+        title: text("从一个真实瞬间建立复现", "Build a reproduction around one real moment"),
+        paragraphs: [
+          text(
+            "“页面有点卡”很难直接变成修复任务。先把它缩成一个用户能重复完成的动作：在 300 条结果里输入筛选词、滚动到第六屏后展开详情、拖动时间线上的手柄，或在网络较慢时点击保存。记录起点、可见结果、设备尺寸、数据量、网络状态和连续操作次数。随后让同一位测试者连续做三到五轮，分别标出输入后迟迟没有响应、运动途中突然停顿、还是结束后内容才跳到新位置。每一种现象都对应不同的调查入口，因此这份记录应成为性能讨论的共同起点。",
+            "A report that the page feels slow is difficult to turn into a repair task. Shrink it into one action a person can repeat: type a filter into a list of 300 results, open detail after scrolling to the sixth viewport, drag a timeline handle, or press Save on a slower connection. Record the starting state, visible result, viewport, data volume, network condition, and number of consecutive actions. Ask the same reviewer to repeat the action three to five times, then mark whether input receives a late response, travel pauses in the middle, or content jumps only after motion ends. Each symptom opens a different investigation, so this record becomes the shared starting point for performance work."
+          ),
+          text(
+            "复现还要保护上下文。许多问题只会在字体刚加载、图片尺寸尚未稳定、搜索结果持续变化、后台标签页切回前台或低电量模式出现。把这些条件写进步骤，才能区分偶然抖动和稳定回归。对于高频路径，准备一个固定种子数据集和一个小型录像尤其有价值：录像告诉团队用户在哪一刻失去节奏，数据集让开发者每次都在相同压力下检查。性能工作由此有了可比较的前后状态，修复可通过实际操作验证，桌面机器上的主观感觉只作补充。",
+            "A reproduction also needs to preserve context. Many issues appear only while fonts are arriving, image dimensions are still settling, search results keep changing, a background tab returns to the foreground, or a device enters a lower-power condition. Put those conditions in the steps so an occasional hitch can be separated from a stable regression. For high-frequency paths, keep a fixed seeded data set and a small visual capture. The capture shows the instant where rhythm is lost, while the data set gives engineering the same pressure on every check. Performance work then has comparable before-and-after states, and a repair can be verified through the actual interaction instead of a subjective impression on one desktop machine."
+          )
+        ]
+      },
+      {
+        id: "read-the-frame",
+        title: text("用一帧的渲染路径定位成本", "Locate cost through a frame’s rendering path"),
+        paragraphs: [
+          text(
+            "浏览器把一帧画出来时，通常要经过事件处理和脚本、样式计算、布局、绘制与合成。性能录制的第一步是把视觉录像和时间线对齐：卡片停止的那一帧，主线程上是否出现很长的脚本块？样式和布局是否连续重复？是否有大面积绘制、图片解码或第三方脚本占住了时间？先读总览里的掉帧区间和长任务，再钻进对应调用栈，效率高于从火焰图开头逐行猜测。团队需要的结论应当具体到“这次滚动在同一帧读了十次尺寸并写了十次位置”，这样下一步才有明确的改动目标。",
+            "When a browser draws a frame, it commonly moves through event handling and scripting, style calculation, layout, paint, and compositing. Start a performance recording by aligning the visual capture with the timeline. On the frame where a card pauses, is there a long script block on the main thread? Are style and layout repeating? Is a broad paint, image decode, or third-party script holding time? Read dropped-frame spans and long tasks in the overview before entering the matching call stack; this is faster than guessing line by line from the start of a flame chart. The useful conclusion is concrete: for example, this scroll reads ten sizes and writes ten positions in one frame. That gives the next change a clear target."
+          ),
+          text(
+            "帧预算需要根据屏幕刷新率和设备余量理解。60Hz 显示器约每 16.7ms 交付一帧，120Hz 的间隔更短；手机的温度、电量、后台活动和 GPU 能力还会压缩可用时间。预算并不要求把每个动作做得完全相同，它要求关键输入始终能得到及时回应。滚动、拖拽、连续输入和媒体拖动属于持续输入，应该优先保护；列表首次进入、装饰性光晕和大面积背景变化可以让出资源。用普通笔记本与常用手机各录一次，再加上较大数据量的场景，能够让“高性能桌面上看起来顺畅”的结论接受现实检验。",
+            "Frame budget must be understood through refresh rate and device margin. A 60 Hz display delivers a frame about every 16.7 ms, a 120 Hz display leaves less time, and a phone’s temperature, battery, background activity, and GPU capacity can narrow the room further. A budget does not require every action to look identical. It protects prompt response for important input. Scrolling, dragging, continuous typing, and media scrubbing involve ongoing input and deserve priority. Initial list entrance, decorative glows, and broad background changes can yield resources. Record once on an ordinary laptop, once on a common phone, and once with a larger data set; that lets a smooth-on-desktop conclusion meet real operating conditions."
+          )
+        ]
+      },
+      {
+        id: "choose-properties",
+        title: text("让属性选择服务于视觉职责", "Let property choice serve the visual job"),
+        paragraphs: [
+          text(
+            "属性选择决定每一帧需要重新计算到哪里。按钮按下、提示进入、卡片轻微移动和淡入淡出通常只是在表达反馈、方向或层级，`transform` 与 `opacity` 能很好地承担这些任务，并且常常便于浏览器在合成阶段处理。内容展开、真实文本换行、网格列数变化和图片比例变化则表达了真实布局，尺寸与布局的更新具有业务意义。两类任务都值得实现，只需要明确边界：把轻反馈放到合成友好的属性上，把真实结构变化限制在尽可能小的容器里，并避免把每一帧都变成一次全页重算。",
+            "Property choice determines how far the browser must recalculate on each frame. A button press, an entering notice, a small card move, and a fade usually express feedback, direction, or hierarchy. `transform` and `opacity` serve those jobs well and often allow the browser to handle them in compositing. Expanding content, real text wrapping, changing grid columns, and changing image ratio express actual layout, so size and layout updates carry product meaning. Both categories deserve implementation. The useful boundary is clear: put light feedback on compositor-friendly properties, constrain real structural change to the smallest practical container, and avoid turning every frame into a whole-page recalculation."
+          ),
+          text(
+            "布局抖动常来自读写交错。代码先读取元素的 `offsetHeight`，立刻写入 `style.height`，又读取另一个元素的位置，会迫使浏览器提前结算尚未完成的工作。把读取集中在一个阶段，把写入集中到下一帧，或把计算后的值交给 CSS 自定义属性，都能降低这种往返。`will-change` 也应只在即将发生的少量动效上短暂使用；给长列表的每个卡片长期提升图层会增加内存、合成和滚动压力。性能优化的质量取决于取舍是否贴合任务，样式表也应保持简洁、明确的规则。",
+            "Layout thrash often comes from alternating reads and writes. Code reads an element’s `offsetHeight`, writes `style.height` immediately, then reads another element’s position; that can force the browser to settle unfinished work early. Gather reads in one phase, gather writes in the next frame, or hand a calculated value to a CSS custom property to reduce the back-and-forth. `will-change` also belongs on the small number of motions about to occur and for a short time. Permanently promoting every card in a long list adds memory, compositing, and scrolling pressure. The quality of a performance repair comes from tradeoffs that fit the task, not from filling a style sheet with a fixed recipe."
+          )
+        ]
+      },
+      {
+        id: "protect-continuous-input",
+        title: text("连续输入优先保持因果关系", "Keep continuous input causally connected"),
+        paragraphs: [
+          text(
+            "用户连续输入筛选词时，每个键盘事件都可能触发状态更新、搜索、列表重排和进入离开动效。如果每次更新都等待上一段 400ms 动画结束，界面会形成视觉队列，输入与结果逐渐脱节。更合适的策略是保留当前最新意图：新查询到来时取消旧的装饰性过渡，立即更新结果数量与活跃条件，再让少量新增项以短促方式出现。对于滚动和拖拽，位置跟随用户手势本身是核心反馈，惯性、阴影、模糊和尾迹属于次级效果，可以按设备能力与偏好收敛。这样用户始终看得出自己的输入正在控制什么。",
+            "When someone types a filter continuously, every key event may trigger state change, search, list reorder, and entrance or exit motion. If each update waits for a previous 400 ms animation to finish, the interface builds a visual queue and input gradually loses its connection to results. A better strategy keeps the latest intent. When a new query arrives, cancel the old decorative transition, update the result count and active criteria immediately, then let only a small number of new items appear briefly. During scrolling and dragging, position following the hand is core feedback. Inertia, shadows, blur, and trails are secondary effects that can narrow with device capability and preference. People can then see what their input is controlling at every moment."
+          ),
+          text(
+            "把昂贵工作移出高频回调同样重要。滚动监听中可以收集可见范围和方向，再用 `requestAnimationFrame` 在下一帧写入视觉状态；搜索可以防抖真正昂贵的远程或本地计算，同时让输入框和结果计数立即回应；拖拽可以把数据提交放在松手后，把显示位置保持在轻量状态里。这里的目标是形成一条稳定的优先级：手势和文字输入先得到确认，关键内容随后更新，装饰性细节在还有余量时才加入。性能和体验在这一点上是同一件事，因为两者都在保护用户的控制感。",
+            "Moving expensive work out of high-frequency callbacks matters as well. A scroll listener can collect visible range and direction, then write visual state on the next frame with `requestAnimationFrame`. Search can debounce truly expensive local or remote computation while the input and result count respond immediately. Dragging can commit data after release while keeping display position in a lightweight state. The goal is a stable priority order: gesture and typed input receive acknowledgement first, important content updates next, and decorative detail joins only when margin remains. Performance and experience are the same concern here because both protect the person’s sense of control."
+          )
+        ]
+      },
+      {
+        id: "ship-a-baseline",
+        title: text("用基线和验收守住下一次改动", "Use baselines and acceptance to protect the next change"),
+        paragraphs: [
+          text(
+            "一次修复只有在下一次功能迭代后仍然成立，才真正提升了产品。为高频组件保留一份轻量基线：固定数据集、复现步骤、设备和屏幕尺寸、十到二十秒的录像，以及一次性能录制中值得关注的区间。基线可以覆盖移动端筛选、桌面拖拽、打开大型详情和网络较慢的保存。它无需成为昂贵的实验室体系，却能让代码评审和回归测试有共同参照。新增动画、图片资源或第三方组件时，团队可以快速问出它影响的是哪条基线、是否占用了连续输入的余量。",
+            "A repair improves the product only when it still holds after the next feature iteration. Keep a lightweight baseline for high-frequency components: a fixed data set, reproduction steps, device and viewport, a ten-to-twenty-second capture, and the noteworthy span in one performance recording. A baseline can cover mobile filtering, desktop dragging, opening a large detail view, and saving on a slower connection. It does not need to become an expensive lab system. It gives code review and regression work a shared reference. When a new animation, image asset, or third-party component arrives, the team can quickly ask which baseline it affects and whether it consumes margin reserved for continuous input."
+          ),
+          text(
+            "验收语言也应描述用户能完成什么。与其只写“保持 60fps”，可以写成：输入筛选词后结果数量立即改变；在指定数量的卡片中滚动时，主操作始终可点击；抽屉打开期间焦点与内容稳定；开启减弱动效后，状态仍完整可读。再为这些目标补充技术证据，例如长任务阈值、录制中的连续掉帧区间、布局读写次数或可接受的视觉层数。产品目标和技术指标并列，能避免为了数字牺牲反馈，也能避免为了效果忽略成本。每次发布前做一次短复查，性能便会从偶发救火变成组件契约的一部分。",
+            "Acceptance language should also describe what a person can accomplish. Instead of writing only keep 60 fps, write that the result count changes immediately after typing a filter, the primary action remains usable while scrolling a specified number of cards, focus and content remain stable during drawer opening, and state stays fully legible with reduced motion enabled. Then add technical evidence for those goals: a long-task threshold, a dropped-frame span in recording, number of layout reads and writes, or an acceptable number of visual layers. Product goals beside technical signals prevent a metric from sacrificing feedback and prevent a visual effect from ignoring cost. A short review before each release makes performance part of the component contract."
+          )
+        ]
+      }
+    ],
+    checklistTitle: text("CSS 动效性能发布清单", "CSS motion performance shipping checklist"),
+    checklist: [
+      {
+        id: "reproduction",
+        label: text("固定条件下可以稳定复现", "The issue reproduces under fixed conditions"),
+        detail: text("记录设备、视口、数据量、网络、起点和连续操作次数。", "Record device, viewport, data volume, network, starting state, and repeated actions.")
+      },
+      {
+        id: "evidence",
+        label: text("录像与性能时间线对齐", "Visual capture aligns with the performance timeline"),
+        detail: text("将可见停顿对应到长脚本、布局、绘制或资源解码的证据。", "Match the visible pause to evidence from scripting, layout, paint, or resource decoding.")
+      },
+      {
+        id: "properties",
+        label: text("轻反馈使用合适的渲染路径", "Light feedback uses an appropriate rendering path"),
+        detail: text("将位移和淡化放在 transform 与 opacity，把真实结构变化限制在局部容器。", "Use transform and opacity for travel and fades, then constrain real structural change to a local container.")
+      },
+      {
+        id: "input",
+        label: text("最新输入始终拥有优先级", "The latest input always has priority"),
+        detail: text("连续搜索、滚动和拖拽会取消过期装饰性过渡，并及时更新关键状态。", "Continuous search, scrolling, and dragging cancel stale decorative transitions and update essential state promptly.")
+      },
+      {
+        id: "baseline",
+        label: text("常用设备和减弱动效路径已回归", "Common devices and the reduced-motion path have regressed"),
+        detail: text("用固定数据集检查普通笔记本、手机、大列表和系统偏好切换。", "Use a fixed data set to check an ordinary laptop, phone, large list, and system-preference change.")
+      }
+    ],
+    caseStudy: {
+      title: text("案例：筛选卡片在连续输入中保持轻量", "Case: filter cards stay lightweight during continuous input"),
+      context: text("结果列表会在用户持续输入时更新。卡片只承担短促的进入与离开反馈，真实排序由数据更新完成，旧过渡可以被最新查询中断。", "A result list updates while someone keeps typing. Cards carry only short entrance and exit feedback, real order comes from data updates, and an old transition can yield to the latest query."),
+      code: jankRuntimeExample,
+      explanation: text("代码先取消过期的装饰性过渡，再同步更新数量和结果。进入与离开只改动透明度和 transform，列表的真实顺序仍由数据和布局决定；减弱动效路径沿用同一状态，只将过渡收敛到极短时间。", "The code first cancels stale decorative transitions, then updates count and results together. Entrance and exit change only opacity and transform while data and layout retain ownership of real order. The reduced-motion path uses the same state and compresses the transition to a very short interval.")
+    },
+    diagrams: [
+      {
+        id: "frame-work-path",
+        title: text("图解一：一帧中的工作路径", "Diagram 1: work across one frame"),
+        alt: text("输入、脚本、样式与布局、绘制和合成依次连接，布局与绘制以警示色提示需要缩小范围。", "Input, script, style and layout, paint, and compositing connect in sequence; layout and paint use warning color to show work that needs a narrower scope."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("input", "输入", "Input", "手势与键盘事件", "Gesture and keyboard event", 35, 205, 145, 110, "surface"),
+          node("script", "脚本", "Script", "状态与计算", "State and computation", 215, 205, 145, 110, "accent"),
+          node("layout", "样式与布局", "Style and layout", "控制读写往返", "Control read/write thrash", 395, 205, 145, 110, "warning"),
+          node("paint", "绘制", "Paint", "限制大面积效果", "Limit broad effects", 575, 205, 145, 110, "warning"),
+          node("composite", "合成", "Composite", "轻反馈优先落点", "Preferred home for light feedback", 755, 205, 145, 110, "success")
+        ],
+        connectors: [
+          { from: "input", to: "script" },
+          { from: "script", to: "layout" },
+          { from: "layout", to: "paint" },
+          { from: "paint", to: "composite" }
+        ]
+      },
+      {
+        id: "property-decision",
+        title: text("图解二：按视觉职责选择属性", "Diagram 2: choose properties by visual job"),
+        alt: text("轻反馈和真实结构变化从视觉职责出发，分别连接到合成友好属性和局部布局更新。", "Light feedback and real structural change begin with visual jobs, then connect to compositor-friendly properties and localized layout updates."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("feedback", "轻反馈", "Light feedback", "按下、提示、微移", "Press, notice, small travel", 80, 115, 255, 105, "success"),
+          node("compositor", "合成属性", "Compositor properties", "transform · opacity", "transform · opacity", 80, 325, 255, 105, "accent"),
+          node("structure", "真实结构", "Real structure", "展开、文本、网格", "Disclosure, text, grid", 625, 115, 255, 105, "surface"),
+          node("localized", "局部布局", "Localized layout", "限制影响范围", "Constrain affected scope", 625, 325, 255, 105, "warning")
+        ],
+        connectors: [
+          { from: "feedback", to: "compositor", label: text("短促反馈", "Short feedback") },
+          { from: "structure", to: "localized", label: text("真实变化", "Real change") }
+        ]
+      },
+      {
+        id: "jank-review-loop",
+        title: text("图解三：卡顿排查与回归闭环", "Diagram 3: jank diagnosis and regression loop"),
+        alt: text("复现、录制、定位、修改、回归形成循环；回归发现问题时回到复现步骤。", "Reproduce, record, locate, change, and regress form a loop; a regression issue returns to reproduction."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("reproduce", "复现", "Reproduce", "固定真实操作", "Fix a real interaction", 385, 45, 190, 90, "ink"),
+          node("record", "录制", "Record", "对齐录像与时间线", "Align capture and timeline", 650, 205, 190, 90, "accent"),
+          node("locate", "定位", "Locate", "识别工作与属性", "Identify work and properties", 520, 385, 190, 90, "warning"),
+          node("change", "修改", "Change", "缩小成本或时长", "Narrow cost or duration", 250, 385, 190, 90, "success"),
+          node("regress", "回归", "Regress", "检查基线设备", "Check baseline devices", 120, 205, 190, 90, "surface")
+        ],
+        connectors: [
+          { from: "reproduce", to: "record" },
+          { from: "record", to: "locate" },
+          { from: "locate", to: "change" },
+          { from: "change", to: "regress" },
+          { from: "regress", to: "reproduce", label: text("继续验证", "Verify again") }
+        ]
+      }
+    ]
+  },
+  {
+    guideId: "spring-or-ease-out",
+    standfirst: text(
+      "Spring 与 ease-out 的选择从动作语义开始：直接操控、可中断的对象需要连续速度与受力感；明确的确认、进入和结果交接需要可预测的抵达。用同一状态比较两种节奏，界面会更容易读懂。",
+      "The choice between spring and ease-out begins with the action’s meaning. Directly manipulated, interruptible objects benefit from continuous velocity and a sense of force. Clear confirmation, entrance, and result handoff benefit from a predictable arrival. Compare both rhythms on the same state and the interface becomes easier to read."
+    ),
+    sections: [
+      {
+        id: "start-with-meaning",
+        title: text("先判断动作在解释什么", "Decide what the action is explaining"),
+        paragraphs: [
+          text(
+            "曲线名称很容易把讨论带到审美偏好，用户真正感受到的是对象怎样回应自己的输入。先给动作写一句职责：侧栏跟随拖拽后回到停靠位，卡片被选中后表达当前焦点，保存按钮确认请求已收到，菜单在触发按钮附近抵达可读位置。职责不同，速度曲线承担的意义也不同。持续受手势影响、可能被再次抓住、方向可能反转的对象，需要保留当前位置和速度之间的连续关系；一次性确认、短暂进入、需要马上让出注意力的结果，则需要清晰而克制的终点。这个判断比先问“用哪条贝塞尔曲线”更可靠。",
+            "Curve names can pull discussion toward visual preference, while people actually feel how an object answers their input. Write one responsibility for the action first: a sidebar returns to its dock after following a drag, a card communicates current focus after selection, a Save button confirms that work was received, or a menu arrives near its trigger in a readable position. Different responsibilities give speed curves different meaning. An object continuously affected by a gesture, likely to be grabbed again, or likely to reverse direction benefits from continuity between current position and velocity. A one-time confirmation, brief entrance, or result that should quickly release attention benefits from a clear restrained endpoint. This judgment is more reliable than asking for a Bézier curve first."
+          ),
+          text(
+            "状态身份是第二个判断点。同一个抽屉从关闭到打开，用户能追踪到同一块内容在移动，因此可以使用带有重量感的收束。保存前后的按钮虽然占据同一位置，语义已经从“可执行”变成“处理中”再变成“完成”，重点是读清文字和结果，过冲会分散注意力。列表排序中的卡片既有身份连续性，也有大量信息需要阅读，适合让真实位置先稳定，再给很小的强调。把对象身份、用户输入和最终阅读目标列在设计说明里，设计、产品和工程就能用同一份理由选择曲线。",
+            "State identity is a second decision point. The same drawer moves from closed to open, so people can track one piece of content in space and it can settle with a sense of weight. A button before and after Save occupies the same place, yet its meaning changes from available to working to complete. Reading its copy and outcome is the priority, and overshoot can compete for attention. Cards in a reordered list retain identity while a large amount of information needs reading, so let real position stabilize first and add only a very small emphasis. Put object identity, user input, and final reading goal in the design note. Design, product, and engineering can then choose a curve from the same reasons."
+          )
+        ]
+      },
+      {
+        id: "use-spring-for-continuity",
+        title: text("弹簧为连续输入保留速度", "Use springs to retain velocity across continuous input"),
+        paragraphs: [
+          text(
+            "弹簧适合把对象看作正在被推动的实体。拖拽卡片、拉开抽屉、调整底部面板、拖动媒体进度和移动画布元素时，用户的手势已经提供了方向、距离和速度。松手后，弹簧可以把这些信息带入目标位置，让对象自然收束；下一次触摸或鼠标输入到来时，又可以从当前速度接手。这个连续性让人感觉界面持续响应自己，每次输入都从当前状态自然延续。弹簧需要服务操控感，因此目标位置、速度传递和取消机制应与手势状态放在同一个组件契约里。",
+            "A spring works well when an object is understood as something being pushed. Dragging a card, pulling open a drawer, adjusting a bottom panel, scrubbing media, and moving a canvas element already provide direction, distance, and velocity through the person’s gesture. After release, a spring can carry that information toward a target so the object settles naturally. When the next touch or pointer input arrives, it can take over from the current velocity. That continuity makes the interface feel responsive to the person instead of restarting from a prerecorded segment on every interaction. A spring serves control, so target position, velocity transfer, and cancellation belong in the same component contract as gesture state."
+          ),
+          text(
+            "调参可以从三项关系开始理解。刚度决定目标拉回对象的力度，数值提高时抵达更快；阻尼决定速度如何被吸收，数值提高时回弹更快收束；质量影响同一外力下的响应节奏。先固定位移和目标，再一次只改一个维度，观察对象是否仍然显得可控。导航抽屉通常需要较高阻尼和紧凑收束，避免遮挡内容时反复摆动；可拖拽卡片可以允许一小段柔和回弹，用来确认落点。参数的好坏取决于动作的后果、出现频率和屏幕密度，每个组件都应保存自己的合理区间，供团队以动作语义为依据维护。",
+            "Parameter tuning can begin with three relationships. Stiffness decides how strongly the target pulls the object back, so a higher value reaches the destination faster. Damping decides how velocity is absorbed, so a higher value settles rebound sooner. Mass shapes response rhythm under the same force. Fix travel and target first, then change one dimension at a time and observe whether the object still feels controllable. A navigation drawer usually needs higher damping and a compact settle so it does not keep moving while covering content. A draggable card can allow one soft small rebound to confirm the drop. Good parameters depend on consequence, frequency, and screen density, so each component should keep a reasonable range instead of copying one global set of numbers."
+          )
+        ]
+      },
+      {
+        id: "use-ease-out-for-arrival",
+        title: text("Ease-out 让明确结果迅速抵达", "Use ease-out for a quick, clear arrival"),
+        paragraphs: [
+          text(
+            "ease-out 的价值在于开始阶段有足够速度，抵达前逐渐放慢，让用户先看到变化已经发生，再有时间读清最终状态。它适合菜单、提示、轻量卡片进入、复制确认、保存结果和按钮按压恢复。这些动作通常有清楚的起点与终点，也很少需要继承上一段手势速度。把持续时间控制在内容与任务需要的范围内，视觉就会显得果断：按钮反馈常在 100 到 180ms 内收住，局部状态交接可以略长，复杂层级的进入再根据阅读量增加。每一段时间都应帮助用户读到结果或找到下一步。",
+            "The value of ease-out is useful speed at the beginning followed by a gradual slowdown before arrival. People first see that change has happened, then have time to read the final state. It suits menus, notices, light card entrances, copy confirmation, save outcomes, and a button recovering from press. These actions usually have a clear start and end and rarely need to inherit velocity from a previous gesture. Keep duration within the needs of content and task and the visual response feels decisive. Button feedback often settles within 100 to 180 ms, local state handoff can run a little longer, and a complex layer entrance can grow with reading load. Every part of the time should help someone read a result or find the next step."
+          ),
+          text(
+            "一段 ease-out 动画也需要保护空间关系。菜单从触发按钮附近出现时，起始透明度、很小的位移和稳定的最终边界足以说明来源；成功提示在保存按钮旁边淡入时，文字、状态色和图标共同表达完成。过大的缩放、旋转和多次弹跳会让一个简单结果变得比内容本身更醒目。将曲线应用到 opacity 与 transform 上，可以保持布局稳定，也让减弱动效模式容易缩短或直接交接。ease-out 在这里是一种信息排序工具：先确认动作，再呈现结果，最后让用户回到下一次操作。",
+            "An ease-out animation also needs to protect spatial relationship. When a menu appears near its trigger, starting opacity, very small travel, and a stable final boundary are enough to explain origin. When a success notice fades beside Save, copy, state color, and icon express completion together. Large scale, rotation, and repeated bouncing can make a simple result more prominent than the content itself. Applying the curve to opacity and transform keeps layout stable and makes reduced-motion mode easy to shorten or hand off directly. Ease-out acts as an information-ordering tool here: acknowledge the action, present the outcome, then return the person to the next operation."
+          )
+        ]
+      },
+      {
+        id: "design-for-interruption",
+        title: text("中断、反向与连点决定实现方式", "Interruption, reversal, and repeated input determine implementation"),
+        paragraphs: [
+          text(
+            "曲线选择离不开中断策略。用户可能在抽屉打开到一半时再次拖回去，在排序动画尚未结束时移动另一张卡片，或在保存结果出现前再次编辑字段。组件需要知道新输入到来后保留什么：当前视觉位置、当前速度、目标状态、焦点和可访问性文案。直接操控的 spring 应立即取消旧目标并接住当前值；一次性 ease-out 反馈可以被新状态替换，让旧结果淡出或直接结束。无论采用哪条路径，状态源都应优先于计时器，避免过期回调在用户已经改变意图后重新覆盖界面。",
+            "Curve choice depends on interruption strategy. A person may pull a drawer back while it is halfway open, move another card while reorder motion is still settling, or edit a field again before a save outcome appears. The component needs to know what remains when new input arrives: current visual position, current velocity, target state, focus, and accessibility copy. A directly manipulated spring should cancel its old target immediately and take over from the current value. A one-time ease-out response can yield to new state so the old outcome fades or finishes directly. In every path, state source should lead timers, preventing a stale callback from repainting an interface after intent has changed."
+          ),
+          text(
+            "浏览器与动画库的 API 也会影响交接质量。CSS transition 很适合简洁、可预期的 ease-out 状态变化；Web Animations API 能提供取消、完成和播放状态，适合需要由状态机统一管理的短动作；物理 spring 则常需要每帧积分或库提供的速度模型。选择实现时，先检查组件是否要接收拖拽速度、是否需要在任何时刻反向、是否有多个对象共享同一状态。把取消函数、目标值和完成条件显式保留，测试才能覆盖快速连点、方向反转和路由切换。实现清楚后，曲线才会在真实使用中保持它原本的语义。",
+            "Browser and animation-library APIs also shape handoff quality. CSS transition suits concise, predictable ease-out state changes. The Web Animations API provides cancellation, completion, and play state for short actions managed by a state machine. A physical spring commonly needs per-frame integration or a library velocity model. When choosing implementation, check whether the component receives drag velocity, reverses at any moment, or has multiple objects sharing one state. Keep cancellation functions, target values, and completion conditions explicit so tests can cover fast repeat presses, direction reversal, and route change. With implementation made clear, the curve retains its intended meaning in real use."
+          )
+        ]
+      },
+      {
+        id: "compare-and-review",
+        title: text("在同一状态上比较并完成验收", "Compare on the same state and complete review"),
+        paragraphs: [
+          text(
+            "比较 spring 与 ease-out 时，应先锁定位移、对象尺寸、触发位置和最终状态，只改变速度模型。这样团队能观察到真正的差异：弹簧是否让连续操控更自然，ease-out 是否让结果更容易阅读。若同时改了距离、颜色、阴影和时长，讨论很快会失去因果关系。建议在组件文档中保留一个可切换的对照演示，并展示完整产品瞬间，例如拖开抽屉后选择导航项、保存后看到确认并继续编辑。原子动效的手感在流程里接受检验，才能判断它是否帮助用户理解当前动作。",
+            "When comparing spring and ease-out, lock travel, object size, trigger position, and final state, then change only the velocity model. The team can then observe the real difference: does the spring make continuous control feel more natural, and does ease-out make the outcome easier to read? If distance, color, shadow, and duration change at the same time, discussion quickly loses causal connection. Keep a switchable comparison in component documentation and show a complete product moment, such as pulling open a drawer before selecting navigation or saving before seeing confirmation and continuing to edit. The feel of an atomic motion earns its place when the full flow tests whether it helps someone understand the current action."
+          ),
+          text(
+            "验收还要覆盖减弱动效和可访问性。系统偏好开启后，侧栏仍然到达正确位置，焦点仍然进入可操作区域，保存状态仍然从“保存中”变成“已保存”；只需减少大幅位移、反复回弹和装饰性旋转。检查键盘触发、触摸拖拽、屏幕较窄时的遮挡、连续输入和页面离开时的取消。最后记录每个组件的选择理由：动作服务什么意义、允许几次回弹、最大时长、如何中断、低动态路径保留什么。这样的记录会让后续设计保持一致，也让用户在不同页面遇到可预测的动效语言。",
+            "Review also covers reduced motion and accessibility. With the system preference enabled, a sidebar still reaches the correct position, focus still enters an operable region, and save state still moves from Saving to Saved. Reduce broad travel, repeated rebound, and decorative rotation. Check keyboard triggering, touch drag, overlap on narrow screens, continuous input, and cancellation during page exit. Finally record why each component chose its curve: what meaning the action serves, how much rebound it allows, its maximum duration, how it interrupts, and what the low-motion path retains. This record keeps future design consistent and gives people a predictable motion language across pages."
+          )
+        ]
+      }
+    ],
+    checklistTitle: text("Spring 与 ease-out 选择清单", "Spring and ease-out selection checklist"),
+    checklist: [
+      {
+        id: "meaning",
+        label: text("先写清动作要解释的意义", "Write the meaning the action must explain"),
+        detail: text("明确对象身份、用户输入、最终阅读目标和下一步操作。", "State object identity, user input, final reading goal, and the next action.")
+      },
+      {
+        id: "continuity",
+        label: text("直接操控保留位置与速度连续性", "Direct manipulation retains position and velocity continuity"),
+        detail: text("拖拽、抽屉和画布对象拥有目标、取消和接管新输入的策略。", "Drags, drawers, and canvas objects have a strategy for target, cancellation, and new input takeover.")
+      },
+      {
+        id: "arrival",
+        label: text("明确结果使用紧凑抵达", "Clear outcomes use a compact arrival"),
+        detail: text("菜单、保存和复制确认以短时 ease-out 支持阅读与继续操作。", "Menus, save, and copy confirmation use short ease-out to support reading and continued work.")
+      },
+      {
+        id: "comparison",
+        label: text("比较时只改变速度模型", "Change only the velocity model during comparison"),
+        detail: text("锁定位移、尺寸、最终状态和触发位置，让差异可被直接观察。", "Lock travel, size, final state, and trigger position so the difference can be observed directly.")
+      },
+      {
+        id: "review",
+        label: text("中断与低动态路径已经验收", "Interruption and the low-motion path have been reviewed"),
+        detail: text("覆盖快速连点、反向、键盘、触摸、路由离开与系统偏好切换。", "Cover repeat presses, reversal, keyboard, touch, route exit, and system-preference changes.")
+      }
+    ],
+    caseStudy: {
+      title: text("案例：抽屉用 spring 接住拖拽，保存提示用 ease-out 交接", "Case: a drawer uses spring after drag while save feedback uses ease-out"),
+      context: text("抽屉在拖拽松手后要延续当前速度并收束到开合位置；保存提示只需要在原操作附近迅速清楚地抵达完成状态。", "After drag release, a drawer needs to retain current velocity and settle to open or closed; save feedback only needs a fast, clear completed state near the original action."),
+      code: springAndEaseRuntimeExample,
+      explanation: text("`springTo` 接收松手瞬间的 releaseVelocity，并把它作为积分器初始速度，因此新的拖拽、反向操作或路由离开都能立即接管旧动画。系统减弱动效偏好通过 change 事件立即落在目标位置，并在完成与取消时清理监听；保存提示使用短时 ease-out，文案和状态仍由同一业务状态驱动，方便用户读到完成结果后继续操作。", "`springTo` receives releaseVelocity from the instant of release and uses it as the integrator’s initial velocity, so a new drag, reversal, or route exit can take over immediately. A reduced-motion preference change lands at the target through its change event, with listeners cleaned up on completion and cancellation; save feedback uses a short ease-out while copy and state remain driven by the same business state, letting people read completion and continue their work.")
+    },
+    diagrams: [
+      {
+        id: "semantic-choice",
+        title: text("图解一：从动作语义选择速度模型", "Diagram 1: choose a velocity model from action meaning"),
+        alt: text("直接操控与一次性确认从动作语义分支，分别连接 spring 和 ease-out，并标出连续性与清晰抵达。", "Direct manipulation and one-time confirmation branch from action meaning to spring and ease-out, labeled with continuity and clear arrival."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("meaning", "动作语义", "Action meaning", "对象、输入、结果", "Object, input, outcome", 375, 55, 210, 95, "ink"),
+          node("direct", "直接操控", "Direct manipulation", "拖拽、拉开、移动", "Drag, pull, move", 95, 250, 210, 105, "accent"),
+          node("spring", "Spring", "Spring", "保留速度与可中断性", "Retain velocity and interruption", 95, 405, 210, 90, "success"),
+          node("confirm", "一次性确认", "One-time confirmation", "保存、复制、菜单", "Save, copy, menu", 655, 250, 210, 105, "surface"),
+          node("ease", "Ease-out", "Ease-out", "迅速清晰地抵达", "Arrive quickly and clearly", 655, 405, 210, 90, "warning")
+        ],
+        connectors: [
+          { from: "meaning", to: "direct", label: text("持续输入", "Continuous input") },
+          { from: "direct", to: "spring" },
+          { from: "meaning", to: "confirm", label: text("明确结果", "Clear outcome") },
+          { from: "confirm", to: "ease" }
+        ]
+      },
+      {
+        id: "spring-parameters",
+        title: text("图解二：弹簧参数如何影响收束", "Diagram 2: how spring parameters shape settling"),
+        alt: text("刚度、阻尼和质量连接到抵达速度、回弹收束和响应节奏，最终汇入可控的落点。", "Stiffness, damping, and mass connect to arrival speed, rebound settling, and response rhythm, then converge on a controllable landing."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("stiffness", "刚度", "Stiffness", "影响抵达速度", "Shapes arrival speed", 55, 115, 205, 95, "accent"),
+          node("damping", "阻尼", "Damping", "影响回弹收束", "Shapes rebound settling", 375, 115, 205, 95, "warning"),
+          node("mass", "质量", "Mass", "影响响应节奏", "Shapes response rhythm", 695, 115, 205, 95, "surface"),
+          node("landing", "可控落点", "Controllable landing", "组件自己的合理范围", "A component-specific reasonable range", 375, 345, 210, 105, "success")
+        ],
+        connectors: [
+          { from: "stiffness", to: "landing" },
+          { from: "damping", to: "landing" },
+          { from: "mass", to: "landing" }
+        ]
+      },
+      {
+        id: "interruption-contract",
+        title: text("图解三：中断时保持同一状态契约", "Diagram 3: retain one state contract through interruption"),
+        alt: text("手势输入、当前视觉值、目标状态和完成结果形成闭环；新输入会回到手势输入并取消旧目标。", "Gesture input, current visual value, target state, and completed outcome form a loop; new input returns to gesture input and cancels the old target."),
+        viewBox: "0 0 960 540",
+        nodes: [
+          node("gesture", "手势输入", "Gesture input", "方向与速度", "Direction and velocity", 385, 45, 190, 90, "accent"),
+          node("current", "当前视觉值", "Current visual value", "位置与焦点", "Position and focus", 650, 205, 190, 90, "surface"),
+          node("target", "目标状态", "Target state", "打开、关闭、已保存", "Open, closed, saved", 520, 385, 190, 90, "ink"),
+          node("complete", "完成结果", "Completed outcome", "可读与可继续操作", "Readable and actionable", 250, 385, 190, 90, "success"),
+          node("cancel", "取消旧目标", "Cancel old target", "新意图即时接管", "New intent takes over", 120, 205, 190, 90, "warning")
+        ],
+        connectors: [
+          { from: "gesture", to: "current" },
+          { from: "current", to: "target" },
+          { from: "target", to: "complete" },
+          { from: "complete", to: "cancel", label: text("新输入", "New input") },
+          { from: "cancel", to: "gesture" }
+        ]
+      }
+    ]
+  }
+] as const satisfies readonly SeoGuideArticleC[];
+
+export function getSeoGuideArticleC(id?: string | null): SeoGuideArticleC | undefined {
+  return seoGuideArticlesC.find((article) => article.guideId === id);
+}

--- a/src/data/seo-guide-articles.ts
+++ b/src/data/seo-guide-articles.ts
@@ -1,0 +1,29 @@
+import { seoGuideArticlesA } from "./seo-guide-articles-a";
+import { seoGuideArticlesB, type SeoGuideLongArticle } from "./seo-guide-articles-b";
+import { seoGuideArticlesC } from "./seo-guide-articles-c";
+import type { SeoGuideId } from "./seo-guide-ids";
+
+export type {
+  SeoGuideArticleCase,
+  SeoGuideArticleChecklistItem,
+  SeoGuideArticleDiagram,
+  SeoGuideArticleDiagramConnector,
+  SeoGuideArticleDiagramNode,
+  SeoGuideArticleSection,
+  SeoGuideArticleText,
+  SeoGuideLongArticle
+} from "./seo-guide-articles-b";
+
+export const seoGuideArticles: readonly SeoGuideLongArticle[] = [
+  ...seoGuideArticlesA,
+  ...seoGuideArticlesB,
+  ...seoGuideArticlesC
+];
+
+const articleByGuideId = new Map<SeoGuideId, SeoGuideLongArticle>(
+  seoGuideArticles.map((article) => [article.guideId, article])
+);
+
+export function getSeoGuideArticle(id?: string | null): SeoGuideLongArticle | undefined {
+  return id ? articleByGuideId.get(id as SeoGuideId) : undefined;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -44,9 +44,7 @@ async function bootstrap(container: HTMLElement) {
     router.ssr = { manifest: undefined };
     await router.load();
     hydrateRoot(container, app, {
-      onRecoverableError(error, errorInfo) {
-        console.error("[Motion Lexicon hydration]", error, errorInfo.componentStack);
-      }
+      onRecoverableError: console.error
     });
   } else {
     createRoot(container).render(app);

--- a/src/pages/FinderPage.tsx
+++ b/src/pages/FinderPage.tsx
@@ -29,6 +29,12 @@ import {
 
 const exampleKeys = ["weight", "continuity", "sequence"] as const;
 
+function finderStateKey(search: string) {
+  const params = new URLSearchParams(search.slice(search.indexOf("?") + 1));
+  params.delete("tab");
+  return params.toString();
+}
+
 function orderCandidates(
   result: MotionFinderResult,
   compareValue: string | null
@@ -79,6 +85,7 @@ export function FinderPage({ locale }: { locale: Locale }) {
   const [isHydrated, setIsHydrated] = useState(false);
   const valuesRef = useRef<ParamValues | null>(null);
   const syncedQueryRef = useRef<string | null>(null);
+  const localFinderStateKeysRef = useRef(new Map<string, true>());
   const parameterFrameRef = useRef(0);
   const pendingParameterUpdateRef = useRef<{
     query: string;
@@ -104,15 +111,19 @@ export function FinderPage({ locale }: { locale: Locale }) {
     [candidates, selectedId]
   );
   const finderStateSearch = useMemo(() => {
-    const params = new URLSearchParams(location.searchStr);
-    params.delete("tab");
-    return params.toString();
+    return finderStateKey(location.searchStr);
   }, [location.searchStr]);
 
   useEffect(() => cancelPendingParameterCommit, [cancelPendingParameterCommit]);
 
   useEffect(() => {
     const timeout = window.setTimeout(() => {
+      if (localFinderStateKeysRef.current.delete(finderStateSearch)) {
+        syncedQueryRef.current = new URLSearchParams(finderStateSearch).get("q")?.trim() ?? "";
+        setIsHydrated(true);
+        return;
+      }
+
       const params = new URLSearchParams(finderStateSearch);
       const query = params.get("q")?.trim() ?? "";
       const previousQuery = syncedQueryRef.current;
@@ -178,8 +189,18 @@ export function FinderPage({ locale }: { locale: Locale }) {
     selected: MotionFinderCandidate,
     nextValues: ParamValues
   ) {
+    const href = finderUrl(query, nextCandidates, selected, nextValues);
+    const nextFinderStateKey = finderStateKey(href);
+    if (nextFinderStateKey !== finderStateSearch) {
+      localFinderStateKeysRef.current.delete(nextFinderStateKey);
+      localFinderStateKeysRef.current.set(nextFinderStateKey, true);
+      if (localFinderStateKeysRef.current.size > 24) {
+        const oldestKey = localFinderStateKeysRef.current.keys().next().value;
+        if (oldestKey) localFinderStateKeysRef.current.delete(oldestKey);
+      }
+    }
     void navigate({
-      href: finderUrl(query, nextCandidates, selected, nextValues),
+      href,
       replace: true,
       resetScroll: false,
       hashScrollIntoView: false

--- a/src/pages/GuidesPage.tsx
+++ b/src/pages/GuidesPage.tsx
@@ -2,7 +2,7 @@ import { Link } from "@tanstack/react-router";
 import { ArrowRight } from "../components/icons";
 import { Seo } from "../components/Seo";
 import { seoGuides } from "../data/seo-guides";
-import { pathFor } from "../data/site";
+import { pathFor, siteUrl } from "../data/site";
 import type { Locale } from "../data/types";
 import { breadcrumbStructuredData } from "../lib/structured-data";
 
@@ -11,14 +11,16 @@ export function GuidesPage({ locale }: { locale: Locale }) {
     ? {
         eyebrow: "场景指南",
         title: "从真实产品问题开始设计动效",
-        copy: "八篇场景指南，把产品状态、动效基础和可复制的 Product Moments 连成一条可执行的路径。",
-        open: "阅读指南"
+        copy: "八篇双语图文长文，把产品状态、动效基础和可复制的 Product Moments 连成一条可执行的路径。",
+        format: "1000+ 字 · 3 张图解 · 清单与代码",
+        open: "阅读完整指南"
       }
     : {
         eyebrow: "Scenario guides",
         title: "Design motion from real product questions",
-        copy: "Eight scenario guides connect product state, motion primitives, and copy-ready Product Moments into a practical path.",
-        open: "Read guide"
+        copy: "Eight illustrated, bilingual field guides connect product state, motion primitives, and copy-ready Product Moments into a practical path.",
+        format: "Long read · 3 diagrams · checklist and code",
+        open: "Read full guide"
       };
   const routePath = pathFor(locale, ["guides"]);
 
@@ -44,7 +46,7 @@ export function GuidesPage({ locale }: { locale: Locale }) {
               "@type": "ListItem",
               position: index + 1,
               name: guide.title[locale],
-              url: `${pathFor(locale, ["guides", guide.id])}`
+              url: `${siteUrl}${pathFor(locale, ["guides", guide.id])}`
             }))
           }
         ]}
@@ -61,6 +63,7 @@ export function GuidesPage({ locale }: { locale: Locale }) {
               <span>{guide.eyebrow[locale]}</span>
               <h2>{guide.title[locale]}</h2>
               <p>{guide.description[locale]}</p>
+              <small>{labels.format}</small>
               <Link to="/$locale/guides/$guideId/" params={{ locale, guideId: guide.id }}>
                 {labels.open}
                 <ArrowRight aria-hidden="true" size={15} />

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -3,7 +3,7 @@ import {
   ArrowRight,
   MotionDirectorGlyph,
   MotionPrimitiveGlyph,
-  ProductMomentGlyph,
+  MotionStateGlyph,
   Search
 } from "../components/icons";
 import { FormEvent, useState } from "react";
@@ -130,8 +130,8 @@ export function LandingPage({ locale }: { locale: Locale }) {
             {labels.finderCopy}
           </p>
           <div className="dual-library-intents" aria-label={locale === "zh" ? "选择起点" : "Choose a starting point"}>
-            <Link to="/$locale/packs/" params={{ locale }}>
-              <ProductMomentGlyph aria-hidden="true" size={16} />
+            <Link to="/$locale/guides/" params={{ locale }}>
+              <MotionStateGlyph aria-hidden="true" size={16} />
               {labels.sceneIntent}
             </Link>
             <Link to="/$locale/catalog/" params={{ locale }} search={{ surface: "components" }}>

--- a/src/pages/SeoGuidePage.tsx
+++ b/src/pages/SeoGuidePage.tsx
@@ -1,9 +1,11 @@
 import { Link } from "@tanstack/react-router";
 import { ArrowLeft, ArrowRight } from "../components/icons";
+import { SeoGuideDiagram } from "../components/SeoGuideDiagram";
 import { Seo } from "../components/Seo";
 import { getMotionPack } from "../data/motion-packs";
 import { getCatalogRecipe } from "../data/recipes";
 import { getSeoGuide } from "../data/seo-guides";
+import { getSeoGuideArticle } from "../data/seo-guide-articles";
 import { pathFor, siteUrl } from "../data/site";
 import type { Locale } from "../data/types";
 import { breadcrumbStructuredData, publisherStructuredData } from "../lib/structured-data";
@@ -34,7 +36,7 @@ export function SeoGuidePage({ locale, guideId }: { locale: Locale; guideId: str
       <section className="library-not-found">
         <span>404</span>
         <h1>{locale === "zh" ? "找不到这篇指南" : "Guide not found"}</h1>
-        <Link className="library-button is-primary" to="/$locale/guides/" params={{ locale }}>{labels.back}</Link>
+        <Link className="library-button is-primary" to="/$locale/guides/" params={{ locale }} activeOptions={{ exact: true }}>{labels.back}</Link>
       </section>
     );
   }
@@ -52,6 +54,17 @@ export function SeoGuidePage({ locale, guideId }: { locale: Locale; guideId: str
     return relatedGuide ? [relatedGuide] : [];
   });
   const routePath = pathFor(locale, ["guides", guide.id]);
+  const longArticle = getSeoGuideArticle(guide.id);
+  const wordCount = longArticle
+    ? longArticle.sections
+      .flatMap((section) => section.paragraphs)
+      .map((paragraph) => paragraph[locale])
+      .join(" ")
+      .trim()
+      .split(locale === "zh" ? "" : /\s+/)
+      .filter(Boolean).length
+    : undefined;
+  const diagramBySection = new Map<number, 0 | 1 | 2>([[0, 0], [2, 1], [4, 2]]);
 
   return (
     <>
@@ -79,6 +92,7 @@ export function SeoGuidePage({ locale, guideId }: { locale: Locale; guideId: str
             dateModified: release.updatedAt,
             inLanguage: locale === "zh" ? "zh-CN" : "en",
             isAccessibleForFree: true,
+            ...(wordCount ? { wordCount } : {}),
             license: "https://creativecommons.org/licenses/by/4.0/",
             author: publisherStructuredData,
             publisher: publisherStructuredData
@@ -98,7 +112,7 @@ export function SeoGuidePage({ locale, guideId }: { locale: Locale; guideId: str
         ]}
       />
       <article className="seo-guide-page">
-        <Link className="motion-pack-back-link" to="/$locale/guides/" params={{ locale }}>
+        <Link className="motion-pack-back-link" to="/$locale/guides/" params={{ locale }} activeOptions={{ exact: true }}>
           <ArrowLeft aria-hidden="true" size={14} />
           {labels.back}
         </Link>
@@ -106,6 +120,7 @@ export function SeoGuidePage({ locale, guideId }: { locale: Locale; guideId: str
           <span>{guide.eyebrow[locale]}</span>
           <h1>{guide.title[locale]}</h1>
           <p>{guide.intro[locale]}</p>
+          {longArticle ? <p className="seo-guide-standfirst">{longArticle.standfirst[locale]}</p> : null}
         </header>
         <section className="seo-guide-decision" aria-labelledby="guide-decision-title">
           <span>{labels.decision}</span>
@@ -122,11 +137,50 @@ export function SeoGuidePage({ locale, guideId }: { locale: Locale; guideId: str
             ))}
           </ol>
         </section>
+        {longArticle ? (
+          <div className="seo-guide-article" aria-label={locale === "zh" ? "完整场景文章" : "Full scenario article"}>
+            {longArticle.sections.map((section, index) => {
+              const diagramIndex = diagramBySection.get(index);
+              return (
+                <section key={section.id} aria-labelledby={`guide-${guide.id}-${section.id}`}>
+                  <h2 id={`guide-${guide.id}-${section.id}`}>{section.title[locale]}</h2>
+                  <div className="seo-guide-article-copy">
+                    {section.paragraphs.map((paragraph, paragraphIndex) => <p key={paragraphIndex}>{paragraph[locale]}</p>)}
+                  </div>
+                  {diagramIndex === undefined ? null : <SeoGuideDiagram diagram={longArticle.diagrams[diagramIndex]} locale={locale} />}
+                </section>
+              );
+            })}
+            <section className="seo-guide-checklist" aria-labelledby={`guide-${guide.id}-checklist`}>
+              <header>
+                <h2 id={`guide-${guide.id}-checklist`}>{longArticle.checklistTitle[locale]}</h2>
+              </header>
+              <ul>
+                {longArticle.checklist.map((item) => (
+                  <li key={item.id}>
+                    <span>
+                      <strong>{item.label[locale]}</strong>
+                      <small>{item.detail[locale]}</small>
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+            <section className="seo-guide-case-study" aria-labelledby={`guide-${guide.id}-case-study`}>
+              <header>
+                <h2 id={`guide-${guide.id}-case-study`}>{longArticle.caseStudy.title[locale]}</h2>
+                <p>{longArticle.caseStudy.context[locale]}</p>
+              </header>
+              <pre><code>{longArticle.caseStudy.code}</code></pre>
+              <p>{longArticle.caseStudy.explanation[locale]}</p>
+            </section>
+          </div>
+        ) : null}
         <section className="seo-guide-links" aria-labelledby="guide-foundations-title">
           <h2 id="guide-foundations-title">{labels.foundations}</h2>
           <div>
             {foundations.map((recipe) => (
-              <Link key={recipe.id} to="/$locale/$categoryId/$recipeId/" params={{ locale, categoryId: recipe.categoryId, recipeId: recipe.id }}>
+              <Link key={recipe.id} to="/$locale/$categoryId/$recipeId/" params={{ locale, categoryId: recipe.categoryId, recipeId: recipe.id }} activeOptions={{ exact: true }}>
                 <span><strong>{recipe.name[locale]}</strong><small>{recipe.shortDescription[locale]}</small></span>
                 <ArrowRight aria-hidden="true" size={15} />
               </Link>
@@ -137,7 +191,7 @@ export function SeoGuidePage({ locale, guideId }: { locale: Locale; guideId: str
           <h2 id="guide-packs-title">{labels.packs}</h2>
           <div>
             {packs.map((pack) => (
-              <Link key={pack.id} to="/$locale/packs/$packId/" params={{ locale, packId: pack.id }}>
+              <Link key={pack.id} to="/$locale/packs/$packId/" params={{ locale, packId: pack.id }} activeOptions={{ exact: true }}>
                 <span><strong>{pack.name[locale]}</strong><small>{pack.shortDescription[locale]}</small></span>
                 <ArrowRight aria-hidden="true" size={15} />
               </Link>
@@ -148,7 +202,7 @@ export function SeoGuidePage({ locale, guideId }: { locale: Locale; guideId: str
           <h2 id="guide-related-title">{labels.related}</h2>
           <div>
             {related.map((relatedGuide) => (
-              <Link key={relatedGuide.id} to="/$locale/guides/$guideId/" params={{ locale, guideId: relatedGuide.id }}>
+              <Link key={relatedGuide.id} to="/$locale/guides/$guideId/" params={{ locale, guideId: relatedGuide.id }} activeOptions={{ exact: true }}>
                 {relatedGuide.title[locale]}
                 <ArrowRight aria-hidden="true" size={15} />
               </Link>

--- a/tests/e2e/a11y.spec.ts
+++ b/tests/e2e/a11y.spec.ts
@@ -2,6 +2,10 @@ import { expect, test, type Page } from "@playwright/test";
 
 const WCAG_AA_NORMAL_TEXT = 4.5;
 
+async function waitForClientReady(page: Page) {
+  await expect(page.locator("html")).toHaveAttribute("data-client-ready", "true");
+}
+
 async function catalogTextContrastSamples(page: Page) {
   return page.evaluate(() => {
     type Rgba = { r: number; g: number; b: number; a: number };
@@ -96,6 +100,7 @@ test("catalog announces localized result changes for category, surface, and sear
   test.skip(testInfo.project.name.includes("mobile"), "Announcement semantics only need one browser audit.");
 
   await page.goto("/zh/catalog/?surface=components");
+  await waitForClientReady(page);
   const status = page.locator("#catalog-result-count");
   const search = page.getByRole("searchbox", { name: "搜索" });
   const cards = page.locator(".library-card");
@@ -170,6 +175,7 @@ test("catalog reflows and preserves keyboard feedback at a 200 percent zoom-equi
 
   await page.setViewportSize({ width: 640, height: 450 });
   await page.goto("/en/catalog/?surface=components");
+  await waitForClientReady(page);
 
   const search = page.getByRole("searchbox", { name: "Search" });
   await expect(search).toHaveAttribute("aria-describedby", /(?:^|\s)catalog-result-count(?:\s|$)/);
@@ -197,6 +203,7 @@ test("catalog segmented control moves focus and URL state with arrow keys", asyn
   test.skip(testInfo.project.name.includes("mobile"), "Keyboard roving focus only needs one browser audit.");
 
   await page.goto("/en/catalog/?surface=components");
+  await waitForClientReady(page);
   const options = page.locator(".library-surface-tabs").getByRole("radio");
 
   await options.first().focus();

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -335,26 +335,44 @@ test("implementation guidance uses one motion timeline and reflows cleanly", asy
   const desktop = await timeline.evaluate((element) => {
     const style = getComputedStyle(element);
     const rowElements = Array.from(element.querySelectorAll<HTMLElement>(":scope > div"));
+    const firstLabel = rowElements[0].querySelector<HTMLElement>("dt");
+    const firstDetail = rowElements[0].querySelector<HTMLElement>("dd");
+    if (!firstLabel || !firstDetail) throw new Error("Missing guidance row content");
+    const labelBox = firstLabel.getBoundingClientRect();
+    const detailBox = firstDetail.getBoundingClientRect();
     return {
       borderWidths: [style.borderTopWidth, style.borderRightWidth, style.borderBottomWidth, style.borderLeftWidth],
       borderRadius: style.borderRadius,
-      rowColumns: getComputedStyle(rowElements[0]).gridTemplateColumns.split(" ").length,
+      labelTop: labelBox.top,
+      labelRight: labelBox.right,
+      detailTop: detailBox.top,
+      detailLeft: detailBox.left,
       rowWidths: rowElements.map((row) => row.getBoundingClientRect().width)
     };
   });
   expect(desktop.borderWidths).toEqual(["1px", "0px", "1px", "0px"]);
   expect(desktop.borderRadius).toBe("0px");
-  expect(desktop.rowColumns).toBe(2);
+  expect(Math.abs(desktop.detailTop - desktop.labelTop)).toBeLessThan(1);
+  expect(desktop.detailLeft).toBeGreaterThan(desktop.labelRight);
   expect(Math.max(...desktop.rowWidths) - Math.min(...desktop.rowWidths)).toBeLessThan(1);
 
   await page.setViewportSize({ width: 390, height: 900 });
   const mobile = await timeline.evaluate((element) => {
     const rowElements = Array.from(element.querySelectorAll<HTMLElement>(":scope > div"));
+    const firstLabel = rowElements[0].querySelector<HTMLElement>("dt");
+    const firstDetail = rowElements[0].querySelector<HTMLElement>("dd");
+    if (!firstLabel || !firstDetail) throw new Error("Missing guidance row content");
+    const labelBox = firstLabel.getBoundingClientRect();
+    const detailBox = firstDetail.getBoundingClientRect();
     return {
-      rowColumns: getComputedStyle(rowElements[0]).gridTemplateColumns.split(" ").length,
+      labelTop: labelBox.top,
+      labelLeft: labelBox.left,
+      detailTop: detailBox.top,
+      detailLeft: detailBox.left,
       overflow: document.documentElement.scrollWidth - document.documentElement.clientWidth
     };
   });
-  expect(mobile.rowColumns).toBe(1);
+  expect(mobile.detailTop).toBeGreaterThan(mobile.labelTop);
+  expect(Math.abs(mobile.detailLeft - mobile.labelLeft)).toBeLessThan(1);
   expect(mobile.overflow).toBeLessThanOrEqual(0);
 });

--- a/tests/e2e/guide-runtime-examples.spec.ts
+++ b/tests/e2e/guide-runtime-examples.spec.ts
@@ -89,3 +89,58 @@ for (const reducedMotion of ["no-preference", "reduce"] as const) {
     expect(runtimeErrors).toEqual([]);
   });
 }
+
+test("spring drawer reverses from its current position without jumping to the previous target", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+  await page.setContent(exampleFor("spring-or-ease-out"));
+
+  const drawer = page.locator("[data-drawer]");
+  const toggle = page.locator("[data-drawer-toggle]");
+  const drawerX = () =>
+    drawer.evaluate((element) => {
+      const match = (element as HTMLElement).style.transform.match(/translateX\(([-\d.]+)px\)/);
+      return Number(match?.[1]);
+    });
+
+  await toggle.click();
+  await expect.poll(async () => drawerX()).toBeGreaterThan(-236);
+  const [beforeReverse, afterReverse] = await drawer.evaluate((element) => {
+    const readX = () => Number((element as HTMLElement).style.transform.match(/translateX\(([-\d.]+)px\)/)?.[1]);
+    const before = readX();
+    (document.querySelector("[data-drawer-toggle]") as HTMLButtonElement).click();
+    return [before, readX()];
+  });
+
+  expect(Math.abs(afterReverse - beforeReverse)).toBeLessThan(12);
+  await expect.poll(async () => drawerX()).toBeLessThan(beforeReverse);
+});
+
+test("spring drawer lets a range drag take over and settle from the selected position", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+  await page.setContent(exampleFor("spring-or-ease-out"));
+
+  const drawer = page.locator("[data-drawer]");
+  const range = page.locator("[data-drawer-range]");
+  const drawerX = () =>
+    drawer.evaluate((element) => Number((element as HTMLElement).style.transform.match(/translateX\(([-\d.]+)px\)/)?.[1]));
+
+  await page.locator("[data-drawer-toggle]").click();
+  await expect.poll(async () => drawerX()).toBeGreaterThan(-236);
+  const [beforeTakeover, afterPointerDown] = await range.evaluate((input) => {
+    const drawerElement = document.querySelector("[data-drawer]") as HTMLElement;
+    const readX = () => Number(drawerElement.style.transform.match(/translateX\(([-\d.]+)px\)/)?.[1]);
+    const before = readX();
+    input.dispatchEvent(new PointerEvent("pointerdown", { bubbles: true }));
+    return [before, readX()];
+  });
+  expect(Math.abs(afterPointerDown - beforeTakeover)).toBeLessThan(12);
+
+  await range.evaluate((input) => {
+    (input as HTMLInputElement).value = "-160";
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+  await expect.poll(async () => drawerX()).toBe(-160);
+
+  await range.evaluate((input) => input.dispatchEvent(new Event("change", { bubbles: true })));
+  await expect.poll(async () => drawerX()).toBeLessThan(-160);
+});

--- a/tests/e2e/guide-runtime-examples.spec.ts
+++ b/tests/e2e/guide-runtime-examples.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "@playwright/test";
+import { seoGuideArticles } from "../../src/data/seo-guide-articles";
+
+function exampleFor(guideId: string) {
+  const article = seoGuideArticles.find((candidate) => candidate.guideId === guideId);
+  if (!article) throw new Error(`Missing guide example: ${guideId}`);
+  return article.caseStudy.code;
+}
+
+test("publish example runs once while the working action is locked", async ({ page }) => {
+  await page.setContent(exampleFor("save-submit-publish-feedback"));
+
+  const publishButton = page.getByRole("button", { name: "Publish article" });
+  const status = page.locator("[data-publish-status]");
+  const requestCount = page.locator("[data-publish-submissions]");
+  const result = page.locator("[data-publish-result]");
+
+  await publishButton.focus();
+  await page.keyboard.press("Enter");
+  await expect(publishButton).toBeDisabled();
+  await publishButton.evaluate((button) => {
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    button.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+
+  await expect(requestCount).toHaveText("1");
+  await expect(status).toHaveText("Article published. You can open it now.");
+  await expect(result).toHaveAttribute("aria-hidden", "false");
+  const publishedLink = page.getByRole("link", { name: "Open published article" });
+  await expect(publishedLink).toBeVisible();
+  await expect(publishedLink).toBeFocused();
+});
+
+for (const reducedMotion of ["no-preference", "reduce"] as const) {
+  test(`deletion example preserves Undo and Delete focus with ${reducedMotion}`, async ({ page }) => {
+    await page.emulateMedia({ reducedMotion });
+    await page.setContent(exampleFor("form-validation-delete-permission"));
+
+    const row = page.locator("[data-project-row]");
+    const deleteButton = page.getByRole("button", { name: "Delete" });
+    const undoButton = page.getByRole("button", { name: "Undo" });
+    const status = page.getByRole("status");
+
+    await deleteButton.click();
+    await expect(status).toHaveText("Project deleted. Undo is available.");
+    await expect(undoButton).toBeFocused();
+    await expect(row).toHaveCount(0);
+
+    await undoButton.click();
+    await expect(status).toHaveText("Project restored.");
+    await expect(row).toBeVisible();
+    await expect(deleteButton).toBeFocused();
+  });
+}
+
+test("filter example cancels a stale transition and commits only the latest query", async ({ page }) => {
+  await page.setContent(exampleFor("css-motion-jank"));
+
+  const input = page.getByRole("searchbox", { name: "Filter projects" });
+  const resultCount = page.getByRole("status");
+  const results = page.locator("[data-result-list] .result-card");
+
+  await expect(resultCount).toHaveText("4 projects shown.");
+  await input.fill("alpha");
+  await input.fill("delta");
+  await expect(resultCount).toHaveText("1 project shown.");
+  await expect(results).toHaveText(["Delta reports"]);
+});
+
+for (const reducedMotion of ["no-preference", "reduce"] as const) {
+  test(`spring and ease-out example runs with visible saving feedback and no page errors in ${reducedMotion}`, async ({ page }) => {
+    const runtimeErrors: string[] = [];
+    page.on("pageerror", (error) => runtimeErrors.push(error.message));
+    await page.emulateMedia({ reducedMotion });
+    await page.setContent(exampleFor("spring-or-ease-out"));
+
+    const drawer = page.locator("[data-drawer]");
+    const saveButton = page.getByRole("button", { name: "Save settings" });
+    const saveStatus = page.getByRole("status");
+    const initialTransform = await drawer.evaluate((element) => (element as HTMLElement).style.transform);
+
+    await page.getByRole("button", { name: "Open drawer" }).click();
+    await expect.poll(() => drawer.evaluate((element) => (element as HTMLElement).style.transform)).not.toBe(initialTransform);
+
+    await saveButton.click();
+    await expect(saveStatus).toHaveAttribute("data-state", "saving");
+    await expect(saveStatus).toHaveText("Saving settings.");
+    await expect(saveStatus).toHaveText("Settings saved.");
+    expect(runtimeErrors).toEqual([]);
+  });
+}

--- a/tests/e2e/motion-director.spec.ts
+++ b/tests/e2e/motion-director.spec.ts
@@ -43,19 +43,72 @@ test("candidate library is reachable, prerendered, and noindex", async ({ page }
   expect(overflow).toBeLessThanOrEqual(1);
 });
 
-test("home and primary navigation expose Pack, Primitive, and Director as peers", async ({ page }, testInfo) => {
+test("home navigation marks Home active and exposes Finder, Packs, Primitives, Guides, and Director", async ({ page }, testInfo) => {
   await page.goto("/zh/");
 
   await expect(page.getByRole("link", { name: "进入 Motion Director" })).toHaveAttribute("href", "/zh/director/");
   if (!testInfo.project.name.includes("mobile")) {
     const nav = page.getByRole("navigation", { name: "主导航" });
+    await expect(nav.getByRole("link", { name: "首页" })).toHaveAttribute("href", "/zh/");
+    await expect(nav.getByRole("link", { name: "首页" })).toHaveAttribute("aria-current", "page");
+    await expect(nav.getByRole("link", { name: "找动效" })).toHaveAttribute("href", "/zh/finder/");
     await expect(nav.getByRole("link", { name: "产品瞬间" })).toHaveAttribute("href", "/zh/packs/");
     await expect(nav.getByRole("link", { name: "动效基础" })).toHaveAttribute("href", "/zh/catalog/?surface=components");
-    await expect(nav.getByRole("link", { name: "Motion Director" })).toHaveAttribute("href", "/zh/director/");
+    await expect(nav.getByRole("link", { name: "场景指南" })).toHaveAttribute("href", "/zh/guides/");
+    await expect(page.locator("header.library-header").getByRole("link", { name: "Motion Director" })).toHaveAttribute("href", "/zh/director/");
+
+    await page.setViewportSize({ width: 1100, height: 900 });
+    await page.getByRole("button", { name: "资源" }).click();
+    const compactNavigation = page.getByRole("navigation", { name: "移动端导航" });
+    await expect(compactNavigation.getByRole("link", { name: "首页" })).toHaveAttribute("aria-current", "page");
   }
 
   await page.getByRole("link", { name: "进入 Motion Director" }).click();
   await expect(page).toHaveURL(/\/zh\/director\/$/);
+});
+
+test("primary navigation assigns one current item on home and scenario guide detail routes", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "The primary navigation is visually hidden on mobile.");
+
+  const primaryNavigation = page.locator("header.library-header .library-primary-nav");
+
+  await page.goto("/zh/");
+  await expect(primaryNavigation.locator('[aria-current="page"]')).toHaveCount(1);
+  await expect(primaryNavigation.getByRole("link", { name: "首页" })).toHaveAttribute("aria-current", "page");
+
+  await page.goto("/zh/guides/css-motion-jank/");
+  await expect(primaryNavigation.locator('[aria-current="page"]')).toHaveCount(1);
+  await expect(primaryNavigation.getByRole("link", { name: "场景指南" })).toHaveAttribute("aria-current", "page");
+  await expect(primaryNavigation.getByRole("link", { name: "首页" })).not.toHaveAttribute("aria-current", "page");
+  await expect(page.locator("header.library-header .library-brand")).not.toHaveAttribute("aria-current", "page");
+});
+
+test("English header adopts its compact navigation before labels crowd the action area", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop Chromium exercises the intermediate header widths.");
+
+  for (const width of [1121, 1200, 1250]) {
+    await page.setViewportSize({ width, height: 900 });
+    await page.goto("/en/");
+
+    await expect(page.locator("header.library-header .library-primary-nav"), `${width}px primary navigation`).toBeHidden();
+    await expect(page.locator("header.library-header .library-director-link"), `${width}px director link`).toBeHidden();
+    await expect(page.locator("header.library-header .library-utility-trigger"), `${width}px resource trigger`).toBeVisible();
+
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+    expect(overflow, `English home at ${width}px`).toBeLessThanOrEqual(1);
+  }
+});
+
+test("resource navigation assigns the vocabulary route one current item", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name.includes("mobile"), "Desktop Chromium exercises the compact resource navigation.");
+
+  await page.setViewportSize({ width: 1100, height: 900 });
+  await page.goto("/zh/vocabulary/");
+  await page.getByRole("button", { name: "资源" }).click();
+
+  const compactNavigation = page.getByRole("navigation", { name: "移动端导航" });
+  await expect(compactNavigation.getByRole("link", { name: "动画词汇" })).toHaveAttribute("aria-current", "page");
+  await expect(compactNavigation.getByRole("link", { name: "动效基础" })).not.toHaveAttribute("aria-current", "page");
 });
 
 test("Director and candidate layouts stay within every product breakpoint", async ({ page }, testInfo) => {

--- a/tests/e2e/seo-guides.spec.ts
+++ b/tests/e2e/seo-guides.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test, type Page } from "@playwright/test";
+import { seoGuideArticles } from "../../src/data/seo-guide-articles";
+
+async function findOverflowingDiagramText(page: Page) {
+  return page.locator(".seo-guide-diagram svg .seo-guide-diagram-node").evaluateAll((nodes) => {
+    return nodes.flatMap((node) => {
+      const bounds = node.querySelector("rect")?.getBBox();
+      if (!bounds) return [];
+      return Array.from(node.querySelectorAll("text")).flatMap((text) => {
+        const box = text.getBBox();
+        const escapesNode = box.x < bounds.x || box.y < bounds.y || box.x + box.width > bounds.x + bounds.width || box.y + box.height > bounds.y + bounds.height;
+        return escapesNode ? [text.getAttribute("aria-label")] : [];
+      });
+    });
+  });
+}
+
+async function findOverflowingCaseStudyCode(page: Page) {
+  return page.locator(".seo-guide-case-study pre").evaluateAll((blocks) => {
+    return blocks.flatMap((block, index) => block.scrollWidth > block.clientWidth + 1 ? [index] : []);
+  });
+}
+
+test("scenario guides render a full illustrated article with a checklist and implementation", async ({ page }, testInfo) => {
+  await page.goto("/zh/guides/css-motion-jank/");
+
+  await expect(page.getByRole("heading", { level: 1, name: "CSS 动效卡顿：从帧到属性逐项排查" })).toBeVisible();
+  await expect(page.locator(".seo-guide-article > section")).toHaveCount(7);
+  await expect(page.locator("figure.seo-guide-diagram")).toHaveCount(3);
+  await expect(page.locator(".seo-guide-checklist li")).toHaveCount(5);
+  await expect(page.locator(".seo-guide-case-study pre code")).toContainText("requestAnimationFrame");
+  const schemas = await page.locator('script[type="application/ld+json"]').allTextContents();
+  expect(schemas.some((schema) => schema.includes('"@type":"TechArticle"') && schema.includes('"wordCount"'))).toBe(true);
+
+  await page.goto("/zh/guides/");
+  const guideSchemas = await page.locator('script[type="application/ld+json"]').allTextContents();
+  expect(guideSchemas.some((schema) => schema.includes('"@type":"ItemList"') && schema.includes('"url":"https://motion-lexicon.pages.dev/zh/guides/save-submit-publish-feedback/"'))).toBe(true);
+
+  await page.goto("/en/guides/save-submit-publish-feedback/");
+  await expect(page.locator('.seo-guide-diagram svg .seo-guide-diagram-node-detail[aria-label="Prevent duplicates and show progress"]')).toHaveCount(1);
+  if (!testInfo.project.name.includes("mobile")) {
+    for (const locale of ["zh", "en"]) {
+      for (const guideId of [
+        "save-submit-publish-feedback",
+        "card-list-filter-continuity",
+        "css-motion-jank",
+        "spring-or-ease-out",
+        "reduced-motion",
+        "form-validation-delete-permission",
+        "from-brief-to-spec",
+        "pack-or-primitive"
+      ]) {
+        await page.goto(`/${locale}/guides/${guideId}/`);
+        expect(await findOverflowingDiagramText(page), `${locale}/${guideId}`).toEqual([]);
+      }
+    }
+  }
+
+  await page.goto("/en/guides/spring-or-ease-out/");
+  await expect(page.getByRole("heading", { level: 1, name: "Choose spring or ease-out by meaning" })).toBeVisible();
+  await expect(page.locator("figure.seo-guide-diagram")).toHaveCount(3);
+  await expect(page.locator(".seo-guide-checklist li")).toHaveCount(5);
+});
+
+test("scenario guide layouts stay inside the viewport", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/zh/guides/save-submit-publish-feedback/");
+
+  await expect(page.locator(".seo-guide-diagram svg").first()).toBeHidden();
+  await expect(page.locator(".seo-guide-diagram-mobile").first()).toBeVisible();
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+  expect(overflow).toBeLessThanOrEqual(1);
+});
+
+test("scenario guide implementation code stays within its container on desktop and mobile", async ({ page }) => {
+  for (const [label, viewport] of [
+    ["desktop", { width: 1440, height: 960 }],
+    ["mobile", { width: 390, height: 844 }]
+  ] as const) {
+    await page.setViewportSize(viewport);
+    await page.goto("/zh/guides/form-validation-delete-permission/");
+
+    await expect(page.locator(".seo-guide-case-study pre")).toContainText("data-delete-status");
+    expect(await findOverflowingCaseStudyCode(page), label).toEqual([]);
+
+    const pageOverflow = await page.evaluate(() => document.documentElement.scrollWidth - window.innerWidth);
+    expect(pageOverflow, label).toBeLessThanOrEqual(1);
+  }
+});
+
+test("deletion guide implementation keeps exit, recovery, and undo in one working flow", async ({ page }) => {
+  const deletionGuide = seoGuideArticles.find((article) => article.guideId === "form-validation-delete-permission");
+  expect(deletionGuide).toBeDefined();
+  await page.setContent(deletionGuide!.caseStudy.code);
+
+  const row = page.locator("[data-project-row]");
+  const status = page.getByRole("status");
+  const undo = page.getByRole("button", { name: "Undo" });
+
+  await page.getByRole("button", { name: "Delete" }).click();
+  await expect(status).toHaveText("Project deleted. Undo is available.");
+  await expect(undo).toBeVisible();
+  await undo.click();
+  await expect(status).toHaveText("Project restored.");
+  await expect(row).toBeVisible();
+
+  await page.getByRole("button", { name: "Delete" }).click();
+  await expect(undo).toBeEnabled();
+  await undo.click();
+  await expect(status).toHaveText("Project restored.");
+  await expect(row).toBeVisible();
+
+  await page.getByRole("button", { name: "Delete" }).click();
+  await expect(row).toHaveCount(0, { timeout: 1_000 });
+});


### PR DESCRIPTION
## 本次更新

- 主导航新增首页与场景指南入口；首页当前状态明确命中“首页”。
- 首页的产品场景入口直接进入场景指南。
- 八篇中英文场景指南升级为长文：每篇五节正文、三张 SVG 图解、五项清单与可复制实现示例。
- `TechArticle` 增加与正文一致的 `wordCount`，静态爬取校验三张图解和代码示例。
- 新增导航、场景指南和窄屏无横向滚动的浏览器测试。

## 内容与性能约束

- 中文正文每篇至少 1000 字，英文正文每篇至少 700 词。
- 长文内容位于独立懒加载路由，首页保持轻量。
- 场景指南路由块与总 JS 体积均有独立上限。

## 验证

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run i18n:check`
- `npm run seo:check`
- `npm run motion:check`
- `npm run a11y:check`
- `npm run build`
- `npm run bundle:check`
- `npm run crawl:dist`
- `npm run test:visual`（166 项）
